### PR TITLE
Update build configs and package metadata

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -48,7 +48,7 @@ jobs:
          cache: true
          cache-dependency-path: |
            **/Directory.Packages.props
-           **/*.sln
+           **/*.slnx
            **/*.csproj
            **/global.json
            **/nuget.config

--- a/.github/workflows/BuildOnly.yml
+++ b/.github/workflows/BuildOnly.yml
@@ -85,8 +85,6 @@ jobs:
         with:
           name: tmp-coverage
           path: |
-            /src/coverage.cobertura.xml
-            /src/coverage*.cobertura.xml
-            /src/TestResults/**/*.cobertura.xml
+            ./**/TestResults/**/*.cobertura.xml
           if-no-files-found: warn
           retention-days: 3

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -29,8 +29,7 @@
         "Deploy",
         "Pack",
         "Print",
-        "Restore",
-        "Test"
+        "Restore"
       ]
     },
     "Verbosity": {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -77,7 +77,6 @@ partial class Build : NukeBuild
         if (Repository.IsOnMainOrMasterBranch())
         {
             var packableProjects = Solution.GetPackableProjects();
-
             foreach (var project in packableProjects!)
             {
                 Log.Information("Packing {Project}", project.Name);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
     <NoWarn>CS1591;IDE0190;IDE1006;IDE0130</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon>logo.png</PackageIcon>
-    <PackageReadmeFile>..\README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>Compatability with Net 8 / 9 / 10 and net462 / net472 / net481</PackageReleaseNotes>
     <PackageTags>Microsoft;Extensions;Hosting;Rx;ReactiveUI;net;netframework</PackageTags>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>


### PR DESCRIPTION
Adjusted GitHub workflow cache paths and coverage file patterns, removed 'Test' from build schema targets, fixed PackageReadmeFile path in Directory.Build.props, and made minor cleanup in Build.cs. These changes improve build reliability and package metadata consistency.