### PR TITLE
Bump dependency versions across projects

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,7 +30,7 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-    <CoreVersion>10.0.2</CoreVersion>
+    <CoreVersion>10.0.3</CoreVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
@@ -46,11 +46,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(IsTestProject)">
-    <PackageReference Include="TUnit" Version="1.12.15"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.2"/>
+    <PackageReference Include="TUnit" Version="1.19.11"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2"/>
     <PackageReference Include="PublicApiGenerator" Version="11.5.4"/>
-    <PackageReference Include="Verify.TUnit" Version="31.9.4"/>
+    <PackageReference Include="Verify.TUnit" Version="31.13.2"/>
 
     <None Include="$(MSBuildThisFileDirectory)testconfig.json">
       <Link>$(AssemblyName).testconfig.json</Link>
@@ -59,7 +59,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
@@ -20,15 +20,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- Align MSBuild dependencies to avoid NU1605 downgrades from transitive EF tooling -->
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.3.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.3.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net9')) ">
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.12">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
@@ -20,15 +20,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- Align MSBuild dependencies to avoid NU1605 downgrades from transitive EF tooling -->
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.3.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.3.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net9')) ">
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.12">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Extensions.Hosting.Maui/Extensions.Hosting.Maui.csproj
+++ b/src/Extensions.Hosting.Maui/Extensions.Hosting.Maui.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net10')) ">
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.30" />
-    <PackageReference Include="Microsoft.Maui.Core" Version="10.0.30" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
+    <PackageReference Include="Microsoft.Maui.Core" Version="10.0.41" />
   </ItemGroup>
   
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net9')) ">

--- a/src/Extensions.Hosting.ReactiveUI.Maui/Extensions.Hosting.ReactiveUI.Maui.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Maui/Extensions.Hosting.ReactiveUI.Maui.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Splat" Version="19.2.1" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.2.1" />
-    <PackageReference Include="ReactiveUI.Maui" Version="23.1.0-beta.1" />
+    <PackageReference Include="Splat" Version="19.3.1" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.3.1" />
+    <PackageReference Include="ReactiveUI.Maui" Version="23.1.8" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net10')) ">

--- a/src/Extensions.Hosting.ReactiveUI.Maui/Extensions.Hosting.ReactiveUI.Maui.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Maui/Extensions.Hosting.ReactiveUI.Maui.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net10')) ">
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.30" />
-    <PackageReference Include="Microsoft.Maui.Core" Version="10.0.30" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
+    <PackageReference Include="Microsoft.Maui.Core" Version="10.0.41" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net9')) ">

--- a/src/Extensions.Hosting.ReactiveUI.WinForms/Extensions.Hosting.ReactiveUI.WinForms.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms/Extensions.Hosting.ReactiveUI.WinForms.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Splat" Version="19.2.1" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.2.1" />
-    <PackageReference Include="ReactiveUI.Drawing" Version="23.1.0-beta.1" />
-    <PackageReference Include="ReactiveUI.WinForms" Version="23.1.0-beta.1" />
+    <PackageReference Include="Splat" Version="19.3.1" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.3.1" />
+    <PackageReference Include="ReactiveUI.Drawing" Version="23.1.8" />
+    <PackageReference Include="ReactiveUI.WinForms" Version="23.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Splat" Version="19.2.1" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.2.1" />
-    <PackageReference Include="ReactiveUI.WinUI" Version="23.1.0-beta.1" />
+    <PackageReference Include="Splat" Version="19.3.1" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.3.1" />
+    <PackageReference Include="ReactiveUI.WinUI" Version="23.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Splat" Version="19.2.1" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.2.1" />
-    <PackageReference Include="ReactiveUI.Drawing" Version="23.1.0-beta.1" />
-    <PackageReference Include="ReactiveUI.WPF" Version="23.1.0-beta.1" />
+    <PackageReference Include="Splat" Version="19.3.1" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.3.1" />
+    <PackageReference Include="ReactiveUI.Drawing" Version="23.1.8" />
+    <PackageReference Include="ReactiveUI.WPF" Version="23.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
+++ b/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/examples/Extensions.Hosting.Maui.Example/Extensions.Hosting.Maui.Example.csproj
+++ b/src/examples/Extensions.Hosting.Maui.Example/Extensions.Hosting.Maui.Example.csproj
@@ -60,8 +60,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
+    <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.41" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(CoreVersion)" />
   </ItemGroup>
 

--- a/src/examples/Extensions.Hosting.Reactive.Example/Extensions.Hosting.Reactive.Example.csproj
+++ b/src/examples/Extensions.Hosting.Reactive.Example/Extensions.Hosting.Reactive.Example.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="7.0.1" />
+    <PackageReference Include="NuGet.Protocol" Version="7.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(CoreVersion)" />
   </ItemGroup>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "3.0-beta.{height}",
+    "version": "3.0",
     "publicReleaseRefSpec": [
         "^refs/heads/main$",
         "^refs/heads/master$",


### PR DESCRIPTION
Update various package and SDK versions to keep dependencies current and avoid transitive downgrade issues. 
Key changes:
- Set CoreVersion to 10.0.3 in Directory.Build.props.
- Bump test-related packages (TUnit, Microsoft.NET.Test.Sdk, CodeCoverage, Verify.TUnit) and Microsoft.SourceLink.GitHub.
- Align MSBuild packages to 18.3.3 to prevent NU1605 downgrades.
- Upgrade EF/Identity packages and tools to 9.0.13 for net9 targets.
- Update MAUI packages to 10.0.41.
- Update Splat to 19.3.1 and ReactiveUI packages (Maui/WinForms/WinUI/WPF/Drawing) to 23.1.8.
- Bump Microsoft.WindowsAppSDK and NuGet.Protocol to newer patch versions. 

These updates address compatibility and maintainability across the solution.