### PR TITLE
Add PackageId and disable packing for examples

### DIFF
--- a/src/Extensions.Hosting.ReactiveUI.Avalonia/Extensions.Hosting.ReactiveUI.Avalonia.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Avalonia/Extensions.Hosting.ReactiveUI.Avalonia.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageId>CP.Extensions.Hosting.ReactiveUI.Avalonia</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/examples/Extensions.Hosting.Avalonia.Example/Extensions.Hosting.Avalonia.Example.csproj
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/Extensions.Hosting.Avalonia.Example.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/Extensions.Hosting.ReactiveAvalonia.Example.csproj
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/Extensions.Hosting.ReactiveAvalonia.Example.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Set an explicit PackageId (CP.Extensions.Hosting.ReactiveUI.Avalonia) in the ReactiveUI Avalonia project and mark the two example projects as IsPackable=false to prevent them from being packaged. These are simple project property updates; target frameworks and other settings remain unchanged.