### PR TITLE
Bump package versions and clean test usings

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -46,11 +46,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(IsTestProject)">
-    <PackageReference Include="TUnit" Version="1.19.22"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2"/>
+    <PackageReference Include="TUnit" Version="1.30.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2"/>
     <PackageReference Include="PublicApiGenerator" Version="11.5.4"/>
-    <PackageReference Include="Verify.TUnit" Version="31.13.2"/>
+    <PackageReference Include="Verify.TUnit" Version="31.15.0"/>
 
     <None Include="$(MSBuildThisFileDirectory)testconfig.json">
       <Link>$(AssemblyName).testconfig.json</Link>

--- a/src/Extensions.Hosting.Avalonia/Extensions.Hosting.Avalonia.csproj
+++ b/src/Extensions.Hosting.Avalonia/Extensions.Hosting.Avalonia.csproj
@@ -12,8 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
+    <PackageReference Include="Avalonia" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Extensions.Hosting.Maui/Extensions.Hosting.Maui.csproj
+++ b/src/Extensions.Hosting.Maui/Extensions.Hosting.Maui.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net10')) ">
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
-    <PackageReference Include="Microsoft.Maui.Core" Version="10.0.41" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.51" />
+    <PackageReference Include="Microsoft.Maui.Core" Version="10.0.51" />
   </ItemGroup>
   
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net9')) ">

--- a/src/Extensions.Hosting.ReactiveUI.Maui/Extensions.Hosting.ReactiveUI.Maui.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Maui/Extensions.Hosting.ReactiveUI.Maui.csproj
@@ -12,12 +12,12 @@
   <ItemGroup>
     <PackageReference Include="Splat" Version="19.3.1" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.3.1" />
-    <PackageReference Include="ReactiveUI.Maui" Version="23.1.8" />
+    <PackageReference Include="ReactiveUI.Maui" Version="23.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net10')) ">
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
-    <PackageReference Include="Microsoft.Maui.Core" Version="10.0.41" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.51" />
+    <PackageReference Include="Microsoft.Maui.Core" Version="10.0.51" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net9')) ">

--- a/src/Extensions.Hosting.ReactiveUI.WinForms/Extensions.Hosting.ReactiveUI.WinForms.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms/Extensions.Hosting.ReactiveUI.WinForms.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Splat" Version="19.3.1" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.3.1" />
-    <PackageReference Include="ReactiveUI.Drawing" Version="23.1.8" />
-    <PackageReference Include="ReactiveUI.WinForms" Version="23.1.8" />
+    <PackageReference Include="ReactiveUI.Drawing" Version="23.2.1" />
+    <PackageReference Include="ReactiveUI.WinForms" Version="23.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Splat" Version="19.3.1" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.3.1" />
-    <PackageReference Include="ReactiveUI.WinUI" Version="23.1.8" />
+    <PackageReference Include="ReactiveUI.WinUI" Version="23.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Splat" Version="19.3.1" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.3.1" />
-    <PackageReference Include="ReactiveUI.Drawing" Version="23.1.8" />
-    <PackageReference Include="ReactiveUI.WPF" Version="23.1.8" />
+    <PackageReference Include="ReactiveUI.Drawing" Version="23.2.1" />
+    <PackageReference Include="ReactiveUI.WPF" Version="23.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
+++ b/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/examples/Extensions.Hosting.Avalonia.Example/Extensions.Hosting.Avalonia.Example.csproj
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/Extensions.Hosting.Avalonia.Example.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(CoreVersion)" />
-    <PackageReference Include="Avalonia" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+    <PackageReference Include="Avalonia" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/examples/Extensions.Hosting.Maui.Example/Extensions.Hosting.Maui.Example.csproj
+++ b/src/examples/Extensions.Hosting.Maui.Example/Extensions.Hosting.Maui.Example.csproj
@@ -60,8 +60,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
-    <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.41" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.51" />
+    <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.51" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(CoreVersion)" />
   </ItemGroup>
 

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/Extensions.Hosting.ReactiveAvalonia.Example.csproj
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/Extensions.Hosting.ReactiveAvalonia.Example.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(CoreVersion)" />
     <PackageReference Include="NuGet.Protocol" Version="7.3.0" />
-    <PackageReference Include="Avalonia" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+    <PackageReference Include="Avalonia" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj
@@ -22,6 +22,8 @@
     <Using Include="TUnit.Core" />
     <Using Include="TUnit.Core.Executors" />
     <Using Include="TUnit.Core.Interfaces" />
+    <Using Include="TUnit.Assertions"/>
+    <Using Include="TUnit.Assertions.Extensions"/>
     <Using Include="System" />
     <Using Include="System.Collections.Generic" />
     <Using Include="System.ComponentModel" />

--- a/src/tests/Extensions.Hosting.Tests/HostBuilderApplicationExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/HostBuilderApplicationExtensionsTests.cs
@@ -2,12 +2,9 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ReactiveMarbles.Extensions.Hosting.AppServices;
-using TUnit;
 
 namespace Extensions.Hosting.Tests;
 

--- a/src/tests/Extensions.Hosting.Tests/MutexBuilderTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/MutexBuilderTests.cs
@@ -2,9 +2,6 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Threading.Tasks;
-using TUnit;
-
 namespace Extensions.Hosting.Tests;
 
 /// <summary>

--- a/src/tests/Extensions.Hosting.Tests/PluginBuilderExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/PluginBuilderExtensionsTests.cs
@@ -2,11 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
-using System.Threading.Tasks;
 using ReactiveMarbles.Extensions.Hosting.Plugins;
-using TUnit;
 
 namespace Extensions.Hosting.Tests;
 

--- a/src/tests/Extensions.Hosting.Tests/PluginOrderAttributeTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/PluginOrderAttributeTests.cs
@@ -2,9 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Threading.Tasks;
 using ReactiveMarbles.Extensions.Hosting.Plugins;
-using TUnit;
 
 namespace Extensions.Hosting.Tests;
 

--- a/src/tests/Extensions.Hosting.Tests/PluginScannerTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/PluginScannerTests.cs
@@ -2,12 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveMarbles.Extensions.Hosting.Plugins;
-using TUnit;
 
 namespace Extensions.Hosting.Tests;
 

--- a/src/tests/Extensions.Hosting.Tests/ResourceMutexTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ResourceMutexTests.cs
@@ -2,11 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using ReactiveMarbles.Extensions.Hosting.AppServices;
-using TUnit;
 
 namespace Extensions.Hosting.Tests;
 

--- a/src/tests/Extensions.Hosting.Tests/TestMutexBuilder.cs
+++ b/src/tests/Extensions.Hosting.Tests/TestMutexBuilder.cs
@@ -2,7 +2,6 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ReactiveMarbles.Extensions.Hosting.AppServices;

--- a/src/tests/Extensions.Hosting.Tests/TestPluginBuilder.cs
+++ b/src/tests/Extensions.Hosting.Tests/TestPluginBuilder.cs
@@ -2,8 +2,6 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Extensions.FileSystemGlobbing;
 using ReactiveMarbles.Extensions.Hosting.Plugins;


### PR DESCRIPTION
Update multiple package dependencies and tidy test code:

- Test infra: bump TUnit to 1.30.0, Microsoft.NET.Test.Sdk to 18.4.0, CodeCoverage to 18.6.2, Verify.TUnit to 31.15.0 and add TUnit.Assertions & TUnit.Assertions.Extensions usings in test project.
- UI frameworks: update Avalonia to 11.3.13 (examples and libs) and add Tmds.DBus.Protocol 0.21.3 to the Avalonia project.
- MAUI: bump Microsoft.Maui packages to 10.0.51 in projects/examples.
- ReactiveUI: upgrade ReactiveUI.* packages to 23.2.1 across Maui, WinForms, WinUI and WPF (including ReactiveUI.Drawing).
- Windows App SDK: bump Microsoft.WindowsAppSDK to 1.8.260317003.
- Code cleanup: remove several unused using directives from test source files to reduce warnings.

These changes keep dependencies current and clean up test codebase warnings.