### PR TITLE
Add Log4Net logging provider and update deps

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,7 +30,8 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-    <CoreVersion>10.0.5</CoreVersion>
+    <CoreVersion>10.0.6</CoreVersion>
+    <AvaloniaVersion>12.0.1</AvaloniaVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
@@ -46,11 +47,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(IsTestProject)">
-    <PackageReference Include="TUnit" Version="1.30.0"/>
+    <PackageReference Include="TUnit" Version="1.37.10"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2"/>
     <PackageReference Include="PublicApiGenerator" Version="11.5.4"/>
-    <PackageReference Include="Verify.TUnit" Version="31.15.0"/>
+    <PackageReference Include="Verify.TUnit" Version="31.16.1"/>
 
     <None Include="$(MSBuildThisFileDirectory)testconfig.json">
       <Link>$(AssemblyName).testconfig.json</Link>
@@ -59,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.Avalonia/Extensions.Hosting.Avalonia.csproj
+++ b/src/Extensions.Hosting.Avalonia/Extensions.Hosting.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net472;net481;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <PackageDescription>This extension adds Avalonia support to generic host applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc.</PackageDescription>
     <PackageId>CP.Extensions.Hosting.Avalonia</PackageId>
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Extensions.Hosting.PluginService/Extensions.Hosting.PluginService.csproj
+++ b/src/Extensions.Hosting.PluginService/Extensions.Hosting.PluginService.csproj
@@ -10,13 +10,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(CoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(CoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="$(CoreVersion)" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="$(CoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Extensions.Hosting.Plugins\Extensions.Hosting.Plugins.csproj" />
+    <ProjectReference Include="..\Extensions.Logging.Log4Net\Extensions.Logging.Log4Net.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Extensions.Hosting.PluginService/ServiceHost.cs
+++ b/src/Extensions.Hosting.PluginService/ServiceHost.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ReactiveMarbles.Extensions.Hosting.Plugins;
+using ReactiveMarbles.Extensions.Logging;
 
 namespace ReactiveMarbles.Extensions.Hosting.PluginService;
 

--- a/src/Extensions.Hosting.ReactiveUI.Avalonia/Extensions.Hosting.ReactiveUI.Avalonia.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Avalonia/Extensions.Hosting.ReactiveUI.Avalonia.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Splat" Version="19.3.1" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="19.3.1" />
-    <PackageReference Include="ReactiveUI.Avalonia" Version="11.4.12" />
+    <PackageReference Include="ReactiveUI.Avalonia" Version="12.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Extensions.Hosting.slnx
+++ b/src/Extensions.Hosting.slnx
@@ -40,5 +40,6 @@
   <Project Path="Extensions.Hosting.WinForms/Extensions.Hosting.WinForms.csproj" />
   <Project Path="Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj" />
   <Project Path="Extensions.Hosting.Wpf/Extensions.Hosting.Wpf.csproj" />
+  <Project Path="Extensions.Logging.Log4Net/Extensions.Logging.Log4Net.csproj" />
   <Project Path="tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj" />
 </Solution>

--- a/src/Extensions.Logging.Log4Net/Entities/MessageCandidate.cs
+++ b/src/Extensions.Logging.Log4Net/Entities/MessageCandidate.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace ReactiveMarbles.Extensions.Logging.Log4Net.Entities;
+
+/// <summary>
+/// Represents a candidate log message, including its log level, event identifier, state, optional exception, and a
+/// formatter function for generating the message text.
+/// </summary>
+/// <remarks>Use this struct to encapsulate all information required to format and emit a log message. The
+/// formatter function can be used to produce the final log message string based on the provided state and exception.
+/// This type is typically used in logging frameworks to defer message formatting until it is needed.</remarks>
+/// <typeparam name="TState">The type of the state object associated with the log message. This provides contextual information or content for
+/// the log entry.</typeparam>
+public readonly record struct MessageCandidate<TState>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageCandidate{TState}"/> struct.
+    /// Initializes a new instance of the MessageCandidate class with the specified log level, event identifier,
+    /// state, exception, and formatter.
+    /// </summary>
+    /// <param name="logLevel">The severity level of the log entry.</param>
+    /// <param name="eventId">The identifier for the event associated with the log entry.</param>
+    /// <param name="state">The state object to be logged. Represents the primary content or context for the log entry.</param>
+    /// <param name="exception">The exception related to the log entry, or null if no exception is associated.</param>
+    /// <param name="formatter">A function that formats the state and exception into a log message string.</param>
+    public MessageCandidate(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        State = state;
+        LogLevel = logLevel;
+        EventId = eventId;
+        Exception = exception;
+        Formatter = formatter;
+    }
+
+    /// <summary>
+    /// Gets the log level the message should be printed with.
+    /// </summary>
+    public LogLevel LogLevel { get; }
+
+    /// <summary>
+    /// Gets the event id of the message.
+    /// </summary>
+    public EventId EventId { get; }
+
+    /// <summary>
+    /// Gets the message state. Can be provided to the formatter to generate the string representation of the error message.
+    /// </summary>
+    public TState State { get; }
+
+    /// <summary>
+    /// Gets exception that should be printed with the message. Null if the log message has no corrosponding exception.
+    /// </summary>
+    public Exception? Exception { get; }
+
+    /// <summary>
+    /// Gets the message formatter. Can be called with the state and exception to generate the string representation of the error message.
+    /// </summary>
+    public Func<TState, Exception?, string> Formatter { get; }
+}

--- a/src/Extensions.Logging.Log4Net/Entities/NodeInfo.cs
+++ b/src/Extensions.Logging.Log4Net/Entities/NodeInfo.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace ReactiveMarbles.Extensions.Logging.Log4Net.Entities;
+
+/// <summary>
+///  Class to store information of a log4net xml config file node.
+/// </summary>
+public class NodeInfo
+{
+    /// <summary>
+    /// Gets or sets the x path to find the node to override.
+    /// </summary>
+    /// <value>
+    /// The x path.
+    /// </value>
+    public string? XPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content of the node.
+    /// </summary>
+    /// <value>
+    /// The content of the node.
+    /// </value>
+    public string? NodeContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the attributes.
+    /// </summary>
+    /// <value>
+    /// The attributes.
+    /// </value>
+    public Dictionary<string, string>? Attributes { get; set; }
+}

--- a/src/Extensions.Logging.Log4Net/Extensions.Logging.Log4Net.csproj
+++ b/src/Extensions.Logging.Log4Net/Extensions.Logging.Log4Net.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <PackageId>CP.Extensions.Logging.Log4Net</PackageId>
+	</PropertyGroup>
+	<PropertyGroup>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="log4net" Version="3.3.1" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.15" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.15" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.15" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.15" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
+	</ItemGroup>
+</Project>

--- a/src/Extensions.Logging.Log4Net/Extensions/DocumentExtensions.cs
+++ b/src/Extensions.Logging.Log4Net/Extensions/DocumentExtensions.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace ReactiveMarbles.Extensions.Logging.Log4Net.Extensions;
+
+/// <summary>
+/// Class with XmlDocument and XDocument extensions.
+/// </summary>
+internal static class DocumentExtensions
+{
+    /// <summary>
+    /// Converts a XmlDocument object into xDocument.
+    /// </summary>
+    /// <param name="xmlDocument">The XML document.</param>
+    /// <returns>The XmlDocument converted to XDocument.</returns>
+    public static XDocument ToXDocument(this XmlDocument xmlDocument)
+    {
+        using (var memoryStream = new MemoryStream())
+        {
+            xmlDocument.Save(memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
+            return XDocument.Load(memoryStream);
+        }
+    }
+
+    /// <summary>
+    /// Converts a XDocument object into XmlDocument.
+    /// </summary>
+    /// <param name="xDocument">The x document.</param>
+    /// <returns>The XDocument converted to XmlDocument.</returns>
+    public static XmlDocument ToXmlDocument(this XDocument xDocument)
+    {
+        using (var memoryStream = new MemoryStream())
+        {
+            xDocument.Save(memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
+            var xmlDoc = new XmlDocument();
+            xmlDoc.Load(memoryStream);
+            return xmlDoc;
+        }
+    }
+}

--- a/src/Extensions.Logging.Log4Net/Extensions/Log4NetProviderExtensions.cs
+++ b/src/Extensions.Logging.Log4Net/Extensions/Log4NetProviderExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace ReactiveMarbles.Extensions.Logging.Log4Net.Extensions;
+
+/// <summary>
+/// Log4Net provider extensions.
+/// </summary>
+public static class Log4NetProviderExtensions
+{
+    /// <summary>
+    /// Creates a logger instance for the specified category type using the provided logger provider.
+    /// </summary>
+    /// <remarks>This extension method simplifies logger creation by associating the logger with the
+    /// full name of the specified category type. Only logger providers of type Log4NetProvider are
+    /// supported.</remarks>
+    /// <typeparam name="TName">The category type for which to create a logger. Typically, this is the class type that will use the logger.</typeparam>
+    /// <param name="self">The logger provider used to create the logger. Must be of type Log4NetProvider.</param>
+    /// <returns>An ILogger instance associated with the specified category type.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the logger provider is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the logger provider is not of type Log4NetProvider.</exception>
+    public static ILogger CreateLogger<TName>(this ILoggerProvider self)
+        where TName : class
+    {
+        if (self == null)
+        {
+            throw new ArgumentNullException(nameof(self));
+        }
+
+        if (!self.GetType().IsAssignableFrom(typeof(Log4NetProvider)))
+        {
+            throw new ArgumentOutOfRangeException(nameof(self), "The ILoggerProvider should be of type Log4NetProvider.");
+        }
+
+        return self.CreateLogger(typeof(TName).FullName!);
+    }
+}

--- a/src/Extensions.Logging.Log4Net/Extensions/LogExtensions.cs
+++ b/src/Extensions.Logging.Log4Net/Extensions/LogExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using log4net;
+
+namespace ReactiveMarbles.Extensions.Logging.Log4Net.Extensions;
+
+/// <summary>
+/// Provides extension methods for the ILog interface to support logging messages at custom log levels such as Critical
+/// and Trace.
+/// </summary>
+/// <remarks>These extension methods enable logging at additional severity levels not present in the standard ILog
+/// interface. Use these methods to log messages with Critical or Trace importance when using log4net.</remarks>
+public static class LogExtensions
+{
+    /// <summary>
+    /// Criticals the specified message.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="message">The message.</param>
+    /// <param name="exception">The exception.</param>
+    public static void Critical(this ILog log, object message, Exception exception)
+        => log?.Logger.Log(null!, log4net.Core.Level.Critical, message, exception);
+
+    /// <summary>
+    /// Traces the specified message.
+    /// </summary>
+    /// <param name="log">The log.</param>
+    /// <param name="message">The message.</param>
+    /// <param name="exception">The exception.</param>
+    public static void Trace(this ILog log, object message, Exception exception)
+        => log?.Logger.Log(null!, log4net.Core.Level.Trace, message, exception);
+}

--- a/src/Extensions.Logging.Log4Net/ILog4NetLogLevelTranslator.cs
+++ b/src/Extensions.Logging.Log4Net/ILog4NetLogLevelTranslator.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace ReactiveMarbles.Extensions.Logging;
+
+/// <summary>
+/// Represents a log level translator between the different logging systems.
+/// </summary>
+public interface ILog4NetLogLevelTranslator
+{
+    /// <summary>
+    /// Translates a <see cref="LogLevel"/> to a log4net <see cref="log4net.Core.Level"/> based on the provided options.
+    /// </summary>
+    /// <param name="logLevel">The log level to translate.</param>
+    /// <param name="options">The log4net provider options influencing the translation.</param>
+    /// <returns>The corresponding log level for log4net.</returns>
+    log4net.Core.Level? TranslateLogLevel(LogLevel logLevel, Log4NetProviderOptions options);
+}

--- a/src/Extensions.Logging.Log4Net/ILog4NetLoggingEventFactory.cs
+++ b/src/Extensions.Logging.Log4Net/ILog4NetLoggingEventFactory.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using log4net.Core;
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Logging.Log4Net.Entities;
+
+namespace ReactiveMarbles.Extensions.Logging;
+
+/// <summary>
+/// Represents a factory that creates the log4net <see cref="log4net.Core.LoggingEvent"/> from a <see cref="MessageCandidate{TState}"/>.
+/// </summary>
+public interface ILog4NetLoggingEventFactory
+{
+    /// <summary>
+    /// Creates a new log4net LoggingEvent instance using the specified message candidate, logger, provider options,
+    /// and external scope provider.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state object associated with the log message.</typeparam>
+    /// <param name="messageCandidate">The candidate message containing the log state and related metadata to be included in the logging event.</param>
+    /// <param name="logger">The log4net logger to associate with the created logging event. Cannot be null.</param>
+    /// <param name="options">The provider options that configure how the logging event is created and formatted.</param>
+    /// <param name="scopeProvider">The external scope provider used to supply additional contextual information for the logging event. May be
+    /// null if no external scopes are required.</param>
+    /// <returns>A LoggingEvent instance populated with the provided message, logger, options, and scope information.</returns>
+    LoggingEvent? CreateLoggingEvent<TState>(
+        in MessageCandidate<TState> messageCandidate,
+        log4net.Core.ILogger logger,
+        Log4NetProviderOptions options,
+        IExternalScopeProvider scopeProvider);
+}

--- a/src/Extensions.Logging.Log4Net/Log4NetExtensions.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetExtensions.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace ReactiveMarbles.Extensions.Logging;
+
+/// <summary>
+/// The log4net extensions class.
+/// </summary>
+public static class Log4NetExtensions
+{
+    /// <summary>
+    /// Adds the log4net.
+    /// </summary>
+    /// <param name="factory">The factory.</param>
+    /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider.</returns>
+    public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
+        => factory.AddLog4Net(new Log4NetProviderOptions());
+
+    /// <summary>
+    /// Adds the log4net.
+    /// </summary>
+    /// <param name="factory">The factory.</param>
+    /// <param name="log4NetConfigFile">The log4net Config File.</param>
+    /// <returns>The <see cref="ILoggerFactory"/> after adding the log4net provider.</returns>
+    public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile)
+        => factory.AddLog4Net(log4NetConfigFile, false);
+
+    /// <summary>
+    /// Adds the log4net logging provider.
+    /// </summary>
+    /// <param name="factory">The factory.</param>
+    /// <param name="log4NetConfigFile">The log4 net configuration file.</param>
+    /// <param name="watch">if set to <c>true</c> [watch].</param>
+    /// <returns>The <see cref="ILoggerFactory"/> after adding the log4net provider.</returns>
+    public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile, bool watch)
+        => factory.AddLog4Net(new Log4NetProviderOptions(log4NetConfigFile, watch));
+
+    /// <summary>
+    /// Adds the log4net logging provider.
+    /// </summary>
+    /// <param name="factory">The logger factory.</param>
+    /// <param name="options">The options for log4net provider.</param>
+    /// <returns>The <see cref="ILoggerFactory"/> after adding the log4net provider.</returns>
+    public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, Log4NetProviderOptions options)
+    {
+        if (factory == null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        factory.AddProvider(new Log4NetProvider(options));
+        return factory;
+    }
+
+    /// <summary>
+    /// Adds the log4net logging provider.
+    /// </summary>
+    /// <param name="builder">The logging builder instance.</param>
+    /// <returns>The <see ref="ILoggingBuilder" /> passed as parameter with the new provider registered.</returns>
+    public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder)
+    {
+        var options = new Log4NetProviderOptions();
+        return builder.AddLog4Net(options);
+    }
+
+    /// <summary>
+    /// Adds the log4net logging provider.
+    /// </summary>
+    /// <param name="builder">The logging builder instance.</param>
+    /// <param name="log4NetConfigFile">The log4net Config File.</param>
+    /// <returns>The <see ref="ILoggingBuilder" /> passed as parameter with the new provider registered.</returns>
+    public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder, string log4NetConfigFile)
+    {
+        var options = new Log4NetProviderOptions(log4NetConfigFile);
+        return builder.AddLog4Net(options);
+    }
+
+    /// <summary>
+    /// Adds the log4net logging provider.
+    /// </summary>
+    /// <param name="builder">The logging builder instance.</param>
+    /// <param name="log4NetConfigFile">The log4net Config File.</param>
+    /// <param name="watch">if set to <c>true</c>, the configuration will be reloaded when the xml configuration file changes.</param>
+    /// <returns>
+    /// The <see ref="ILoggingBuilder" /> passed as parameter with the new provider registered.
+    /// </returns>
+    public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder, string log4NetConfigFile, bool watch)
+    {
+        var options = new Log4NetProviderOptions(log4NetConfigFile, watch);
+        return builder.AddLog4Net(options);
+    }
+
+    /// <summary>
+    /// Adds a Log4Net-based logging provider to the specified logging builder.
+    /// </summary>
+    /// <remarks>Use this method to enable Log4Net logging in an application's logging pipeline. This method
+    /// registers the Log4Net provider as a singleton service.</remarks>
+    /// <param name="builder">The logging builder to which the Log4Net provider will be added.</param>
+    /// <param name="options">The options used to configure the Log4Net provider. Cannot be null.</param>
+    /// <returns>The same instance of <see cref="ILoggingBuilder"/> for chaining.</returns>
+    public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder, Log4NetProviderOptions options)
+    {
+        if (builder == null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        builder.Services.AddSingleton<ILoggerProvider>(new Log4NetProvider(options));
+        return builder;
+    }
+}

--- a/src/Extensions.Logging.Log4Net/Log4NetLogLevelTranslator.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetLogLevelTranslator.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using log4net.Core;
+using Microsoft.Extensions.Logging;
+
+namespace ReactiveMarbles.Extensions.Logging;
+
+/// <inheritdoc cref="ILog4NetLogLevelTranslator"/>
+public sealed class Log4NetLogLevelTranslator : ILog4NetLogLevelTranslator
+{
+    /// <inheritdoc/>
+    public Level? TranslateLogLevel(LogLevel logLevel, Log4NetProviderOptions options)
+    {
+        switch (logLevel)
+        {
+            case LogLevel.Critical:
+                if (options == null)
+                {
+                    throw new ArgumentNullException(nameof(options));
+                }
+
+                var overrideCriticalLevelWith = options.OverrideCriticalLevelWith;
+                return !string.IsNullOrEmpty(overrideCriticalLevelWith)
+                        && overrideCriticalLevelWith.Equals(LogLevel.Critical.ToString(), StringComparison.OrdinalIgnoreCase)
+                            ? Level.Critical
+                            : Level.Fatal;
+            case LogLevel.Debug:
+                return Level.Debug;
+            case LogLevel.Error:
+                return Level.Error;
+            case LogLevel.Information:
+                return Level.Info;
+            case LogLevel.Warning:
+                return Level.Warn;
+            case LogLevel.Trace:
+                return Level.Trace;
+        }
+
+        return null;
+    }
+}

--- a/src/Extensions.Logging.Log4Net/Log4NetLogger.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetLogger.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using log4net;
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Logging.Log4Net.Entities;
+
+namespace ReactiveMarbles.Extensions.Logging;
+
+/// <summary>
+/// The log4net logger class.
+/// </summary>
+public class Log4NetLogger : ILogger
+{
+    private readonly IExternalScopeProvider _externalScopeProvider;
+
+    /// <summary>
+    /// The log.
+    /// </summary>
+    private readonly log4net.Core.ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Log4NetLogger"/> class using the specified provider options and external scope.
+    /// provider.
+    /// </summary>
+    /// <param name="options">The options used to configure the logger, including repository and logger name information. Cannot be null.</param>
+    /// <param name="externalScopeProvider">The external scope provider used to capture and manage logging scopes. Cannot be null.</param>
+    /// <exception cref="ArgumentNullException">Thrown if either options or externalScopeProvider is null.</exception>
+    public Log4NetLogger(Log4NetProviderOptions options, IExternalScopeProvider externalScopeProvider)
+    {
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+        _externalScopeProvider = externalScopeProvider ?? throw new ArgumentNullException(nameof(externalScopeProvider));
+        _logger = LogManager.GetLogger(options.LoggerRepository, options.Name).Logger;
+    }
+
+    /// <summary>
+    /// Gets the name.
+    /// </summary>
+    public string Name
+        => _logger.Name;
+
+    /// <summary>
+    /// Gets a get-only property for accessing the <see cref="Log4NetProviderOptions"/>
+    /// within the instance.
+    /// </summary>
+    internal Log4NetProviderOptions Options { get; }
+
+    /// <summary>
+    /// Begins a logical operation scope.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state.</typeparam>
+    /// <param name="state">The identifier for the scope.</param>
+    /// <returns>
+    /// An IDisposable that ends the logical operation scope on dispose.
+    /// </returns>
+    public IDisposable BeginScope<TState>(TState state)
+        => _externalScopeProvider.Push(state);
+
+    /// <summary>
+    /// Determines whether the logging level is enabled.
+    /// </summary>
+    /// <param name="logLevel">The log level.</param>
+    /// <returns>The <see cref="bool"/> value indicating whether the logging level is enabled.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Throws when <paramref name="logLevel"/> is outside allowed range.</exception>
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        var translatedLogLevel = Options.LogLevelTranslator?.TranslateLogLevel(logLevel, Options);
+        if (translatedLogLevel != null)
+        {
+            return _logger.IsEnabledFor(translatedLogLevel);
+        }
+
+        if (logLevel == LogLevel.None)
+        {
+            return false;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(logLevel));
+    }
+
+    /// <summary>
+    /// Logs an exception into the log.
+    /// </summary>
+    /// <param name="logLevel">The log level.</param>
+    /// <param name="eventId">The event Id.</param>
+    /// <param name="state">The state.</param>
+    /// <param name="exception">The exception.</param>
+    /// <param name="formatter">The formatter.</param>
+    /// <typeparam name="TState">The type of the state.</typeparam>
+    /// <exception cref="ArgumentNullException">Throws when the <paramref name="formatter"/> is null.</exception>
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        EnsureValidFormatter(formatter);
+
+        var candidate = new MessageCandidate<TState>(logLevel, eventId, state, exception, formatter);
+
+        var loggingEvent = Options.LoggingEventFactory?.CreateLoggingEvent(in candidate, _logger, Options, _externalScopeProvider);
+
+        if (loggingEvent == null)
+        {
+            return;
+        }
+
+        _logger.Log(loggingEvent);
+    }
+
+    private static void EnsureValidFormatter<TState>(Func<TState, Exception, string> formatter)
+    {
+        if (formatter == null)
+        {
+            throw new ArgumentNullException(nameof(formatter));
+        }
+    }
+}

--- a/src/Extensions.Logging.Log4Net/Log4NetLoggingEventFactory.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetLoggingEventFactory.cs
@@ -1,0 +1,225 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using log4net.Core;
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Logging.Log4Net.Entities;
+
+namespace ReactiveMarbles.Extensions.Logging;
+
+/// <inheritdoc cref="ILog4NetLoggingEventFactory"/>
+public class Log4NetLoggingEventFactory
+    : ILog4NetLoggingEventFactory
+{
+    /// <summary>
+    /// The default property name for scopes that don't provide their own property name by implementing
+    /// an <see cref="IEnumerable{T}"/> where T is <see cref="KeyValuePair{TKey,TValue}"/> and where TKey
+    /// is <see cref="string"/>.
+    /// </summary>
+    protected const string DefaultScopeProperty = "scope";
+    private const string EventIdProperty = "eventId";
+
+    /// <inheritdoc/>
+    public LoggingEvent? CreateLoggingEvent<TState>(
+        in MessageCandidate<TState> messageCandidate,
+        log4net.Core.ILogger logger,
+        Log4NetProviderOptions options,
+        IExternalScopeProvider scopeProvider)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (logger == null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        var callerStackBoundaryDeclaringType = typeof(LoggerExtensions);
+        var message = messageCandidate.Formatter(messageCandidate.State, messageCandidate.Exception);
+        var logLevel = options.LogLevelTranslator?.TranslateLogLevel(messageCandidate.LogLevel, options);
+
+        if (logLevel == null || (string.IsNullOrEmpty(message) && messageCandidate.Exception == null))
+        {
+            return null;
+        }
+
+        var loggingEvent = new LoggingEvent(
+            callerStackBoundaryDeclaringType: callerStackBoundaryDeclaringType,
+            repository: logger.Repository,
+            loggerName: logger.Name,
+            level: logLevel,
+            message: message,
+            exception: messageCandidate.Exception);
+
+        EnrichWithScopes(loggingEvent, scopeProvider);
+
+        loggingEvent.Properties[EventIdProperty] = messageCandidate.EventId;
+
+        return loggingEvent;
+    }
+
+    /// <summary>
+    /// Gets the scopes from the external scope provider and converts them to the properties on the logging event.
+    /// This function will honor the convention that logging scopes can provide their own property name, by implementing
+    /// an <see cref="IEnumerable{T}"/> where T is <see cref="KeyValuePair{TKey,TValue}"/> and where TKey is
+    /// <see cref="string"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation will call Convert.ToString(scope, CultureInfo.InvariantCulture) on all scope objects.
+    /// If you want to do this conversion inside the Log4Net Pipeline, e. g. with a custom layout, you can override this
+    /// method and change the behaviour.
+    /// </remarks>
+    /// <param name="loggingEvent">The <see cref="LoggingEvent"/> the scope information will be added to.</param>
+    /// <param name="scopeProvider">The external provider for the current logging scope.</param>
+    protected virtual void EnrichWithScopes(LoggingEvent loggingEvent, IExternalScopeProvider scopeProvider) => scopeProvider?.ForEachScope(
+            (scope, @event) =>
+        {
+            // This function will add the scopes in the legacy way they were added before the IExternalScopeProvider was introduced,
+            // to maintain backwards compatibility.
+            // This pretty much means that we are emulating a LogicalThreadContextStack, which is a stack, that allows pushing
+            // strings on to it, which will be concatenated with space as a separator.
+            // See: https://github.com/apache/logging-log4net/blob/47aaf46d5f031ea29d781bac4617bd1bb9446215/src/log4net/Util/LogicalThreadContextStack.cs#L343
+
+            // Because string implements IEnumerable we first need to check for string.
+            if (scope is string)
+            {
+                var previousValue = @event.Properties[DefaultScopeProperty] as string;
+
+                @event.Properties[DefaultScopeProperty] = JoinOldAndNewValue(previousValue, scope.ToString());
+                return;
+            }
+
+            if (scope is IEnumerable col)
+            {
+                foreach (var item in col)
+                {
+                    if (item is KeyValuePair<string, string> keyValuePair3)
+                    {
+                        var keyValuePair = keyValuePair3;
+                        var previousValue = @event.Properties[keyValuePair.Key] as string;
+                        @event.Properties[keyValuePair.Key] = JoinOldAndNewValue(previousValue, keyValuePair.Value);
+                        continue;
+                    }
+
+                    if (item is KeyValuePair<string, object> keyValuePair2)
+                    {
+                        var keyValuePair = keyValuePair2;
+                        var previousValue = @event.Properties[keyValuePair.Key] as string;
+
+                        // The current culture should not influence how integers/floats/... are displayed in logging,
+                        // so we are using Convert.ToString which will convert IConvertible and IFormattable with
+                        // the specified IFormatProvider.
+                        var additionalValue = Convert.ToString(keyValuePair.Value, CultureInfo.InvariantCulture);
+                        @event.Properties[keyValuePair.Key] = JoinOldAndNewValue(previousValue, additionalValue);
+                        continue;
+                    }
+                }
+
+                return;
+            }
+
+            if (FromValueTuple<string>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<int>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<long>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<short>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<decimal>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<double>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<float>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<uint>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<ulong>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<ushort>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<byte>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<sbyte>())
+            {
+                return;
+            }
+
+            if (FromValueTuple<object>())
+            {
+                return;
+            }
+
+            if (scope is not null)
+            {
+                var previousValue = @event.Properties[DefaultScopeProperty] as string;
+                var additionalValue = Convert.ToString(scope, CultureInfo.InvariantCulture);
+                @event.Properties[DefaultScopeProperty] = JoinOldAndNewValue(previousValue, additionalValue);
+                return;
+            }
+
+            bool FromValueTuple<T>()
+            {
+                if (scope is ValueTuple<string, T> valueTuple)
+                {
+                    var previousValue = @event.Properties[valueTuple.Item1] as string;
+                    var additionalValue = Convert.ToString(valueTuple.Item2, CultureInfo.InvariantCulture);
+                    @event.Properties[valueTuple.Item1] = JoinOldAndNewValue(previousValue, additionalValue);
+                    return true;
+                }
+
+                return false;
+            }
+        },
+            loggingEvent);
+
+    private static string? JoinOldAndNewValue(string? previousValue, string? newValue)
+    {
+        if (string.IsNullOrEmpty(previousValue))
+        {
+            return newValue;
+        }
+
+        return previousValue + " " + newValue;
+    }
+}

--- a/src/Extensions.Logging.Log4Net/Log4NetProvider.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetProvider.cs
@@ -1,0 +1,368 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using log4net;
+using log4net.Config;
+using log4net.Repository;
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Logging.Log4Net.Entities;
+using ReactiveMarbles.Extensions.Logging.Log4Net.Extensions;
+using ReactiveMarbles.Extensions.Logging.Log4Net.Scope;
+
+namespace ReactiveMarbles.Extensions.Logging;
+
+/// <summary>
+/// The log4net provider class.
+/// </summary>
+/// <seealso cref="ILoggerProvider" />
+public class Log4NetProvider : ILoggerProvider, ISupportExternalScope
+{
+    /// <summary>
+    /// The loggers collection.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, Log4NetLogger> _loggers = new ConcurrentDictionary<string, Log4NetLogger>();
+
+    /// <summary>
+    /// Prevents to dispose the object more than single time.
+    /// </summary>
+    private bool _disposedValue;
+
+    /// <summary>
+    /// The log4net repository.
+    /// </summary>
+    private ILoggerRepository? _loggerRepository;
+
+    /// <summary>
+    /// The provider options.
+    /// </summary>
+    private Log4NetProviderOptions? _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
+    /// </summary>
+    public Log4NetProvider()
+        : this(new Log4NetProviderOptions())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
+    /// </summary>
+    /// <param name="log4NetConfigFileName">The log4NetConfigFile.</param>
+    public Log4NetProvider(string log4NetConfigFileName)
+        : this(new Log4NetProviderOptions(log4NetConfigFileName))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
+    /// </summary>
+    /// <param name="options">The options.</param>
+    /// <exception cref="ArgumentNullException">options.</exception>
+    /// <exception cref="NotSupportedException">Wach cannot be true when you are overwriting config file values with values from configuration section.</exception>
+    public Log4NetProvider(Log4NetProviderOptions options)
+    {
+        SetOptionsIfValid(options);
+
+        var loggingAssembly = GetLoggingReferenceAssembly();
+
+        CreateLoggerRepository(loggingAssembly);
+        ConfigureLog4NetLibrary();
+    }
+
+    /// <summary>
+    /// Finalizes an instance of the <see cref="Log4NetProvider"/> class.
+    /// </summary>
+    ~Log4NetProvider()
+    {
+        Dispose(false);
+    }
+
+    /// <summary>
+    /// Gets the external logging scope provider.
+    /// </summary>
+    /// <remarks>
+    /// Reading the offical logging implementations, it seems like we need to handle the case that this might never be set.
+    /// We handle it with a NullScopeProvider instead of null checks, to make the process of implementing interfaces like
+    /// <see cref="ILog4NetLoggingEventFactory"/> less error prone for consumers.
+    /// </remarks>
+    public IExternalScopeProvider ExternalScopeProvider { get; private set; } = NullScopeProvider.Instance;
+
+    /// <summary>
+    /// Creates the logger.
+    /// </summary>
+    /// <returns>An instance of the <see cref="ILogger"/>.</returns>
+    public ILogger CreateLogger()
+        => CreateLogger(_options?.Name ?? string.Empty);
+
+    /// <summary>
+    /// Creates the logger.
+    /// </summary>
+    /// <param name="categoryName">The category name.</param>
+    /// <returns>An instance of the <see cref="ILogger"/>.</returns>
+    public ILogger CreateLogger(string categoryName)
+        => _loggers.GetOrAdd(categoryName, CreateLoggerImplementation);
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Sets the external scope provider to be used for logging operations.
+    /// </summary>
+    /// <remarks>Use this method to configure how scope information is managed and included in log messages.
+    /// Setting the scope provider to null disables external scoping support.</remarks>
+    /// <param name="scopeProvider">The external scope provider that supplies scope information for log entries. Can be null to disable external
+    /// scoping.</param>
+    public void SetScopeProvider(IExternalScopeProvider scopeProvider) => ExternalScopeProvider = scopeProvider;
+
+    /// <summary>
+    /// Releases unmanaged and - optionally - managed resources.
+    /// </summary>
+    /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                _loggerRepository?.Shutdown();
+                _loggers.Clear();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    /// <summary>
+    /// Updates configuration nodes overriding values if required.
+    /// </summary>
+    /// <param name="configXmlDocument">The configuration file XML document.</param>
+    /// <param name="overridingNodes">The overriding values available.</param>
+    /// <returns>An <see cref="XmlDocument"/> within the overriding values replaced.</returns>
+    private static XmlDocument UpdateNodesWithOverridingValues(XmlDocument configXmlDocument, IEnumerable<NodeInfo> overridingNodes)
+    {
+        var additionalConfig = overridingNodes;
+        if (additionalConfig != null)
+        {
+            var configXDoc = configXmlDocument.ToXDocument();
+            foreach (var nodeInfo in additionalConfig)
+            {
+                var node = configXDoc.XPathSelectElement(nodeInfo.XPath!);
+                if (node != null)
+                {
+                    if (nodeInfo.NodeContent != null)
+                    {
+                        node.Value = nodeInfo.NodeContent;
+                    }
+
+                    AddOrUpdateAttributes(node, nodeInfo);
+                }
+            }
+
+            return configXDoc.ToXmlDocument();
+        }
+
+        return configXmlDocument;
+    }
+
+    /// <summary>
+    /// Adds or updates the attributes specified in the node information.
+    /// </summary>
+    /// <param name="node">The node.</param>
+    /// <param name="nodeInfo">The node information.</param>
+    private static void AddOrUpdateAttributes(XElement node, NodeInfo nodeInfo)
+    {
+        if (nodeInfo?.Attributes != null)
+        {
+            foreach (var attribute in nodeInfo.Attributes)
+            {
+                var nodeAttribute = node.Attributes()
+                    .FirstOrDefault(a => a.Name.LocalName.Equals(attribute.Key, StringComparison.OrdinalIgnoreCase));
+                if (nodeAttribute != null)
+                {
+                    nodeAttribute.Value = attribute.Value;
+                }
+                else
+                {
+                    node.SetAttributeValue(attribute.Key, attribute.Value);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses log4net config file.
+    /// </summary>
+    /// <param name="filename">The filename.</param>
+    /// <returns>The <see cref="XmlElement"/> with the log4net XML element.</returns>
+    private static XmlDocument ParseLog4NetConfigFile(string filename)
+    {
+        using (var stream = File.OpenRead(filename))
+        {
+            var settings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Prohibit
+            };
+
+            var log4netConfig = new XmlDocument();
+            using (var reader = XmlReader.Create(stream, settings))
+            {
+                log4netConfig.Load(reader);
+            }
+
+            return log4netConfig;
+        }
+    }
+
+    /// <summary>
+    /// Creates the logger implementation.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <returns>The <see cref="Log4NetLogger"/> instance.</returns>
+    private Log4NetLogger CreateLoggerImplementation(string name)
+    {
+        var loggerOptions = new Log4NetProviderOptions
+        {
+            Name = name,
+            LoggerRepository = _loggerRepository?.Name,
+            OverrideCriticalLevelWith = _options?.OverrideCriticalLevelWith ?? string.Empty,
+            LoggingEventFactory = _options?.LoggingEventFactory ?? new Log4NetLoggingEventFactory(),
+            LogLevelTranslator = _options?.LogLevelTranslator ?? new Log4NetLogLevelTranslator(),
+        };
+
+        return new Log4NetLogger(loggerOptions, ExternalScopeProvider);
+    }
+
+    /// <summary>
+    /// Gets the current executing assembly considering the target framework.
+    /// </summary>
+    /// <returns>The assembly to be used as the reference logging assembly.</returns>
+    private Assembly GetLoggingReferenceAssembly() => _options?.ConfigurationAssembly ?? Assembly.GetExecutingAssembly();
+
+    /// <summary>
+    /// Ensures that provided options combinations are valid, and sets the class field if everything is ok.
+    /// </summary>
+    /// <param name="options">The options to validate.</param>
+    /// <exception cref="NotSupportedException">
+    /// Throws when the Watch option is set and there are properties to override.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// Throws when the options parameter is null.
+    /// </exception>
+    private void SetOptionsIfValid(Log4NetProviderOptions options)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (options.Watch
+            && options.PropertyOverrides.Count > 0)
+        {
+            throw new NotSupportedException("Wach cannot be true when you are overwriting config file values with values from configuration section.");
+        }
+
+        _options = options;
+    }
+
+    /// <summary>
+    /// Configures the log4net library using the available configuration data.
+    /// </summary>
+    private void ConfigureLog4NetLibrary()
+    {
+        if (_options?.UseWebOrAppConfig == true)
+        {
+            XmlConfigurator.Configure(_loggerRepository!);
+            return;
+        }
+
+        if (_options?.ExternalConfigurationSetup == false)
+        {
+            var fileNamePath = CreateLog4NetFilePath();
+            if (_options.Watch)
+            {
+                XmlConfigurator.ConfigureAndWatch(
+                    _loggerRepository!,
+                    new FileInfo(fileNamePath));
+            }
+            else
+            {
+                var configXml = ParseLog4NetConfigFile(fileNamePath);
+                if (_options.PropertyOverrides?.Count > 0)
+                {
+                    configXml = UpdateNodesWithOverridingValues(
+                        configXml,
+                        _options.PropertyOverrides);
+                }
+
+                XmlConfigurator.Configure(_loggerRepository!, configXml.DocumentElement!);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates the log4net.config file path.
+    /// </summary>
+    /// <returns>The full path to the log4net.config file.</returns>
+    private string CreateLog4NetFilePath()
+    {
+        var fileNamePath = _options?.Log4NetConfigFileName;
+        if (!Path.IsPathRooted(fileNamePath))
+        {
+            fileNamePath = Path.Combine(AppContext.BaseDirectory, fileNamePath!);
+        }
+
+        return Path.GetFullPath(fileNamePath);
+    }
+
+    /// <summary>
+    /// Gets or creates the logger repository using the given assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly to be used to create the repository.</param>
+    private void CreateLoggerRepository(Assembly assembly)
+    {
+        var repositoryType = typeof(log4net.Repository.Hierarchy.Hierarchy);
+
+        if (!string.IsNullOrEmpty(_options!.LoggerRepository))
+        {
+            try
+            {
+                _loggerRepository = LogManager.GetRepository(_options.LoggerRepository!);
+                if (_options.ExternalConfigurationSetup)
+                {
+                    // The logger repository is already configured. We can exit here.
+                    return;
+                }
+            }
+            catch (log4net.Core.LogException)
+            {
+                // The logger repository is not defined outside the extension.
+                _loggerRepository = null;
+            }
+
+            _loggerRepository ??=
+                    LogManager.CreateRepository(_options.LoggerRepository!, repositoryType);
+        }
+        else
+        {
+            _loggerRepository =
+                LogManager.CreateRepository(assembly, repositoryType);
+        }
+    }
+}

--- a/src/Extensions.Logging.Log4Net/Log4NetProviderOptions.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetProviderOptions.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Logging.Log4Net.Entities;
+
+namespace ReactiveMarbles.Extensions.Logging;
+
+/// <summary>
+/// The log4Net provider options.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="Log4NetProviderOptions"/> class with the specified configuration file name and.
+/// watch setting.
+/// </remarks>
+/// <param name="log4NetConfigFileName">The path to the log4net configuration file to be used for logger setup. Cannot be null or empty.</param>
+/// <param name="watch">true to enable watching the configuration file for changes; otherwise, false.</param>
+public sealed class Log4NetProviderOptions(string log4NetConfigFileName, bool watch)
+{
+    /// <summary>
+    /// The default log4 net file name.
+    /// </summary>
+    private const string DefaultLog4NetFileName = "log4net.config";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Log4NetProviderOptions"/> class.
+    /// </summary>
+    public Log4NetProviderOptions()
+        : this(DefaultLog4NetFileName)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Log4NetProviderOptions"/> class.
+    /// </summary>
+    /// <param name="log4NetConfigFileName">Name of the log4 net configuration file.</param>
+    public Log4NetProviderOptions(string log4NetConfigFileName)
+        : this(log4NetConfigFileName, false)
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the log file.
+    /// </summary>
+    public string Log4NetConfigFileName { get; set; } = log4NetConfigFileName;
+
+    /// <summary>
+    /// Gets or sets the logger repository.
+    /// </summary>
+    public string? LoggerRepository { get; set; }
+
+    /// <summary>
+    /// Gets or sets the level value that should be used to override default's critical level.
+    /// </summary>
+    public string OverrideCriticalLevelWith { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the property overrides.
+    /// </summary>
+    public List<NodeInfo> PropertyOverrides { get; set; } = new List<NodeInfo>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this <see cref="Log4NetProviderOptions"/> is watch.
+    /// </summary>
+    public bool Watch { get; set; } = watch;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether let user setup log4net externally.
+    /// </summary>
+    public bool ExternalConfigurationSetup { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether let user setup log4net from web.config / app.config.
+    /// </summary>
+    public bool UseWebOrAppConfig { get; set; }
+
+    /// <summary>
+    /// Gets or sets the assembly used to create the log4net repository identity when <see cref="LoggerRepository"/> is not provided.
+    /// </summary>
+    public Assembly? ConfigurationAssembly { get; set; }
+
+    /// <summary>
+    /// Gets or sets the factory for the log4net <see cref="log4net.Core.LoggingEvent"/>.
+    /// </summary>
+    public ILog4NetLoggingEventFactory? LoggingEventFactory { get; set; }
+
+    /// <summary>
+    /// Gets or sets the translator between the <see cref="LogLevel"/> and the log4net <see cref="log4net.Core.Level"/>.
+    /// </summary>
+    public ILog4NetLogLevelTranslator? LogLevelTranslator { get; set; }
+}

--- a/src/Extensions.Logging.Log4Net/Scope/NullScope.cs
+++ b/src/Extensions.Logging.Log4Net/Scope/NullScope.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ReactiveMarbles.Extensions.Logging.Log4Net.Scope;
+
+/// <summary>
+/// A logger scope that does not save any information and does not need to be disposed.
+/// </summary>
+internal sealed class NullScope : IDisposable
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullScope"/> class.
+    /// Constructor that prevents external instantiation.
+    /// </summary>
+    private NullScope()
+    {
+    }
+
+    /// <summary>
+    /// Gets the singleton instance that represent every <see cref="NullScope"/>.
+    /// </summary>
+    internal static NullScope Instance { get; } = new NullScope();
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // This is a null scope so we need to dispose nothing.
+    }
+}

--- a/src/Extensions.Logging.Log4Net/Scope/NullScopeProvider.cs
+++ b/src/Extensions.Logging.Log4Net/Scope/NullScopeProvider.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace ReactiveMarbles.Extensions.Logging.Log4Net.Scope;
+
+/// <summary>
+/// A <see cref="IExternalScopeProvider"/> that will not save nor return scopes.
+/// </summary>
+internal sealed class NullScopeProvider : IExternalScopeProvider
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullScopeProvider"/> class.
+    /// Constructor that prevents external instantiation.
+    /// </summary>
+    private NullScopeProvider()
+    {
+    }
+
+    /// <summary>
+    /// Gets the singleton instance that represents every <see cref="NullScopeProvider"/>.
+    /// </summary>
+    internal static NullScopeProvider Instance { get; } = new NullScopeProvider();
+
+    /// <inheritdoc/>
+    public void ForEachScope<TState>(Action<object, TState> callback, TState state)
+    {
+        // All scopes are null scopes so do nothing.
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Push(object? state) => NullScope.Instance;
+}

--- a/src/examples/Extensions.Hosting.Avalonia.Example/Extensions.Hosting.Avalonia.Example.csproj
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/Extensions.Hosting.Avalonia.Example.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(CoreVersion)" />
-    <PackageReference Include="Avalonia" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
+    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/Extensions.Hosting.ReactiveAvalonia.Example.csproj
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/Extensions.Hosting.ReactiveAvalonia.Example.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(CoreVersion)" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.0" />
-    <PackageReference Include="Avalonia" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
+    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
+    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/MainWindow.axaml
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/MainWindow.axaml
@@ -5,6 +5,7 @@
     xmlns:local="using:Extensions.Hosting.ReactiveAvalonia.Example"
     xmlns:reactiveui="clr-namespace:ReactiveUI.Avalonia;assembly=ReactiveUI.Avalonia"
     x:TypeArguments="local:AppViewModel"
+    x:DataType="local:AppViewModel"
     Height="450"
     Title="ReactiveMarbles NuGet Browser"
     Width="800">

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/NugetDetailsView.axaml
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/NugetDetailsView.axaml
@@ -4,7 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Extensions.Hosting.ReactiveAvalonia.Example"
     xmlns:reactiveui="clr-namespace:ReactiveUI.Avalonia;assembly=ReactiveUI.Avalonia"
-    x:TypeArguments="local:NugetDetailsViewModel">
+    x:TypeArguments="local:NugetDetailsViewModel"
+    x:DataType="local:NugetDetailsViewModel">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />

--- a/src/examples/Extensions.Hosting.ReactiveWpf.Example/Extensions.Hosting.ReactiveWpf.Example.csproj
+++ b/src/examples/Extensions.Hosting.ReactiveWpf.Example/Extensions.Hosting.ReactiveWpf.Example.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="7.3.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(CoreVersion)" />
   </ItemGroup>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "3.0",
+    "version": "3.1",
     "publicReleaseRefSpec": [
         "^refs/heads/main$",
         "^refs/heads/master$",


### PR DESCRIPTION
Introduce a new CP.Extensions.Logging.Log4Net project with provider, logger, options, event factory, translators, extensions and supporting types (Entities, Scope, Extensions). 
Add the project to the solution and wire it into Extensions.Hosting.PluginService as a project reference. 
Update Directory.Build.props to bump Core and Avalonia versions and test/package tooling versions. 
Adjust Avalonia extension csproj to target modern frameworks only and use the shared AvaloniaVersion; bump ReactiveUI.Avalonia and Tmds.DBus.Protocol versions. 
Minor example project/views and version.json updated accordingly.