### PR TITLE
Update deps: bump versions, add security package, TUnit

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,8 +30,8 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-    <CoreVersion>10.0.6</CoreVersion>
-    <AvaloniaVersion>12.0.1</AvaloniaVersion>
+    <CoreVersion>10.0.7</CoreVersion>
+    <AvaloniaVersion>12.0.2</AvaloniaVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
@@ -22,6 +22,8 @@
     <!-- Align MSBuild dependencies to avoid NU1605 downgrades from transitive EF tooling -->
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.4.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0" PrivateAssets="all" />
+    <!-- Fix security vulnerability GHSA-37gx-xxp4-5rgx and GHSA-w3x6-4m5h-cxqf -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net9')) ">

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
@@ -22,6 +22,8 @@
     <!-- Align MSBuild dependencies to avoid NU1605 downgrades from transitive EF tooling -->
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.4.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0" PrivateAssets="all" />
+    <!-- Fix security vulnerability GHSA-37gx-xxp4-5rgx and GHSA-w3x6-4m5h-cxqf -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net9')) ">

--- a/src/examples/Extensions.Hosting.Maui.Example/Extensions.Hosting.Maui.Example.csproj
+++ b/src/examples/Extensions.Hosting.Maui.Example/Extensions.Hosting.Maui.Example.csproj
@@ -60,8 +60,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.51" />
-    <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.51" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
+    <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.60" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(CoreVersion)" />
   </ItemGroup>
 

--- a/src/tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj
@@ -22,8 +22,8 @@
     <Using Include="TUnit.Core" />
     <Using Include="TUnit.Core.Executors" />
     <Using Include="TUnit.Core.Interfaces" />
-    <Using Include="TUnit.Assertions"/>
-    <Using Include="TUnit.Assertions.Extensions"/>
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
     <Using Include="System" />
     <Using Include="System.Collections.Generic" />
     <Using Include="System.ComponentModel" />
@@ -38,5 +38,8 @@
     <Using Include="System.Reactive.Threading.Tasks" />
     <Using Include="System.Threading" />
     <Using Include="System.Threading.Tasks" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="TUnit" Version="1.43.11" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bump CoreVersion to 10.0.7 and AvaloniaVersion to 12.0.2 in Directory.Build.props. 
Add System.Security.Cryptography.Xml v10.0.7 to the Sqlite and SqlServer EF project files to address security advisories (GHSA-37gx-xxp4-5rgx and GHSA-w3x6-4m5h-cxqf). 
Normalize spacing in TUnit Using entries and update TUnit to version 1.43.11 in the test project.