### PR TITLE
feat: add reactive plugin shim project

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="ReactiveUI.Maui" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.Primitives" Version="6.0.0" />
     <PackageVersion Include="ReactiveUI.Primitives.Core" Version="6.0.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="6.0.0" />
     <PackageVersion Include="ReactiveUI.WinForms" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.WinUI" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.WPF" Version="24.0.0-beta.3" />

--- a/src/Extensions.Hosting.Avalonia/Internals/AvaloniaThread.cs
+++ b/src/Extensions.Hosting.Avalonia/Internals/AvaloniaThread.cs
@@ -6,7 +6,6 @@ using System;
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveMarbles.Extensions.Hosting.UiThread;
 

--- a/src/Extensions.Hosting.MainUIThread/BaseUiThread.cs
+++ b/src/Extensions.Hosting.MainUIThread/BaseUiThread.cs
@@ -61,7 +61,11 @@ public abstract class BaseUiThread<T> : IDisposable
             IsBackground = true
         };
 
+#if NET5_0_OR_GREATER
+        if (OperatingSystem.IsWindows())
+#else
         if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+#endif
         {
             // Set the apartment state for Windows desktop UI frameworks.
             newUiThread.SetApartmentState(ApartmentState.STA);

--- a/src/Extensions.Hosting.Plugins.Reactive/Extensions.Hosting.Plugins.Reactive.csproj
+++ b/src/Extensions.Hosting.Plugins.Reactive/Extensions.Hosting.Plugins.Reactive.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462;net472;net48;net481;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <PackageDescription>This extension adds reactive plug-in support to generic host based applications.</PackageDescription>
+    <PackageId>CP.Extensions.Hosting.Plugins.Reactive</PackageId>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.Plugins\**\*.cs" Exclude="..\Extensions.Hosting.Plugins\bin\**;..\Extensions.Hosting.Plugins\obj\**" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="ReactiveUI.Primitives.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="ReactiveUI.Primitives.Disposables.MultipleDisposable" Alias="CompositeDisposable" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Extensions.Hosting.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>

--- a/src/Extensions.Hosting.Plugins/HostBuilderPluginExtensions.cs
+++ b/src/Extensions.Hosting.Plugins/HostBuilderPluginExtensions.cs
@@ -9,9 +9,17 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Hosting;
+#if REACTIVE_SHIM
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.Internals;
+#else
 using ReactiveMarbles.Extensions.Hosting.Plugins.Internals;
+#endif
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Provides extension methods for configuring and loading plugins in host builder pipelines.</summary>
 /// <remarks>These extension methods enable plugin discovery and configuration for applications using IHostBuilder
@@ -200,7 +208,7 @@ public static class HostBuilderPluginExtensions
                     continue;
                 }
 
-                var loadedAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(frameworkAssemblyPath);
+                var loadedAssembly = AssemblyLoadContext.LoadFromAssemblyPath(frameworkAssemblyPath);
                 _ = scannedAssemblies.Add(loadedAssembly);
             }
         }

--- a/src/Extensions.Hosting.Plugins/HostedServiceBase.cs
+++ b/src/Extensions.Hosting.Plugins/HostedServiceBase.cs
@@ -8,7 +8,11 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Provides a base implementation for a hosted service with support for resource cleanup, logging, and application lifetime events.</summary>
 /// <remarks>This base class integrates with the application's lifetime events to manage service startup,

--- a/src/Extensions.Hosting.Plugins/IPlugin.cs
+++ b/src/Extensions.Hosting.Plugins/IPlugin.cs
@@ -4,7 +4,11 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Defines a contract for plug-ins that can configure services and settings for the application host during startup.</summary>
 /// <remarks>Implementations of this interface can be used to extend or modify the application's dependency

--- a/src/Extensions.Hosting.Plugins/IPluginBuilder.cs
+++ b/src/Extensions.Hosting.Plugins/IPluginBuilder.cs
@@ -7,7 +7,11 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Extensions.FileSystemGlobbing;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Defines a contract for configuring and building plugin discovery and loading behavior within an application.</summary>
 /// <remarks>Implementations of this interface allow customization of plugin and framework assembly scanning,

--- a/src/Extensions.Hosting.Plugins/Internals/AssemblyDependencyResolver.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/AssemblyDependencyResolver.cs
@@ -6,7 +6,11 @@ using System;
 using System.IO;
 using System.Reflection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.Internals;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins.Internals;
+#endif
 
 /// <summary>Provides methods for resolving the paths of managed assemblies and unmanaged DLLs relative to a specified plugin directory.</summary>
 /// <param name="pluginPath">The absolute path to the root directory containing the plugin and its dependencies. Cannot be null or empty.</param>

--- a/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
@@ -6,7 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.Internals;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins.Internals;
+#endif
 
 /// <summary>Provides functionality for loading and managing assemblies in a custom context, enabling isolation and control over assembly loading behavior.</summary>
 /// <remarks>AssemblyLoadContext allows applications to load assemblies into isolated contexts, which can be
@@ -24,11 +28,19 @@ public class AssemblyLoadContext(string name)
     /// this property to access the standard assembly loading behavior provided by .NET.</remarks>
     public static AssemblyLoadContext Default { get; } = new AssemblyLoadContext("default");
 
+    /// <summary>Gets the assemblies that are loaded into the current application domain.</summary>
+    public static IEnumerable<Assembly> Assemblies => AppDomain.CurrentDomain.GetAssemblies();
+
     /// <summary>Gets the name associated with the current instance.</summary>
     public string Name { get; } = name;
 
-    /// <summary>Gets the assemblies that are loaded into the current application domain.</summary>
-    public IEnumerable<Assembly> Assemblies => AppDomain.CurrentDomain.GetAssemblies();
+    /// <summary>Loads an assembly from the specified file path.</summary>
+    /// <remarks>The assembly is loaded into the load-from context. If the assembly has already been loaded,
+    /// this method may return a reference to the existing assembly. This method does not resolve dependencies
+    /// automatically; dependent assemblies must be available to the loader.</remarks>
+    /// <param name="assemblyPath">The path to the assembly file to load. The path must be a valid file system path to a managed assembly file.</param>
+    /// <returns>The loaded assembly represented by the specified file path.</returns>
+    public static Assembly LoadFromAssemblyPath(string assemblyPath) => Assembly.LoadFrom(assemblyPath);
 
     /// <summary>Loads an assembly given its display name.</summary>
     /// <remarks>This method loads the assembly into the current load context. If the assembly has already
@@ -47,27 +59,19 @@ public class AssemblyLoadContext(string name)
         return Load(assemblyName);
     }
 
-    /// <summary>Loads an assembly from the specified file path.</summary>
-    /// <remarks>The assembly is loaded into the load-from context. If the assembly has already been loaded,
-    /// this method may return a reference to the existing assembly. This method does not resolve dependencies
-    /// automatically; dependent assemblies must be available to the loader.</remarks>
-    /// <param name="assemblyPath">The path to the assembly file to load. The path must be a valid file system path to a managed assembly file.</param>
-    /// <returns>The loaded assembly represented by the specified file path.</returns>
-    public Assembly LoadFromAssemblyPath(string assemblyPath) => Assembly.LoadFrom(assemblyPath);
-
-    /// <summary>Loads the assembly with the specified name.</summary>
-    /// <remarks>Override this method to implement custom assembly loading logic in a derived class.</remarks>
-    /// <param name="assemblyName">The name of the assembly to load. Cannot be null.</param>
-    /// <returns>The loaded assembly, or null if the assembly cannot be found.</returns>
-    protected virtual Assembly Load(AssemblyName assemblyName) => null!;
-
     /// <summary>Loads an unmanaged dynamic-link library (DLL) from the specified absolute path.</summary>
     /// <remarks>This method is intended to be called by derived classes to provide custom logic for loading
     /// unmanaged libraries. The caller is responsible for ensuring that the specified path points to a valid and
     /// compatible DLL.</remarks>
     /// <param name="dllPath">The absolute path to the unmanaged DLL to load. Cannot be null or empty.</param>
     /// <returns>A handle to the loaded unmanaged DLL. Returns <see cref="IntPtr.Zero"/> if the library could not be loaded.</returns>
-    protected IntPtr LoadUnmanagedDllFromPath(string dllPath) => IntPtr.Zero;
+    protected static IntPtr LoadUnmanagedDllFromPath(string dllPath) => IntPtr.Zero;
+
+    /// <summary>Loads the assembly with the specified name.</summary>
+    /// <remarks>Override this method to implement custom assembly loading logic in a derived class.</remarks>
+    /// <param name="assemblyName">The name of the assembly to load. Cannot be null.</param>
+    /// <returns>The loaded assembly, or null if the assembly cannot be found.</returns>
+    protected virtual Assembly Load(AssemblyName assemblyName) => null!;
 
     /// <summary>Loads the specified unmanaged DLL into the process address space.</summary>
     /// <remarks>Override this method to provide custom logic for loading unmanaged libraries when resolving

--- a/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContextExtensions.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContextExtensions.cs
@@ -4,7 +4,11 @@
 
 using System.Reflection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.Internals;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins.Internals;
+#endif
 
 /// <summary>Provides extension methods for the AssemblyLoadContext class.</summary>
 /// <remarks>This static class contains methods that extend the functionality of AssemblyLoadContext, enabling
@@ -32,7 +36,7 @@ public static class AssemblyLoadContextExtensions
                 return false;
             }
 
-            foreach (var assembly in assemblyLoadContext.Assemblies)
+            foreach (var assembly in AssemblyLoadContext.Assemblies)
             {
                 var name = assembly.GetName().Name;
                 if (name is null)

--- a/src/Extensions.Hosting.Plugins/Internals/PluginBuilder.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/PluginBuilder.cs
@@ -7,7 +7,11 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Extensions.FileSystemGlobbing;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.Internals;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins.Internals;
+#endif
 
 /// <summary>Provides configuration and matching logic for plugin discovery and loading within the application.</summary>
 /// <remarks>The PluginBuilder class exposes properties and delegates that allow customization of plugin scanning,

--- a/src/Extensions.Hosting.Plugins/Internals/PluginLoadContext.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/PluginLoadContext.cs
@@ -5,7 +5,11 @@
 using System;
 using System.Reflection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.Internals;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins.Internals;
+#endif
 
 /// <summary>Provides an isolated assembly load context for loading plugins from a specified directory.</summary>
 /// <remarks>PluginLoadContext enables loading and resolving assemblies and unmanaged libraries for plugins
@@ -45,6 +49,6 @@ internal sealed class PluginLoadContext(string pluginPath, string name) : Assemb
     private Assembly? LoadAssemblyFromResolvedPath(AssemblyName assemblyName)
     {
         var assemblyPath = ResolveAssemblyPath(assemblyName);
-        return assemblyPath is null ? null : LoadFromAssemblyPath(assemblyPath);
+        return assemblyPath is null ? null : AssemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
     }
 }

--- a/src/Extensions.Hosting.Plugins/PluginBase{T1,T2,T3}.cs
+++ b/src/Extensions.Hosting.Plugins/PluginBase{T1,T2,T3}.cs
@@ -5,7 +5,11 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Provides a base implementation for plugins that register three hosted services with the application host.</summary>
 /// <remarks>This class is intended to be used as a base for plugins that require multiple hosted services to be

--- a/src/Extensions.Hosting.Plugins/PluginBase{T1,T2}.cs
+++ b/src/Extensions.Hosting.Plugins/PluginBase{T1,T2}.cs
@@ -5,7 +5,11 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Provides a base implementation for plugins that register two hosted services with a dependency injection container.</summary>
 /// <remarks>This class is intended to be used as a base for plugins that require multiple hosted services to be

--- a/src/Extensions.Hosting.Plugins/PluginBase{T}.cs
+++ b/src/Extensions.Hosting.Plugins/PluginBase{T}.cs
@@ -5,7 +5,11 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Provides a base implementation for plugins that register a hosted service of the specified type with the application's dependency injection container.</summary>
 /// <typeparam name="T">The type of the hosted service to register. Must implement <see cref="IHostedService"/>.</typeparam>

--- a/src/Extensions.Hosting.Plugins/PluginBuilderExtensions.cs
+++ b/src/Extensions.Hosting.Plugins/PluginBuilderExtensions.cs
@@ -5,7 +5,11 @@
 using System;
 using System.IO;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Provides extension methods for configuring plug-in and framework assembly scanning behavior on an <see cref="IPluginBuilder"/> instance.</summary>
 /// <remarks>These extension methods allow customization of directory scanning, inclusion and exclusion patterns

--- a/src/Extensions.Hosting.Plugins/PluginOrderAttribute.cs
+++ b/src/Extensions.Hosting.Plugins/PluginOrderAttribute.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Specifies the initialization order for a plug-in class.</summary>
 /// <remarks>Apply this attribute to a plug-in class to control the sequence in which plug-ins are initialized.

--- a/src/Extensions.Hosting.Plugins/PluginScanner.cs
+++ b/src/Extensions.Hosting.Plugins/PluginScanner.cs
@@ -6,7 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 
 /// <summary>Provides methods for discovering and instantiating plugin implementations from assemblies using naming conventions or type scanning.</summary>
 /// <remarks>The PluginScanner class is intended for use in scenarios where plugins implementing the IPlugin

--- a/src/Extensions.Hosting.SingleInstance/Extensions.Hosting.SingleInstance.csproj
+++ b/src/Extensions.Hosting.SingleInstance/Extensions.Hosting.SingleInstance.csproj
@@ -10,4 +10,10 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Extensions.Hosting.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/Extensions.Hosting.SingleInstance/ResourceMutex.cs
+++ b/src/Extensions.Hosting.SingleInstance/ResourceMutex.cs
@@ -70,6 +70,18 @@ public sealed class ResourceMutex : IDisposable
     /// <summary>Stores the resource name value.</summary>
     private readonly string _resourceName;
 
+    /// <summary>Stores the mutex factory value.</summary>
+    private readonly Func<string, (Mutex Mutex, bool CreatedNew)> _createMutex;
+
+    /// <summary>Stores the mutex release action value.</summary>
+    private readonly Action<Mutex> _releaseMutex;
+
+    /// <summary>Stores the optional before release action value.</summary>
+    private readonly Action? _beforeReleaseMutex;
+
+    /// <summary>Stores the owner thread join timeout value.</summary>
+    private readonly TimeSpan _ownerThreadJoinTimeout;
+
     /// <summary>Stores the lock acquired signal value.</summary>
     private readonly ManualResetEventSlim _lockAcquiredSignal = new(initialState: false);
 
@@ -82,15 +94,39 @@ public sealed class ResourceMutex : IDisposable
     /// <summary>Stores the owner thread value.</summary>
     private Thread? _ownerThread;
 
+    /// <summary>Initializes a new instance of the <see cref="ResourceMutex"/> class with testable mutex operations.</summary>
+    /// <param name="logger">The logger instance used to record diagnostic and operational messages for the mutex.</param>
+    /// <param name="mutexId">The unique identifier for the mutex. Used to distinguish this mutex from others.</param>
+    /// <param name="resourceName">The name of the resource associated with the mutex. If null, the mutex identifier is used as the resource name.</param>
+    /// <param name="createMutex">The operation used to create the underlying mutex.</param>
+    /// <param name="releaseMutex">The operation used to release the underlying mutex.</param>
+    /// <param name="ownerThreadJoinTimeout">The amount of time to wait for the owner thread to exit during disposal.</param>
+    /// <param name="beforeReleaseMutex">An optional operation to run on the owner thread before releasing the mutex.</param>
+    internal ResourceMutex(
+        ILogger logger,
+        string mutexId,
+        string? resourceName,
+        Func<string, (Mutex Mutex, bool CreatedNew)> createMutex,
+        Action<Mutex> releaseMutex,
+        TimeSpan ownerThreadJoinTimeout,
+        Action? beforeReleaseMutex = null)
+    {
+        _logger = logger;
+        _mutexId = mutexId;
+        _resourceName = resourceName ?? mutexId;
+        _createMutex = createMutex;
+        _releaseMutex = releaseMutex;
+        _ownerThreadJoinTimeout = ownerThreadJoinTimeout;
+        _beforeReleaseMutex = beforeReleaseMutex;
+    }
+
     /// <summary>Initializes a new instance of the <see cref="ResourceMutex"/> class with the specified logger, mutex identifier, and optional. resource name.</summary>
     /// <param name="logger">The logger instance used to record diagnostic and operational messages for the mutex.</param>
     /// <param name="mutexId">The unique identifier for the mutex. Used to distinguish this mutex from others.</param>
     /// <param name="resourceName">The name of the resource associated with the mutex. If null, the mutex identifier is used as the resource name.</param>
     private ResourceMutex(ILogger logger, string mutexId, string? resourceName = null)
+        : this(logger, mutexId, resourceName, CreateMutex, static mutex => mutex.ReleaseMutex(), TimeSpan.FromSeconds(5), null)
     {
-        _logger = logger;
-        _mutexId = mutexId;
-        _resourceName = resourceName ?? mutexId;
     }
 
     /// <summary>Gets a value indicating whether the object is locked.</summary>
@@ -159,13 +195,34 @@ public sealed class ResourceMutex : IDisposable
 
         // Signal the owning thread to release the mutex, then wait for it to finish.
         _releaseSignal.Set();
-        if (_ownerThread?.Join(TimeSpan.FromSeconds(5)) == false)
+        if (_ownerThread?.Join(_ownerThreadJoinTimeout) == false)
         {
             _mutexOwnerReleaseTimedOut(_logger, _mutexId, _resourceName, null);
         }
 
         _releaseSignal.Dispose();
         _lockAcquiredSignal.Dispose();
+    }
+
+    /// <summary>Creates the underlying named mutex.</summary>
+    /// <param name="mutexId">The fully qualified mutex identifier.</param>
+    /// <returns>The created mutex and a value indicating whether it was newly created.</returns>
+    private static (Mutex Mutex, bool CreatedNew) CreateMutex(string mutexId)
+    {
+#if NET462
+        // Added Mutex Security, hopefully this prevents the UnauthorizedAccessException more gracefully
+        var sid = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+        var mutexSecurity = new MutexSecurity();
+        mutexSecurity.AddAccessRule(new(sid, MutexRights.FullControl, AccessControlType.Allow));
+        mutexSecurity.AddAccessRule(new(sid, MutexRights.ChangePermissions, AccessControlType.Deny));
+        mutexSecurity.AddAccessRule(new(sid, MutexRights.Delete, AccessControlType.Deny));
+
+        // 1) Create Mutex
+        return (new Mutex(true, mutexId, out var createdNew, mutexSecurity), createdNew);
+#else
+        // 1) Create Mutex
+        return (new Mutex(true, mutexId, out var createdNew), createdNew);
+#endif
     }
 
     /// <summary>
@@ -182,20 +239,9 @@ public sealed class ResourceMutex : IDisposable
         // check whether there's an local instance running already, but use local so this works in a multi-user environment
         try
         {
-#if NET462
-            // Added Mutex Security, hopefully this prevents the UnauthorizedAccessException more gracefully
-            var sid = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
-            var mutexSecurity = new MutexSecurity();
-            mutexSecurity.AddAccessRule(new(sid, MutexRights.FullControl, AccessControlType.Allow));
-            mutexSecurity.AddAccessRule(new(sid, MutexRights.ChangePermissions, AccessControlType.Deny));
-            mutexSecurity.AddAccessRule(new(sid, MutexRights.Delete, AccessControlType.Deny));
-
-            // 1) Create Mutex
-            applicationMutex = new(true, _mutexId, out var createdNew, mutexSecurity);
-#else
-            // 1) Create Mutex
-            applicationMutex = new(true, _mutexId, out var createdNew);
-#endif
+            var mutex = _createMutex(_mutexId);
+            applicationMutex = mutex.Mutex;
+            var createdNew = mutex.CreatedNew;
 
             // 2) if the mutex wasn't created new get the right to it, this returns false if it's already locked
             if (!createdNew)
@@ -251,22 +297,25 @@ public sealed class ResourceMutex : IDisposable
 
         // Hold until Dispose() signals that we should release.
         _releaseSignal.Wait();
+        _beforeReleaseMutex?.Invoke();
 
         // Release on this thread - the same thread that acquired the mutex - to satisfy Mutex thread-affinity.
         try
         {
             if (IsLocked && applicationMutex is not null)
             {
-                applicationMutex.ReleaseMutex();
+                _releaseMutex(applicationMutex);
                 IsLocked = false;
                 _mutexReleased(_logger, _mutexId, _resourceName, null);
             }
-
-            applicationMutex?.Dispose();
         }
         catch (Exception ex)
         {
             _mutexReleaseFailed(_logger, _mutexId, _resourceName, ex);
+        }
+        finally
+        {
+            applicationMutex?.Dispose();
         }
     }
 }

--- a/src/Extensions.Hosting.WinForms/Internals/MultiShellContext.cs
+++ b/src/Extensions.Hosting.WinForms/Internals/MultiShellContext.cs
@@ -40,6 +40,9 @@ internal sealed class MultiShellContext : ApplicationContext
     /// <param name="args">A FormClosedEventArgs object that contains the event data.</param>
     private void OnFormClosed(object? s, FormClosedEventArgs args)
     {
+        _ = s;
+        _ = args;
+
         // When we have closed the last of the "starting" forms, end the program.
         if (Interlocked.Decrement(ref _openForms) != 0)
         {

--- a/src/Extensions.Hosting.WinForms/Internals/WinFormsThread.cs
+++ b/src/Extensions.Hosting.WinForms/Internals/WinFormsThread.cs
@@ -79,6 +79,9 @@ public class WinFormsThread(IServiceProvider serviceProvider) : BaseUiThread<IWi
     /// <param name="eventArgs">An object that contains the event data associated with the application exit event.</param>
     private void OnApplicationExit(object? sender, EventArgs eventArgs)
     {
+        _ = sender;
+        _ = eventArgs;
+
         Application.ApplicationExit -= OnApplicationExit;
 
         HandleApplicationExit();

--- a/src/Extensions.Hosting.slnx
+++ b/src/Extensions.Hosting.slnx
@@ -31,6 +31,7 @@
   <Project Path="Extensions.Hosting.MainUIThread/Extensions.Hosting.MainUIThread.csproj" />
   <Project Path="Extensions.Hosting.Maui/Extensions.Hosting.Maui.csproj" />
   <Project Path="Extensions.Hosting.Plugins/Extensions.Hosting.Plugins.csproj" />
+  <Project Path="Extensions.Hosting.Plugins.Reactive/Extensions.Hosting.Plugins.Reactive.csproj" />
   <Project Path="Extensions.Hosting.PluginService/Extensions.Hosting.PluginService.csproj" />
   <Project Path="Extensions.Hosting.ReactiveUI.Avalonia/Extensions.Hosting.ReactiveUI.Avalonia.csproj" Id="711b6a7d-e7b8-4903-9015-43116783fc45" />
   <Project Path="Extensions.Hosting.ReactiveUI.Maui/Extensions.Hosting.ReactiveUI.Maui.csproj" />

--- a/src/examples/Extensions.Hosting.Avalonia.Example/App.axaml.cs
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/App.axaml.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using Avalonia;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 
 namespace Extensions.Hosting.Avalonia.Example;

--- a/src/examples/Extensions.Hosting.Avalonia.Example/MainWindow.axaml.cs
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/MainWindow.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Interactivity;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ReactiveMarbles.Extensions.Hosting.Avalonia;
 
 namespace Extensions.Hosting.Avalonia.Example;
@@ -22,6 +23,12 @@ public partial class MainWindow : Window, IAvaloniaShell
     /// <summary>Stores the logger value.</summary>
     private readonly ILogger<MainWindow> _logger;
 
+    /// <summary>Initializes a new instance of the <see cref="MainWindow"/> class for the Avalonia runtime loader.</summary>
+    public MainWindow()
+        : this(NullLogger<MainWindow>.Instance)
+    {
+    }
+
     /// <summary>Initializes a new instance of the <see cref="MainWindow"/> class and sets up the user interface and event handlers.</summary>
     /// <remarks>This constructor initializes the UI components and attaches the Click event handler for the
     /// Exit button, enabling the application to close when the button is clicked.</remarks>
@@ -32,7 +39,7 @@ public partial class MainWindow : Window, IAvaloniaShell
         _logger = logger;
 
         // Attach event handlers
-        var exitButton = this.FindControl<Button>("ExitButton");
+        var exitButton = this.FindControl<Button>(nameof(ExitButton));
         exitButton?.Click += ExitButton_Click;
     }
 

--- a/src/examples/Extensions.Hosting.Avalonia.Example/Program.cs
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/Program.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using Avalonia;
 using Microsoft.Extensions.Hosting;
 using ReactiveMarbles.Extensions.Hosting.Avalonia;
 
@@ -39,8 +38,6 @@ public static class Program
             .UseAvaloniaLifetime()
             .UseConsoleLifetime()
             .Build();
-
-        Console.WriteLine("Run!");
 
         host.Run();
 

--- a/src/examples/Extensions.Hosting.Maui.Example/Extensions.Hosting.Maui.Example.csproj
+++ b/src/examples/Extensions.Hosting.Maui.Example/Extensions.Hosting.Maui.Example.csproj
@@ -37,7 +37,7 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-    <NoWarn>NU1605;SA1633;SA1600;SA1601;SA1027;SA1137;SX1309;CA1805;CA1400;RCS1102;SA1400;SA1508;SA1512;SA1642;SX1101</NoWarn>
+    <NoWarn>$(NoWarn);NU1605;SA1633;SA1600;SA1601;SA1027;SA1137;SX1309;CA1805;CA1400;RCS1102;SA1400;SA1508;SA1512;SA1642;SX1101</NoWarn>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/examples/Extensions.Hosting.Maui.Example/Platforms/Windows/App.xaml.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/Platforms/Windows/App.xaml.cs
@@ -2,8 +2,6 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Microsoft.UI.Xaml;
-
 namespace Extensions.Hosting.Maui.Example.WinUI;
 
 /// <summary>Provides application-specific behavior to supplement the default Application class.</summary>

--- a/src/testconfig.json
+++ b/src/testconfig.json
@@ -12,11 +12,13 @@
                 "skipAutoProperties": true,
                 "modulePaths": {
                     "include": [
-                        "Extensions.Hosting\\..*"
+                        "^Extensions\\.Hosting\\..*$"
                     ],
                     "exclude": [
                         ".*Tests.*",
-                        ".*TestRunner.*"
+                        ".*TestRunner.*",
+                        "^Extensions\\.Hosting\\..*\\.Example$",
+                        "^Extensions\\.Logging\\..*"
                     ]
                 }
             }

--- a/src/tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\..\Extensions.Hosting.SingleInstance\Extensions.Hosting.SingleInstance.csproj" />
     <ProjectReference Include="..\..\Extensions.Hosting.MainUIThread\Extensions.Hosting.MainUIThread.csproj" />
     <ProjectReference Include="..\..\Extensions.Hosting.Plugins\Extensions.Hosting.Plugins.csproj" />
+    <ProjectReference Include="..\..\Extensions.Hosting.Plugins.Reactive\Extensions.Hosting.Plugins.Reactive.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/tests/Extensions.Hosting.Tests/HostBuilderApplicationExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/HostBuilderApplicationExtensionsTests.cs
@@ -43,6 +43,21 @@ public class HostBuilderApplicationExtensionsTests
         await Assert.That(result).IsEqualTo(hostBuilder);
     }
 
+    /// <summary>Verifies that ConfigureSingleInstance with mutexId stores the mutex identifier on IHostBuilder.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSingleInstance_WithMutexId_RegistersConfiguredMutexId()
+    {
+        var hostBuilder = Host.CreateDefaultBuilder();
+        var mutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+
+        _ = hostBuilder.ConfigureSingleInstance(mutexId);
+
+        using var host = hostBuilder.Build();
+        var mutexBuilder = host.Services.GetRequiredService<IMutexBuilder>();
+        await Assert.That(mutexBuilder.MutexId).IsEqualTo(mutexId);
+    }
+
     /// <summary>Verifies that ConfigureSingleInstance with IHostApplicationBuilder returns the same builder and registers the mutex builder.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -94,6 +109,21 @@ public class HostBuilderApplicationExtensionsTests
         });
         await Assert.That(result).IsNotNull();
         await Assert.That(result).IsEqualTo(hostBuilder);
+    }
+
+    /// <summary>Verifies that ConfigureSingleInstance accepts a null configure action for IHostBuilder.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSingleInstance_IHostBuilder_WithNullConfigureAction_RegistersMutexBuilder()
+    {
+        Action<IMutexBuilder>? configureAction = null;
+        var hostBuilder = Host.CreateDefaultBuilder();
+
+        _ = hostBuilder.ConfigureSingleInstance(configureAction!);
+
+        using var host = hostBuilder.Build();
+        var mutexBuilder = host.Services.GetService<IMutexBuilder>();
+        await Assert.That(mutexBuilder).IsNotNull();
     }
 
     /// <summary>Verifies that ConfigureSingleInstance configure action is invoked.</summary>

--- a/src/tests/Extensions.Hosting.Tests/Plugin.cs
+++ b/src/tests/Extensions.Hosting.Tests/Plugin.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using ReactivePlugin = ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.IPlugin;
+using StandardPlugin = ReactiveMarbles.Extensions.Hosting.Plugins.IPlugin;
+
+namespace Extensions.Hosting.Tests;
+
+/// <summary>Conventional plugin type used to cover naming-convention scanners.</summary>
+public sealed class Plugin : StandardPlugin, ReactivePlugin
+{
+    /// <inheritdoc />
+    public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
+    {
+    }
+}

--- a/src/tests/Extensions.Hosting.Tests/ReactiveAssemblyLoadingTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactiveAssemblyLoadingTests.cs
@@ -4,14 +4,14 @@
 
 using System.IO;
 using System.Reflection;
-using ReactiveMarbles.Extensions.Hosting.Plugins.Internals;
-using PluginAssemblyDependencyResolver = ReactiveMarbles.Extensions.Hosting.Plugins.Internals.AssemblyDependencyResolver;
-using PluginAssemblyLoadContext = ReactiveMarbles.Extensions.Hosting.Plugins.Internals.AssemblyLoadContext;
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.Internals;
+using ReactiveAssemblyDependencyResolver = ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.Internals.AssemblyDependencyResolver;
+using ReactiveAssemblyLoadContext = ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.Internals.AssemblyLoadContext;
 
 namespace Extensions.Hosting.Tests;
 
-/// <summary>Contains tests for plugin assembly loading helper types.</summary>
-public class AssemblyLoadingTests
+/// <summary>Contains tests for reactive shim plugin assembly loading helper types.</summary>
+public class ReactiveAssemblyLoadingTests
 {
     /// <summary>Verifies that the dependency resolver resolves existing managed assembly paths.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
@@ -25,7 +25,7 @@ public class AssemblyLoadingTests
             var dependencyPath = Path.Combine(tempDirectory, "Dependency.dll");
             await File.WriteAllTextAsync(pluginPath, string.Empty);
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
-            var resolver = new PluginAssemblyDependencyResolver(pluginPath);
+            var resolver = new ReactiveAssemblyDependencyResolver(pluginPath);
 
             var resolvedPath = resolver.ResolveAssemblyToPath(new AssemblyName("Dependency"));
 
@@ -47,7 +47,7 @@ public class AssemblyLoadingTests
         {
             var pluginPath = Path.Combine(tempDirectory, $"{nameof(Plugin)}.dll");
             await File.WriteAllTextAsync(pluginPath, string.Empty);
-            var resolver = new PluginAssemblyDependencyResolver(pluginPath);
+            var resolver = new ReactiveAssemblyDependencyResolver(pluginPath);
 
             var resolvedPath = resolver.ResolveAssemblyToPath(new AssemblyName("Missing.Dependency"));
 
@@ -64,7 +64,7 @@ public class AssemblyLoadingTests
     [Test]
     public async Task ResolveAssemblyToPath_WithNullAssemblyName_ThrowsArgumentNullException()
     {
-        var resolver = new PluginAssemblyDependencyResolver($"{nameof(Plugin)}.dll");
+        var resolver = new ReactiveAssemblyDependencyResolver($"{nameof(Plugin)}.dll");
         AssemblyName? assemblyName = null;
 
         var act = () => resolver.ResolveAssemblyToPath(assemblyName!);
@@ -84,7 +84,7 @@ public class AssemblyLoadingTests
             var dependencyPath = Path.Combine(tempDirectory, "native.dll");
             await File.WriteAllTextAsync(pluginPath, string.Empty);
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
-            var resolver = new PluginAssemblyDependencyResolver(pluginPath);
+            var resolver = new ReactiveAssemblyDependencyResolver(pluginPath);
 
             var resolvedPath = resolver.ResolveUnmanagedDllToPath("native");
 
@@ -108,7 +108,7 @@ public class AssemblyLoadingTests
             var dependencyPath = Path.Combine(tempDirectory, "native.custom");
             await File.WriteAllTextAsync(pluginPath, string.Empty);
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
-            var resolver = new PluginAssemblyDependencyResolver(pluginPath);
+            var resolver = new ReactiveAssemblyDependencyResolver(pluginPath);
 
             var resolvedPath = resolver.ResolveUnmanagedDllToPath("native.custom");
 
@@ -125,7 +125,7 @@ public class AssemblyLoadingTests
     [Test]
     public async Task ResolveUnmanagedDllToPath_WithEmptyName_ThrowsArgumentException()
     {
-        var resolver = new PluginAssemblyDependencyResolver($"{nameof(Plugin)}.dll");
+        var resolver = new ReactiveAssemblyDependencyResolver($"{nameof(Plugin)}.dll");
 
         var act = () => resolver.ResolveUnmanagedDllToPath(string.Empty);
 
@@ -137,10 +137,10 @@ public class AssemblyLoadingTests
     [Test]
     public async Task AssemblyLoadContext_Default_ExposesNameAndAssemblies()
     {
-        var context = PluginAssemblyLoadContext.Default;
+        var context = ReactiveAssemblyLoadContext.Default;
 
         await Assert.That(context.Name).IsEqualTo("default");
-        await Assert.That(PluginAssemblyLoadContext.Assemblies.Any()).IsTrue();
+        await Assert.That(ReactiveAssemblyLoadContext.Assemblies.Any()).IsTrue();
     }
 
     /// <summary>Verifies that loading from a null assembly name throws.</summary>
@@ -148,7 +148,7 @@ public class AssemblyLoadingTests
     [Test]
     public async Task LoadFromAssemblyName_WithNullAssemblyName_ThrowsArgumentNullException()
     {
-        var context = new PluginAssemblyLoadContext("test");
+        var context = new ReactiveAssemblyLoadContext("test");
         AssemblyName? assemblyName = null;
 
         var act = () => context.LoadFromAssemblyName(assemblyName!);
@@ -161,7 +161,7 @@ public class AssemblyLoadingTests
     [Test]
     public async Task LoadFromAssemblyName_WithUnresolvedAssemblyName_ReturnsNull()
     {
-        var context = new PluginAssemblyLoadContext("test");
+        var context = new ReactiveAssemblyLoadContext("test");
 
         Assembly? assembly = context.LoadFromAssemblyName(new AssemblyName("Missing.Assembly"));
 
@@ -173,7 +173,7 @@ public class AssemblyLoadingTests
     [Test]
     public async Task LoadFromAssemblyName_WithDerivedLoad_ReturnsAssembly()
     {
-        var expectedAssembly = typeof(AssemblyLoadingTests).Assembly;
+        var expectedAssembly = typeof(ReactiveAssemblyLoadingTests).Assembly;
         var context = new TestAssemblyLoadContext("test", expectedAssembly);
 
         var assembly = context.LoadFromAssemblyName(expectedAssembly.GetName());
@@ -186,9 +186,9 @@ public class AssemblyLoadingTests
     [Test]
     public async Task LoadFromAssemblyPath_WithExistingAssemblyPath_ReturnsAssembly()
     {
-        var expectedAssembly = typeof(AssemblyLoadingTests).Assembly;
+        var expectedAssembly = typeof(ReactiveAssemblyLoadingTests).Assembly;
 
-        var assembly = PluginAssemblyLoadContext.LoadFromAssemblyPath(expectedAssembly.Location);
+        var assembly = ReactiveAssemblyLoadContext.LoadFromAssemblyPath(expectedAssembly.Location);
 
         await Assert.That(assembly.GetName().Name).IsEqualTo(expectedAssembly.GetName().Name);
     }
@@ -198,7 +198,7 @@ public class AssemblyLoadingTests
     [Test]
     public async Task LoadUnmanagedDllHelpers_ByDefault_ReturnZero()
     {
-        var context = new TestAssemblyLoadContext("test", typeof(AssemblyLoadingTests).Assembly);
+        var context = new TestAssemblyLoadContext("test", typeof(ReactiveAssemblyLoadingTests).Assembly);
 
         await Assert.That(TestAssemblyLoadContext.LoadNativeFromPath("native.dll")).IsEqualTo(IntPtr.Zero);
         await Assert.That(context.LoadNativeByName("native")).IsEqualTo(IntPtr.Zero);
@@ -209,12 +209,25 @@ public class AssemblyLoadingTests
     [Test]
     public async Task TryGetAssembly_WithNullContext_ReturnsFalse()
     {
-        PluginAssemblyLoadContext? context = null;
+        ReactiveAssemblyLoadContext? context = null;
 
-        var result = context!.TryGetAssembly(typeof(AssemblyLoadingTests).Assembly.GetName(), out var assembly);
+        var result = context!.TryGetAssembly(typeof(ReactiveAssemblyLoadingTests).Assembly.GetName(), out var assembly);
 
         await Assert.That(result).IsFalse();
         await Assert.That(assembly).IsNull();
+    }
+
+    /// <summary>Verifies that TryGetAssembly returns true when an assembly is loaded.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task TryGetAssembly_WithLoadedAssembly_ReturnsTrue()
+    {
+        var context = ReactiveAssemblyLoadContext.Default;
+
+        var result = context.TryGetAssembly(typeof(ReactiveAssemblyLoadingTests).Assembly.GetName(), out var assembly);
+
+        await Assert.That(result).IsTrue();
+        await Assert.That(assembly).IsEqualTo(typeof(ReactiveAssemblyLoadingTests).Assembly);
     }
 
     /// <summary>Verifies that TryGetAssembly returns false when an assembly is not loaded.</summary>
@@ -222,7 +235,7 @@ public class AssemblyLoadingTests
     [Test]
     public async Task TryGetAssembly_WithMissingAssembly_ReturnsFalse()
     {
-        var context = PluginAssemblyLoadContext.Default;
+        var context = ReactiveAssemblyLoadContext.Default;
 
         var result = context.TryGetAssembly(new AssemblyName("Missing.Plugin.Assembly"), out var assembly);
 
@@ -259,7 +272,7 @@ public class AssemblyLoadingTests
     [Test]
     public async Task PluginLoadContext_LoadFromAssemblyName_WithAlreadyLoadedAssembly_ReturnsAssembly()
     {
-        var expectedAssembly = typeof(AssemblyLoadingTests).Assembly;
+        var expectedAssembly = typeof(ReactiveAssemblyLoadingTests).Assembly;
         var context = new PluginLoadContext(expectedAssembly.Location, nameof(Plugin));
 
         var assembly = context.LoadFromAssemblyName(expectedAssembly.GetName());
@@ -286,7 +299,7 @@ public class AssemblyLoadingTests
     [Test]
     public async Task PluginLoadContext_LoadFromAssemblyName_WithMissingAssembly_ReturnsNull()
     {
-        var context = new PluginLoadContext(typeof(AssemblyLoadingTests).Assembly.Location, nameof(Plugin));
+        var context = new PluginLoadContext(typeof(ReactiveAssemblyLoadingTests).Assembly.Location, nameof(Plugin));
 
         Assembly? assembly = context.LoadFromAssemblyName(new AssemblyName("Missing.Plugin.Assembly"));
 
@@ -298,12 +311,37 @@ public class AssemblyLoadingTests
     [Test]
     public async Task PluginLoadContext_LoadUnmanagedDll_WithMissingLibrary_ReturnsZero()
     {
-        var context = new PluginLoadContext(typeof(AssemblyLoadingTests).Assembly.Location, nameof(Plugin));
+        var context = new PluginLoadContext(typeof(ReactiveAssemblyLoadingTests).Assembly.Location, nameof(Plugin));
         var method = typeof(PluginLoadContext).GetMethod("LoadUnmanagedDll", BindingFlags.Instance | BindingFlags.NonPublic);
 
         var result = (IntPtr)method!.Invoke(context, ["missing"])!;
 
         await Assert.That(result).IsEqualTo(IntPtr.Zero);
+    }
+
+    /// <summary>Verifies that PluginLoadContext resolves unmanaged dependency paths before loading.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task PluginLoadContext_LoadUnmanagedDll_WithExistingLibrary_ReturnsZeroFromShimLoader()
+    {
+        var tempDirectory = CreateTemporaryDirectory();
+        try
+        {
+            var pluginPath = Path.Combine(tempDirectory, $"{nameof(Plugin)}.dll");
+            var dependencyPath = Path.Combine(tempDirectory, "native.dll");
+            await File.WriteAllTextAsync(pluginPath, string.Empty);
+            await File.WriteAllTextAsync(dependencyPath, string.Empty);
+            var context = new PluginLoadContext(pluginPath, nameof(Plugin));
+            var method = typeof(PluginLoadContext).GetMethod("LoadUnmanagedDll", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            var result = (IntPtr)method!.Invoke(context, ["native"])!;
+
+            await Assert.That(result).IsEqualTo(IntPtr.Zero);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
     }
 
     /// <summary>Creates a temporary directory for assembly resolver tests.</summary>
@@ -319,17 +357,18 @@ public class AssemblyLoadingTests
     /// <returns>The path to an unloaded managed assembly.</returns>
     private static string GetUnloadedAssemblyPath()
     {
-        var assemblyDirectory = Path.GetDirectoryName(typeof(AssemblyLoadingTests).Assembly.Location)!;
+        var assemblyDirectory = Path.GetDirectoryName(typeof(ReactiveAssemblyLoadingTests).Assembly.Location)!;
         var loadedAssemblyNames = AppDomain.CurrentDomain.GetAssemblies()
             .Select(assembly => assembly.GetName().Name)
             .Where(name => name is not null)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var assemblyPath in Directory.EnumerateFiles(assemblyDirectory, "*.dll"))
+        foreach (var assemblyPath in Directory.EnumerateFiles(assemblyDirectory, "*.dll").OrderBy(Path.GetFileName))
         {
             var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
             if (!loadedAssemblyNames.Contains(assemblyName) &&
-                !assemblyName.StartsWith("Extensions.Hosting", StringComparison.OrdinalIgnoreCase))
+                !assemblyName.StartsWith("Extensions.Hosting", StringComparison.OrdinalIgnoreCase) &&
+                IsManagedAssembly(assemblyPath))
             {
                 return assemblyPath;
             }
@@ -338,10 +377,26 @@ public class AssemblyLoadingTests
         throw new InvalidOperationException("No unloaded assembly was available in the test output directory.");
     }
 
+    /// <summary>Returns a value indicating whether the file is a managed assembly.</summary>
+    /// <param name="assemblyPath">The assembly path to inspect.</param>
+    /// <returns>True when the file is a managed assembly.</returns>
+    private static bool IsManagedAssembly(string assemblyPath)
+    {
+        try
+        {
+            _ = AssemblyName.GetAssemblyName(assemblyPath);
+            return true;
+        }
+        catch (BadImageFormatException)
+        {
+            return false;
+        }
+    }
+
     /// <summary>Test assembly load context that delegates managed loads to a supplied assembly.</summary>
     /// <param name="name">The load context name.</param>
     /// <param name="assembly">The assembly returned from managed load requests.</param>
-    private sealed class TestAssemblyLoadContext(string name, Assembly assembly) : PluginAssemblyLoadContext(name)
+    private sealed class TestAssemblyLoadContext(string name, Assembly assembly) : ReactiveAssemblyLoadContext(name)
     {
         /// <summary>Calls the protected native load-from-path helper.</summary>
         /// <param name="path">The native library path.</param>

--- a/src/tests/Extensions.Hosting.Tests/ReactiveHostedServiceBaseTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactiveHostedServiceBaseTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+
+namespace Extensions.Hosting.Tests;
+
+/// <summary>Contains unit tests for the reactive shim hosted service base lifecycle implementation.</summary>
+public class ReactiveHostedServiceBaseTests
+{
+    /// <summary>Verifies that lifetime callbacks invoke the overridable lifecycle methods.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task LifetimeCallbacks_InvokeLifecycleMethods()
+    {
+        using var lifetime = new TestHostApplicationLifetime();
+        var service = new TestHostedService(lifetime);
+
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        lifetime.TriggerStarted();
+        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        await Assert.That(service.StartedCount).IsEqualTo(1);
+        await Assert.That(service.CleanupDisposable).IsNotNull();
+        await Assert.That(service.CleanupDisposable!.IsDisposed).IsFalse();
+
+        lifetime.TriggerStopping();
+        await Assert.That(service.StoppingCount).IsEqualTo(1);
+        await Assert.That(service.CleanupDisposable.IsDisposed).IsTrue();
+        await Assert.That(service.IsDisposed).IsTrue();
+
+        lifetime.TriggerStopped();
+        await Assert.That(service.StoppedCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that disposing the service is idempotent and disposes cleanup resources.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_IsIdempotentAndDisposesCleanup()
+    {
+        using var lifetime = new TestHostApplicationLifetime();
+        var service = new TestHostedService(lifetime);
+
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        lifetime.TriggerStarted();
+        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        service.Dispose();
+        service.Dispose();
+
+        await Assert.That(service.CleanupDisposable).IsNotNull();
+        await Assert.That(service.CleanupDisposable!.IsDisposed).IsTrue();
+        await Assert.That(service.IsDisposed).IsTrue();
+    }
+
+    /// <summary>Verifies that StopAsync returns a completed task.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_ReturnsCompletedTask()
+    {
+        using var lifetime = new TestHostApplicationLifetime();
+        var service = new DefaultHostedService(lifetime);
+
+        var stopTask = service.StopAsync(CancellationToken.None);
+
+        await Assert.That(stopTask.IsCompletedSuccessfully).IsTrue();
+    }
+
+    /// <summary>Verifies that the default OnStarted implementation completes successfully.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task OnStarted_DefaultImplementation_CompletesSuccessfully()
+    {
+        using var lifetime = new TestHostApplicationLifetime();
+        var service = new DefaultHostedService(lifetime);
+
+        await service.OnStarted().ConfigureAwait(false);
+
+        await Assert.That(service).IsNotNull();
+    }
+
+    /// <summary>Verifies that an OnStarted exception is observed and contained by the lifetime callback.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task LifetimeStarted_WhenOnStartedThrows_DoesNotThrowFromCallback()
+    {
+        using var lifetime = new TestHostApplicationLifetime();
+        var service = new ThrowingStartedHostedService(lifetime);
+
+        await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        lifetime.TriggerStarted();
+        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
+
+        await Assert.That(service.StartedCount).IsEqualTo(1);
+    }
+
+    /// <summary>Test hosted service used to observe lifecycle callback execution.</summary>
+    /// <param name="lifetime">The test lifetime source.</param>
+    private sealed class TestHostedService(IHostApplicationLifetime lifetime)
+        : HostedServiceBase<TestHostedService>(NullLogger<TestHostedService>.Instance, lifetime)
+    {
+        /// <summary>Gets the started signal.</summary>
+        public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the cleanup disposable.</summary>
+        public TrackingDisposable? CleanupDisposable { get; private set; }
+
+        /// <summary>Gets the number of started callbacks.</summary>
+        public int StartedCount { get; private set; }
+
+        /// <summary>Gets the number of stopping callbacks.</summary>
+        public int StoppingCount { get; private set; }
+
+        /// <summary>Gets the number of stopped callbacks.</summary>
+        public int StoppedCount { get; private set; }
+
+        /// <inheritdoc />
+        public override Task OnStarted()
+        {
+            StartedCount++;
+            CleanupDisposable = new();
+            CleanUp.Add(CleanupDisposable);
+            _ = Started.TrySetResult(true);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public override void OnStopping()
+        {
+            StoppingCount++;
+            base.OnStopping();
+        }
+
+        /// <inheritdoc />
+        public override void OnStopped()
+        {
+            StoppedCount++;
+            base.OnStopped();
+        }
+    }
+
+    /// <summary>Hosted service that uses the base lifecycle implementations.</summary>
+    /// <param name="lifetime">The test lifetime source.</param>
+    private sealed class DefaultHostedService(IHostApplicationLifetime lifetime)
+        : HostedServiceBase<DefaultHostedService>(NullLogger<DefaultHostedService>.Instance, lifetime);
+
+    /// <summary>Hosted service that throws from OnStarted.</summary>
+    /// <param name="lifetime">The test lifetime source.</param>
+    private sealed class ThrowingStartedHostedService(IHostApplicationLifetime lifetime)
+        : HostedServiceBase<ThrowingStartedHostedService>(NullLogger<ThrowingStartedHostedService>.Instance, lifetime)
+    {
+        /// <summary>Gets the started signal.</summary>
+        public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the number of started callbacks.</summary>
+        public int StartedCount { get; private set; }
+
+        /// <inheritdoc />
+        public override Task OnStarted()
+        {
+            StartedCount++;
+            _ = Started.TrySetResult(true);
+            throw new InvalidOperationException("Start failure for test coverage.");
+        }
+    }
+
+    /// <summary>Disposable used to verify cleanup disposal.</summary>
+    private sealed class TrackingDisposable : IDisposable
+    {
+        /// <summary>Gets a value indicating whether this instance was disposed.</summary>
+        public bool IsDisposed { get; private set; }
+
+        /// <inheritdoc />
+        public void Dispose() => IsDisposed = true;
+    }
+
+    /// <summary>Test application lifetime that exposes manual trigger methods.</summary>
+    private sealed class TestHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+    {
+        /// <summary>Stores the started token source.</summary>
+        private readonly CancellationTokenSource _started = new();
+
+        /// <summary>Stores the stopping token source.</summary>
+        private readonly CancellationTokenSource _stopping = new();
+
+        /// <summary>Stores the stopped token source.</summary>
+        private readonly CancellationTokenSource _stopped = new();
+
+        /// <inheritdoc />
+        public CancellationToken ApplicationStarted => _started.Token;
+
+        /// <inheritdoc />
+        public CancellationToken ApplicationStopping => _stopping.Token;
+
+        /// <inheritdoc />
+        public CancellationToken ApplicationStopped => _stopped.Token;
+
+        /// <summary>Triggers the started token.</summary>
+        public void TriggerStarted() => _started.Cancel();
+
+        /// <summary>Triggers the stopping token.</summary>
+        public void TriggerStopping() => _stopping.Cancel();
+
+        /// <summary>Triggers the stopped token.</summary>
+        public void TriggerStopped() => _stopped.Cancel();
+
+        /// <inheritdoc />
+        public void StopApplication() => TriggerStopping();
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _started.Dispose();
+            _stopping.Dispose();
+            _stopped.Dispose();
+        }
+    }
+}

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginBaseTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginBaseTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+
+namespace Extensions.Hosting.Tests;
+
+/// <summary>Contains tests for reactive shim plugin base hosted-service registration helpers.</summary>
+public class ReactivePluginBaseTests
+{
+    /// <summary>Verifies that PluginBase with one hosted service registers that service.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureHost_WithOneHostedService_RegistersService()
+    {
+        var services = new ServiceCollection();
+        var plugin = new PluginBase<FirstReactiveHostedService>();
+
+        plugin.ConfigureHost(new object(), services);
+
+        await Assert.That(services.Any(IsFirstHostedServiceRegistration)).IsTrue();
+    }
+
+    /// <summary>Verifies that PluginBase with two hosted services registers both services.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureHost_WithTwoHostedServices_RegistersServices()
+    {
+        var services = new ServiceCollection();
+        var plugin = new PluginBase<FirstReactiveHostedService, SecondReactiveHostedService>();
+
+        plugin.ConfigureHost(new object(), services);
+
+        await Assert.That(services.Any(IsFirstHostedServiceRegistration)).IsTrue();
+        await Assert.That(services.Any(IsSecondHostedServiceRegistration)).IsTrue();
+    }
+
+    /// <summary>Verifies that PluginBase with three hosted services registers all services.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureHost_WithThreeHostedServices_RegistersServices()
+    {
+        var services = new ServiceCollection();
+        var plugin = new PluginBase<FirstReactiveHostedService, SecondReactiveHostedService, ThirdReactiveHostedService>();
+
+        plugin.ConfigureHost(new object(), services);
+
+        await Assert.That(services.Any(IsFirstHostedServiceRegistration)).IsTrue();
+        await Assert.That(services.Any(IsSecondHostedServiceRegistration)).IsTrue();
+        await Assert.That(services.Any(IsThirdHostedServiceRegistration)).IsTrue();
+    }
+
+    /// <summary>Returns a value indicating whether the descriptor registers the first hosted service.</summary>
+    /// <param name="serviceDescriptor">The service descriptor to inspect.</param>
+    /// <returns>True when the descriptor registers the first hosted service.</returns>
+    private static bool IsFirstHostedServiceRegistration(ServiceDescriptor serviceDescriptor) =>
+        IsHostedServiceRegistration<FirstReactiveHostedService>(serviceDescriptor);
+
+    /// <summary>Returns a value indicating whether the descriptor registers the second hosted service.</summary>
+    /// <param name="serviceDescriptor">The service descriptor to inspect.</param>
+    /// <returns>True when the descriptor registers the second hosted service.</returns>
+    private static bool IsSecondHostedServiceRegistration(ServiceDescriptor serviceDescriptor) =>
+        IsHostedServiceRegistration<SecondReactiveHostedService>(serviceDescriptor);
+
+    /// <summary>Returns a value indicating whether the descriptor registers the third hosted service.</summary>
+    /// <param name="serviceDescriptor">The service descriptor to inspect.</param>
+    /// <returns>True when the descriptor registers the third hosted service.</returns>
+    private static bool IsThirdHostedServiceRegistration(ServiceDescriptor serviceDescriptor) =>
+        IsHostedServiceRegistration<ThirdReactiveHostedService>(serviceDescriptor);
+
+    /// <summary>Returns a value indicating whether the descriptor registers the requested hosted service type.</summary>
+    /// <typeparam name="T">The hosted service implementation type.</typeparam>
+    /// <param name="serviceDescriptor">The service descriptor to inspect.</param>
+    /// <returns>True when the descriptor registers the requested hosted service type.</returns>
+    private static bool IsHostedServiceRegistration<T>(ServiceDescriptor serviceDescriptor)
+        where T : class, IHostedService =>
+        serviceDescriptor.ServiceType == typeof(IHostedService) &&
+        serviceDescriptor.ImplementationType == typeof(T);
+
+    /// <summary>First hosted service used for reactive registration tests.</summary>
+    public sealed class FirstReactiveHostedService : ReactiveHostedService;
+
+    /// <summary>Second hosted service used for reactive registration tests.</summary>
+    public sealed class SecondReactiveHostedService : ReactiveHostedService;
+
+    /// <summary>Third hosted service used for reactive registration tests.</summary>
+    public sealed class ThirdReactiveHostedService : ReactiveHostedService;
+
+    /// <summary>Base hosted service used for reactive registration tests.</summary>
+    public abstract class ReactiveHostedService : IHostedService
+    {
+        /// <inheritdoc />
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        /// <inheritdoc />
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginBuilderExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginBuilderExtensionsTests.cs
@@ -1,0 +1,204 @@
+// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+
+namespace Extensions.Hosting.Tests;
+
+/// <summary>Contains unit tests for the reactive shim PluginBuilderExtensions class.</summary>
+public class ReactivePluginBuilderExtensionsTests
+{
+    /// <summary>Verifies that AddScanDirectories throws when directories is null.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task AddScanDirectories_WithNullDirectories_ThrowsArgumentNullException()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        void Act() => PluginBuilderExtensions.AddScanDirectories(builder, null!);
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that AddScanDirectories adds directories to both collections.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task AddScanDirectories_WithValidDirectories_AddsToBothCollections()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        var testDir = Path.GetTempPath();
+
+        builder.AddScanDirectories(testDir);
+
+        await Assert.That(builder.PluginDirectories.Count).IsEqualTo(1);
+        await Assert.That(builder.FrameworkDirectories.Count).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that multiple directories can be added.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task AddScanDirectories_MultipleDirectories_AddsAll()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        var dir1 = Path.GetTempPath();
+        var dir2 = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        builder.AddScanDirectories(dir1, dir2);
+
+        await Assert.That(builder.PluginDirectories.Count).IsEqualTo(2);
+        await Assert.That(builder.FrameworkDirectories.Count).IsEqualTo(2);
+    }
+
+    /// <summary>Verifies that ExcludeFrameworks throws when frameworkGlobs is null.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ExcludeFrameworks_WithNullGlobs_ThrowsArgumentNullException()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        void Act() => PluginBuilderExtensions.ExcludeFrameworks(builder, null!);
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that ExcludeFrameworks does not throw with valid input.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ExcludeFrameworks_WithValidGlobs_DoesNotThrow()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        Exception? exception = null;
+
+        try
+        {
+            builder.ExcludeFrameworks("**/bin/**");
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        await Assert.That(exception).IsNull();
+    }
+
+    /// <summary>Verifies that ExcludePlugins throws when pluginGlobs is null.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ExcludePlugins_WithNullGlobs_ThrowsArgumentNullException()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        void Act() => PluginBuilderExtensions.ExcludePlugins(builder, null!);
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that ExcludePlugins does not throw with valid input.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ExcludePlugins_WithValidGlobs_DoesNotThrow()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        Exception? exception = null;
+
+        try
+        {
+            builder.ExcludePlugins("**/test/**");
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        await Assert.That(exception).IsNull();
+    }
+
+    /// <summary>Verifies that IncludeFrameworks throws when frameworkGlobs is null.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task IncludeFrameworks_WithNullGlobs_ThrowsArgumentNullException()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        void Act() => PluginBuilderExtensions.IncludeFrameworks(builder, null!);
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that IncludeFrameworks does not throw with valid input.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task IncludeFrameworks_WithValidGlobs_DoesNotThrow()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        Exception? exception = null;
+
+        try
+        {
+            builder.IncludeFrameworks("**/*.dll");
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        await Assert.That(exception).IsNull();
+    }
+
+    /// <summary>Verifies that IncludePlugins throws when pluginGlobs is null.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task IncludePlugins_WithNullGlobs_ThrowsArgumentNullException()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        void Act() => PluginBuilderExtensions.IncludePlugins(builder, null!);
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that IncludePlugins does not throw with valid input.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task IncludePlugins_WithValidGlobs_DoesNotThrow()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        Exception? exception = null;
+
+        try
+        {
+            builder.IncludePlugins("**/*Plugin.dll");
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        await Assert.That(exception).IsNull();
+    }
+
+    /// <summary>Verifies that RequirePlugins throws when pluginBuilder is null.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task RequirePlugins_WithNullBuilder_ThrowsArgumentNullException()
+    {
+        static void Act() => PluginBuilderExtensions.RequirePlugins(null!);
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that RequirePlugins sets FailIfNoPlugins to true by default.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task RequirePlugins_Default_SetsFailIfNoPluginsTrue()
+    {
+        var builder = new ReactiveTestPluginBuilder();
+        builder.RequirePlugins();
+        await Assert.That(builder.FailIfNoPlugins).IsTrue();
+    }
+
+    /// <summary>Verifies that RequirePlugins sets FailIfNoPlugins to false when specified.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task RequirePlugins_WithFalse_SetsFailIfNoPluginsFalse()
+    {
+        var builder = new ReactiveTestPluginBuilder
+        {
+            FailIfNoPlugins = true
+        };
+
+        builder.RequirePlugins(false);
+        await Assert.That(builder.FailIfNoPlugins).IsFalse();
+    }
+}

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginOrderAttributeTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginOrderAttributeTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+
+namespace Extensions.Hosting.Tests;
+
+/// <summary>Contains unit tests for the reactive shim PluginOrderAttribute class.</summary>
+public class ReactivePluginOrderAttributeTests
+{
+    /// <summary>Verifies that the default constructor sets Order to 0.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task DefaultConstructor_SetsOrderToZero()
+    {
+        var attribute = new PluginOrderAttribute();
+        await Assert.That(attribute.Order).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that the int constructor sets the Order property correctly.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task IntConstructor_SetsOrderCorrectly()
+    {
+        var attribute = new PluginOrderAttribute(42);
+        await Assert.That(attribute.Order).IsEqualTo(42);
+    }
+
+    /// <summary>Verifies that the int constructor handles negative values.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task IntConstructor_WithNegativeValue_SetsOrderCorrectly()
+    {
+        var attribute = new PluginOrderAttribute(-10);
+        await Assert.That(attribute.Order).IsEqualTo(-10);
+    }
+
+    /// <summary>Verifies that the enum constructor converts the enum to its int value.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task EnumConstructor_ConvertsToIntValue()
+    {
+        var attribute = new PluginOrderAttribute(TestOrder.High);
+        await Assert.That(attribute.Order).IsEqualTo((int)TestOrder.High);
+    }
+
+    /// <summary>Verifies that the attribute can be retrieved from a decorated class.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Attribute_CanBeRetrievedFromClass()
+    {
+        var type = typeof(ReactiveOrderedTestPlugin);
+        var attribute = (PluginOrderAttribute?)Attribute.GetCustomAttribute(type, typeof(PluginOrderAttribute));
+
+        await Assert.That(attribute).IsNotNull();
+        await Assert.That(attribute!.Order).IsEqualTo(100);
+    }
+
+    /// <summary>A reactive shim plugin with a custom order attribute for testing plugin ordering.</summary>
+    [PluginOrder(100)]
+    public class ReactiveOrderedTestPlugin : ReactivePluginScannerTests.ReactiveScannerTestPlugin;
+}

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginScannerTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginScannerTests.cs
@@ -3,14 +3,12 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
-using ReactiveMarbles.Extensions.Hosting.Plugins;
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
 
 namespace Extensions.Hosting.Tests;
 
-/// <summary>Contains unit tests for the PluginScanner class, verifying its behavior when scanning for plugin instances and handling invalid input.</summary>
-/// <remarks>These tests ensure that PluginScanner methods correctly handle null arguments and return expected
-/// results when no plugins are found. The class uses the TUnit testing framework.</remarks>
-public class PluginScannerTests
+/// <summary>Contains unit tests for the reactive shim PluginScanner class.</summary>
+public class ReactivePluginScannerTests
 {
     /// <summary>Verifies that ScanForPluginInstances throws an ArgumentNullException when passed a null argument.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
@@ -30,18 +28,18 @@ public class PluginScannerTests
         await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
-    /// <summary>Verifies that the plugin scanner returns an empty collection when no plugins are found by naming convention in the current assembly.</summary>
+    /// <summary>Verifies that naming convention scanning returns empty when no conventional plugin exists.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
     public async Task ByNamingConvention_FindsNoPlugin_ReturnsEmpty()
     {
-        var assembly = typeof(string).Assembly;
-        var plugins = PluginScanner.ByNamingConvention(assembly);
+        var plugins = PluginScanner.ByNamingConvention(typeof(string).Assembly);
+
         await Assert.That(plugins).IsNotNull();
         await Assert.That(plugins.Any()).IsFalse();
     }
 
-    /// <summary>Verifies that the plugin scanner discovers a plugin by naming convention.</summary>
+    /// <summary>Verifies that the reactive shim plugin scanner discovers a plugin by naming convention.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
     public async Task ByNamingConvention_FindsConventionalPlugin()
@@ -56,50 +54,59 @@ public class PluginScannerTests
     [Test]
     public async Task ScanForPluginInstances_WithValidAssembly_ReturnsNonNullCollection()
     {
-        var assembly = typeof(PluginScannerTests).Assembly;
-        var plugins = PluginScanner.ScanForPluginInstances(assembly);
+        var plugins = PluginScanner.ScanForPluginInstances(typeof(ReactivePluginScannerTests).Assembly);
+
         await Assert.That(plugins).IsNotNull();
     }
 
-    /// <summary>Verifies that ScanForPluginInstances discovers the TestPlugin class.</summary>
+    /// <summary>Verifies that ScanForPluginInstances discovers the reactive test plugin.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
-    public async Task ScanForPluginInstances_FindsTestPlugin()
+    public async Task ScanForPluginInstances_FindsReactiveTestPlugin()
     {
-        var assembly = typeof(TestPlugin).Assembly;
-        var plugins = PluginScanner.ScanForPluginInstances(assembly).ToList();
+        var plugins = PluginScanner.ScanForPluginInstances(typeof(ReactiveScannerTestPlugin).Assembly).ToList();
+
         await Assert.That(plugins.Count).IsGreaterThanOrEqualTo(1);
-        await Assert.That(plugins.Any(p => p is TestPlugin)).IsTrue();
+        await Assert.That(plugins.Any(plugin => plugin is ReactiveScannerTestPlugin)).IsTrue();
     }
 
-    /// <summary>Verifies that ScanForPluginInstances does not include abstract plugin classes.</summary>
+    /// <summary>Verifies that ScanForPluginInstances does not include abstract reactive plugin classes.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
     public async Task ScanForPluginInstances_DoesNotIncludeAbstractPlugins()
     {
-        var assembly = typeof(AbstractTestPlugin).Assembly;
-        var plugins = PluginScanner.ScanForPluginInstances(assembly).ToList();
-        await Assert.That(plugins.Any(p => p.GetType() == typeof(AbstractTestPlugin))).IsFalse();
+        var plugins = PluginScanner.ScanForPluginInstances(typeof(ReactiveAbstractTestPlugin).Assembly).ToList();
+
+        await Assert.That(plugins.Any(plugin => plugin.GetType() == typeof(ReactiveAbstractTestPlugin))).IsFalse();
     }
 
-    /// <summary>Verifies that the test plugin can be configured via ConfigureHost.</summary>
+    /// <summary>Verifies that the reactive test plugin can be configured via ConfigureHost.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
-    public async Task TestPlugin_ConfigureHost_DoesNotThrow()
+    public async Task ReactiveTestPlugin_ConfigureHost_SetsConfiguredFlag()
     {
-        var plugin = new TestPlugin();
-        var serviceCollection = new ServiceCollection();
+        var plugin = new ReactiveScannerTestPlugin();
+        var services = new ServiceCollection();
 
-        Exception? exception = null;
-        try
-        {
-            plugin.ConfigureHost(new object(), serviceCollection);
-        }
-        catch (Exception ex)
-        {
-            exception = ex;
-        }
+        plugin.ConfigureHost(new object(), services);
 
-        await Assert.That(exception).IsNull();
+        await Assert.That(plugin.WasConfigured).IsTrue();
+    }
+
+    /// <summary>A reactive shim test plugin implementation for unit testing purposes.</summary>
+    public class ReactiveScannerTestPlugin : IPlugin
+    {
+        /// <summary>Gets a value indicating whether ConfigureHost was called.</summary>
+        public bool WasConfigured { get; private set; }
+
+        /// <inheritdoc />
+        public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection) => WasConfigured = true;
+    }
+
+    /// <summary>An abstract reactive shim plugin used to test that abstract classes are not discovered.</summary>
+    public abstract class ReactiveAbstractTestPlugin : IPlugin
+    {
+        /// <inheritdoc />
+        public abstract void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection);
     }
 }

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginShimTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginShimTests.cs
@@ -5,13 +5,63 @@
 using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using ReactiveMarbles.Extensions.Hosting.Plugins;
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
 
 namespace Extensions.Hosting.Tests;
 
-/// <summary>Contains tests for host builder plugin configuration extensions.</summary>
-public class HostBuilderPluginExtensionsTests
+/// <summary>Contains tests for the reactive plugin shim surface.</summary>
+public class ReactivePluginShimTests
 {
+    /// <summary>Verifies that the reactive shim PluginBase registers hosted services.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task PluginBase_WithReactiveNamespace_RegistersHostedService()
+    {
+        var services = new ServiceCollection();
+        var plugin = new PluginBase<ReactiveHostedService>();
+
+        plugin.ConfigureHost(new object(), services);
+
+        await Assert.That(services.Any(IsReactiveHostedServiceRegistration)).IsTrue();
+    }
+
+    /// <summary>Verifies that the reactive shim plugin scanner discovers reactive plugin implementations.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task PluginScanner_WithReactiveNamespace_FindsReactivePlugin()
+    {
+        var plugins = PluginScanner.ScanForPluginInstances(typeof(ReactiveDiscoveredPlugin).Assembly).ToList();
+
+        await Assert.That(plugins.Any(plugin => plugin is ReactiveDiscoveredPlugin)).IsTrue();
+    }
+
+    /// <summary>Verifies that the reactive shim host builder extension configures discovered plugins in order.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigurePlugins_WithReactiveNamespace_LoadsConfiguredPluginsInOrder()
+    {
+        var configuredPlugins = new List<string>();
+        var hostBuilder = Host.CreateDefaultBuilder();
+
+        _ = hostBuilder.ConfigurePlugins(builder =>
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            AddCurrentAssemblyAsFramework(builder);
+            builder.AssemblyScanFunc = _ =>
+            [
+                new LaterReactiveRecordingPlugin(configuredPlugins),
+                null,
+                new EarlierReactiveRecordingPlugin(configuredPlugins),
+            ];
+        });
+
+        using var host = hostBuilder.Build();
+
+        await Assert.That(configuredPlugins.Count).IsEqualTo(2);
+        await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierReactiveRecordingPlugin.Name);
+        await Assert.That(configuredPlugins[1]).IsEqualTo(LaterReactiveRecordingPlugin.Name);
+    }
+
     /// <summary>Verifies that ConfigurePlugins with a null IHostBuilder throws.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -32,33 +82,6 @@ public class HostBuilderPluginExtensionsTests
         await Assert.That(act).Throws<ArgumentNullException>();
     }
 
-    /// <summary>Verifies that IHostBuilder plugin configuration scans and configures ordered plugins.</summary>
-    /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Test]
-    public async Task ConfigurePlugins_IHostBuilder_LoadsConfiguredPluginsInOrder()
-    {
-        var configuredPlugins = new List<string>();
-        var hostBuilder = Host.CreateDefaultBuilder();
-
-        _ = hostBuilder.ConfigurePlugins(builder =>
-        {
-            ArgumentNullException.ThrowIfNull(builder);
-            AddCurrentAssemblyAsFramework(builder);
-            builder.AssemblyScanFunc = _ =>
-            [
-                new LaterRecordingPlugin(configuredPlugins),
-                null,
-                new EarlierRecordingPlugin(configuredPlugins),
-            ];
-        });
-
-        using var host = hostBuilder.Build();
-
-        await Assert.That(configuredPlugins.Count).IsEqualTo(2);
-        await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierRecordingPlugin.Name);
-        await Assert.That(configuredPlugins[1]).IsEqualTo(LaterRecordingPlugin.Name);
-    }
-
     /// <summary>Verifies that IHostApplicationBuilder applies caller configuration before scanning for plugins.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -71,12 +94,12 @@ public class HostBuilderPluginExtensionsTests
         {
             ArgumentNullException.ThrowIfNull(builder);
             AddCurrentAssemblyAsFramework(builder);
-            builder.AssemblyScanFunc = _ => [new EarlierRecordingPlugin(configuredPlugins)];
+            builder.AssemblyScanFunc = _ => [new EarlierReactiveRecordingPlugin(configuredPlugins)];
         });
 
         await Assert.That(result).IsEqualTo(hostBuilder);
         await Assert.That(configuredPlugins.Count).IsEqualTo(1);
-        await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierRecordingPlugin.Name);
+        await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierReactiveRecordingPlugin.Name);
     }
 
     /// <summary>Verifies that repeated IHostBuilder plugin configuration calls reuse the same builder instance.</summary>
@@ -96,13 +119,30 @@ public class HostBuilderPluginExtensionsTests
         await Assert.That(firstBuilder).IsEqualTo(secondBuilder);
     }
 
+    /// <summary>Verifies that repeated IHostApplicationBuilder plugin configuration calls reuse the same builder instance.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigurePlugins_IHostApplicationBuilder_MultipleCalls_ReusePluginBuilder()
+    {
+        IPluginBuilder? firstBuilder = null;
+        IPluginBuilder? secondBuilder = null;
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        _ = hostBuilder.ConfigurePlugins(builder => firstBuilder = builder);
+        _ = hostBuilder.ConfigurePlugins(builder => secondBuilder = builder);
+
+        await Assert.That(firstBuilder).IsNotNull();
+        await Assert.That(secondBuilder).IsNotNull();
+        await Assert.That(firstBuilder).IsEqualTo(secondBuilder);
+    }
+
     /// <summary>Verifies that content-root scanning can provide the assembly used for plugin discovery.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
     public async Task ConfigurePlugins_IHostBuilder_WithContentRootScan_LoadsConfiguredPlugin()
     {
         var configuredPlugins = new List<string>();
-        var assemblyPath = typeof(HostBuilderPluginExtensionsTests).Assembly.Location;
+        var assemblyPath = typeof(ReactivePluginShimTests).Assembly.Location;
         var hostBuilder = Host.CreateDefaultBuilder()
             .UseContentRoot(Path.GetDirectoryName(assemblyPath)!);
 
@@ -111,13 +151,13 @@ public class HostBuilderPluginExtensionsTests
             ArgumentNullException.ThrowIfNull(builder);
             builder.UseContentRoot = true;
             _ = builder.FrameworkMatcher.AddInclude(Path.GetFileName(assemblyPath));
-            builder.AssemblyScanFunc = _ => [new EarlierRecordingPlugin(configuredPlugins)];
+            builder.AssemblyScanFunc = _ => [new EarlierReactiveRecordingPlugin(configuredPlugins)];
         });
 
         using var host = hostBuilder.Build();
 
         await Assert.That(configuredPlugins.Count).IsEqualTo(1);
-        await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierRecordingPlugin.Name);
+        await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierReactiveRecordingPlugin.Name);
     }
 
     /// <summary>Verifies that invalid plugin files discovered by the plugin matcher are ignored.</summary>
@@ -154,7 +194,7 @@ public class HostBuilderPluginExtensionsTests
     [Test]
     public async Task ConfigurePlugins_IHostBuilder_WithAlreadyLoadedPluginFile_IgnoresPlugin()
     {
-        var assemblyPath = typeof(HostBuilderPluginExtensionsTests).Assembly.Location;
+        var assemblyPath = typeof(ReactivePluginShimTests).Assembly.Location;
         var hostBuilder = Host.CreateDefaultBuilder();
 
         _ = hostBuilder.ConfigurePlugins(builder =>
@@ -185,13 +225,13 @@ public class HostBuilderPluginExtensionsTests
                 ArgumentNullException.ThrowIfNull(builder);
                 builder.FrameworkDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
                 _ = builder.FrameworkMatcher.AddInclude(Path.GetFileName(assemblyPath));
-                builder.AssemblyScanFunc = _ => [new EarlierRecordingPlugin(configuredPlugins)];
+                builder.AssemblyScanFunc = _ => [new EarlierReactiveRecordingPlugin(configuredPlugins)];
             });
 
             using var host = hostBuilder.Build();
 
             await Assert.That(configuredPlugins.Count).IsEqualTo(1);
-            await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierRecordingPlugin.Name);
+            await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierReactiveRecordingPlugin.Name);
         }
         finally
         {
@@ -216,13 +256,13 @@ public class HostBuilderPluginExtensionsTests
                 ArgumentNullException.ThrowIfNull(builder);
                 builder.PluginDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
                 _ = builder.PluginMatcher.AddInclude(Path.GetFileName(assemblyPath));
-                builder.AssemblyScanFunc = _ => [new EarlierRecordingPlugin(configuredPlugins)];
+                builder.AssemblyScanFunc = _ => [new EarlierReactiveRecordingPlugin(configuredPlugins)];
             });
 
             using var host = hostBuilder.Build();
 
             await Assert.That(configuredPlugins.Count).IsEqualTo(1);
-            await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierRecordingPlugin.Name);
+            await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierReactiveRecordingPlugin.Name);
         }
         finally
         {
@@ -242,28 +282,11 @@ public class HostBuilderPluginExtensionsTests
         await Assert.That(act).Throws<InvalidOperationException>();
     }
 
-    /// <summary>Verifies that repeated IHostApplicationBuilder plugin configuration calls reuse the same builder instance.</summary>
-    /// <returns>A task that represents the asynchronous test operation.</returns>
-    [Test]
-    public async Task ConfigurePlugins_IHostApplicationBuilder_MultipleCalls_ReusePluginBuilder()
-    {
-        IPluginBuilder? firstBuilder = null;
-        IPluginBuilder? secondBuilder = null;
-        var hostBuilder = Host.CreateApplicationBuilder();
-
-        _ = hostBuilder.ConfigurePlugins(builder => firstBuilder = builder);
-        _ = hostBuilder.ConfigurePlugins(builder => secondBuilder = builder);
-
-        await Assert.That(firstBuilder).IsNotNull();
-        await Assert.That(secondBuilder).IsNotNull();
-        await Assert.That(firstBuilder).IsEqualTo(secondBuilder);
-    }
-
     /// <summary>Adds the current test assembly to the framework scan set.</summary>
     /// <param name="pluginBuilder">The plugin builder to configure.</param>
     private static void AddCurrentAssemblyAsFramework(IPluginBuilder pluginBuilder)
     {
-        var assemblyPath = typeof(HostBuilderPluginExtensionsTests).Assembly.Location;
+        var assemblyPath = typeof(ReactivePluginShimTests).Assembly.Location;
         pluginBuilder.FrameworkDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
         _ = pluginBuilder.FrameworkMatcher.AddInclude(Path.GetFileName(assemblyPath));
     }
@@ -283,30 +306,56 @@ public class HostBuilderPluginExtensionsTests
     private static string CopyCurrentAssemblyToTemporaryPlugin(string tempDirectory)
     {
         var pluginPath = Path.Combine(tempDirectory, $"{nameof(Plugin)}.{Guid.NewGuid():N}.dll");
-        File.Copy(typeof(HostBuilderPluginExtensionsTests).Assembly.Location, pluginPath);
+        File.Copy(typeof(ReactivePluginShimTests).Assembly.Location, pluginPath);
         return pluginPath;
     }
 
-    /// <summary>Records configuration with an earlier plugin order.</summary>
+    /// <summary>Returns a value indicating whether the descriptor registers the reactive hosted service.</summary>
+    /// <param name="serviceDescriptor">The service descriptor to inspect.</param>
+    /// <returns>True when the descriptor registers the reactive hosted service.</returns>
+    private static bool IsReactiveHostedServiceRegistration(ServiceDescriptor serviceDescriptor) =>
+        serviceDescriptor.ServiceType == typeof(IHostedService) &&
+        serviceDescriptor.ImplementationType == typeof(ReactiveHostedService);
+
+    /// <summary>Hosted service used to verify reactive shim service registration.</summary>
+    public sealed class ReactiveHostedService : IHostedService
+    {
+        /// <inheritdoc />
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        /// <inheritdoc />
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    /// <summary>Reactive plugin implementation discovered by the reactive shim scanner.</summary>
+    public sealed class ReactiveDiscoveredPlugin : IPlugin
+    {
+        /// <inheritdoc />
+        public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
+        {
+        }
+    }
+
+    /// <summary>Records configuration with an earlier reactive plugin order.</summary>
     /// <param name="configuredPlugins">The configured plugin log.</param>
     [PluginOrder(-1)]
-    private sealed class EarlierRecordingPlugin(List<string> configuredPlugins) : IPlugin
+    private sealed class EarlierReactiveRecordingPlugin(List<string> configuredPlugins) : IPlugin
     {
         /// <summary>Stores the plugin name.</summary>
-        public const string Name = "Earlier";
+        public const string Name = "EarlierReactive";
 
         /// <inheritdoc />
         public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection) =>
             configuredPlugins.Add(Name);
     }
 
-    /// <summary>Records configuration with a later plugin order.</summary>
+    /// <summary>Records configuration with a later reactive plugin order.</summary>
     /// <param name="configuredPlugins">The configured plugin log.</param>
     [PluginOrder(10)]
-    private sealed class LaterRecordingPlugin(List<string> configuredPlugins) : IPlugin
+    private sealed class LaterReactiveRecordingPlugin(List<string> configuredPlugins) : IPlugin
     {
         /// <summary>Stores the plugin name.</summary>
-        public const string Name = "Later";
+        public const string Name = "LaterReactive";
 
         /// <inheritdoc />
         public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection) =>

--- a/src/tests/Extensions.Hosting.Tests/ReactiveTestPluginBuilder.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactiveTestPluginBuilder.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Microsoft.Extensions.FileSystemGlobbing;
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+
+namespace Extensions.Hosting.Tests;
+
+/// <summary>Test implementation of the reactive shim IPluginBuilder for unit testing.</summary>
+public class ReactiveTestPluginBuilder : IPluginBuilder
+{
+    /// <inheritdoc />
+    public IList<string> PluginDirectories { get; } = new List<string>();
+
+    /// <inheritdoc />
+    public IList<string> FrameworkDirectories { get; } = new List<string>();
+
+    /// <inheritdoc />
+    public bool UseContentRoot { get; set; }
+
+    /// <inheritdoc />
+    public bool FailIfNoPlugins { get; set; }
+
+    /// <inheritdoc />
+    public Matcher FrameworkMatcher { get; } = new Matcher();
+
+    /// <inheritdoc />
+    public Matcher PluginMatcher { get; } = new Matcher();
+
+    /// <inheritdoc />
+    public Func<string, bool> ValidatePlugin { get; set; } = _ => true;
+
+    /// <inheritdoc />
+    public Func<Assembly, IEnumerable<IPlugin?>?> AssemblyScanFunc { get; set; } = PluginScanner.ScanForPluginInstances;
+}

--- a/src/tests/Extensions.Hosting.Tests/ResourceMutexTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ResourceMutexTests.cs
@@ -104,6 +104,81 @@ public class ResourceMutexTests
         await Assert.That(second.IsLocked).IsFalse();
     }
 
+    /// <summary>Verifies that ResourceMutex can claim an existing named mutex that is not owned.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Create_WhenNamedMutexExistsButIsUnowned_ClaimsMutex()
+    {
+        var logger = NullLogger.Instance;
+        var id = "test-mutex-existing-" + Guid.NewGuid().ToString("N");
+        using var existing = new Mutex(initiallyOwned: false, @"Local\" + id);
+
+        using var mutex = ResourceMutex.Create(logger, id);
+
+        await Assert.That(mutex.IsLocked).IsTrue();
+    }
+
+    /// <summary>Verifies that ResourceMutex reports an unlocked state when mutex creation fails.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Create_WithInvalidMutexName_ReturnsUnlockedMutex()
+    {
+        var logger = NullLogger.Instance;
+        var id = "test-mutex-invalid-" + Guid.NewGuid().ToString("N") + @"\child";
+
+        using var mutex = ResourceMutex.Create(logger, id);
+
+        await Assert.That(mutex.IsLocked).IsFalse();
+    }
+
+    /// <summary>Verifies that ResourceMutex recovers ownership from an abandoned named mutex.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Create_WhenNamedMutexIsAbandoned_RecoversMutex()
+    {
+        var logger = NullLogger.Instance;
+        var id = "test-mutex-abandoned-" + Guid.NewGuid().ToString("N");
+        var ready = new ManualResetEventSlim(initialState: false);
+        var abandonThread = new Thread(() =>
+        {
+            _ = new Mutex(initiallyOwned: true, @"Local\" + id);
+            ready.Set();
+        });
+
+        abandonThread.Start();
+        ready.Wait();
+        abandonThread.Join();
+
+        using var mutex = ResourceMutex.Create(logger, id);
+
+        await Assert.That(mutex.IsLocked).IsTrue();
+    }
+
+    /// <summary>Verifies that ResourceMutex reports an unlocked state when mutex creation is unauthorized.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Create_WhenMutexFactoryThrowsUnauthorized_ReturnsUnlockedMutex()
+    {
+        static (Mutex Mutex, bool CreatedNew) ThrowUnauthorized(string mutexId)
+        {
+            _ = mutexId;
+            throw new UnauthorizedAccessException();
+        }
+
+        using var mutex = new ResourceMutex(
+            NullLogger.Instance,
+            "test-mutex-unauthorized-" + Guid.NewGuid().ToString("N"),
+            resourceName: null,
+            ThrowUnauthorized,
+            static mutex => mutex.ReleaseMutex(),
+            TimeSpan.FromSeconds(5));
+
+        var locked = mutex.Lock();
+
+        await Assert.That(locked).IsFalse();
+        await Assert.That(mutex.IsLocked).IsFalse();
+    }
+
     /// <summary>Verifies that ResourceMutex can be created as a global mutex.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -194,5 +269,91 @@ public class ResourceMutexTests
 
         await Assert.That(exception).IsNull();
         await Assert.That(mutex.IsLocked).IsFalse();
+    }
+
+    /// <summary>Verifies that ResourceMutex does not throw when the owner thread cannot exit before the dispose timeout.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_WhenOwnerThreadDoesNotExitWithinTimeout_DoesNotThrow()
+    {
+        var id = "test-mutex-timeout-" + Guid.NewGuid().ToString("N");
+        using var releaseStarted = new ManualResetEventSlim(initialState: false);
+        using var releaseCanContinue = new ManualResetEventSlim(initialState: false);
+        var mutex = new ResourceMutex(
+            NullLogger.Instance,
+            @"Local\" + id,
+            resourceName: null,
+            CreateNamedMutex,
+            static mutex => mutex.ReleaseMutex(),
+            TimeSpan.FromSeconds(1),
+            beforeReleaseMutex: () =>
+            {
+                releaseStarted.Set();
+                releaseCanContinue.Wait();
+            });
+
+        Exception? exception = null;
+        try
+        {
+            var locked = mutex.Lock();
+            await Assert.That(locked).IsTrue();
+
+            mutex.Dispose();
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+        finally
+        {
+            releaseCanContinue.Set();
+        }
+
+        await Assert.That(exception).IsNull();
+        await Assert.That(releaseStarted.IsSet).IsTrue();
+    }
+
+    /// <summary>Verifies that ResourceMutex does not throw when releasing the underlying mutex fails.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_WhenReleaseOperationThrows_DoesNotThrow()
+    {
+        static void ReleaseThenThrow(Mutex mutex)
+        {
+            mutex.ReleaseMutex();
+            throw new InvalidOperationException("Release failure.");
+        }
+
+        var id = "test-mutex-release-failure-" + Guid.NewGuid().ToString("N");
+        var mutex = new ResourceMutex(
+            NullLogger.Instance,
+            @"Local\" + id,
+            resourceName: null,
+            CreateNamedMutex,
+            ReleaseThenThrow,
+            TimeSpan.FromSeconds(5));
+
+        Exception? exception = null;
+        try
+        {
+            var locked = mutex.Lock();
+            await Assert.That(locked).IsTrue();
+
+            mutex.Dispose();
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        await Assert.That(exception).IsNull();
+    }
+
+    /// <summary>Creates a named mutex for ResourceMutex test seams.</summary>
+    /// <param name="mutexId">The fully qualified mutex identifier.</param>
+    /// <returns>The created mutex and a value indicating whether it was newly created.</returns>
+    private static (Mutex Mutex, bool CreatedNew) CreateNamedMutex(string mutexId)
+    {
+        return (new Mutex(true, mutexId, out var createdNew), createdNew);
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a reactive plugin shim project and supporting test coverage for the shared Extensions.Hosting.Plugins codebase.

## What is the new behavior?

- `Extensions.Hosting.Plugins.Reactive` builds from the same source as `Extensions.Hosting.Plugins` using linked compile items and `REACTIVE_SHIM`.
- Shared plugin source exposes `ReactiveMarbles.Extensions.Hosting.Reactive.Plugins` namespaces when the shim symbol is defined.
- Coverage is scoped to production `Extensions.Hosting.*` assemblies and includes the new reactive plugin assembly.
- Plugin, reactive shim, assembly loading, hosted service, resource mutex, and SingleInstance host-builder paths have broader TUnit coverage.

## What is the current behavior?

`Extensions.Hosting.Plugins` only builds a single non-reactive package surface, and the test coverage configuration does not include a reactive sibling assembly.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation performed locally:

- `dotnet test --solution Extensions.Hosting.slnx -c Release --coverage --coverage-output-format cobertura --results-directory .\TestResults -- --output Detailed`
- `dotnet build Extensions.Hosting.slnx -c Release -warnaserror --no-restore /m:1 '/clp:ErrorsOnly;Summary'`

MTP coverage summary: 100.00% line coverage for configured `Extensions.Hosting.*` modules; `Extensions.Hosting.Plugins`, `Extensions.Hosting.Plugins.Reactive`, and `Extensions.Hosting.SingleInstance` all report no missed source lines.

GitHub CI: `BuildOnly / windows-latest` passed on amended commit `9c59e6b`.