### PR TITLE
feat: add reactive platform shim projects

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,22 +27,27 @@
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
+    <PackageVersion Include="ReactiveUI.Primitives.Core" Version="6.0.0" />
+    <!--Reactive UI with ReactiveUI.Primitives support-->
+    <PackageVersion Include="ReactiveUI.Primitives" Version="6.0.0" />
     <PackageVersion Include="ReactiveUI" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.0-beta.1" />
     <PackageVersion Include="ReactiveUI.Core" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.Disposables" Version="6.0.0" />
     <PackageVersion Include="ReactiveUI.Drawing" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.Maui" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.Primitives" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.Core" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.Maui.Reactive" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.WinForms.Reactive" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.WinUI.Reactive" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.Wpf.Reactive" Version="6.0.0" />
     <PackageVersion Include="ReactiveUI.WinForms" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.WinUI" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.WPF" Version="24.0.0-beta.3" />
+    <PackageVersion Include="ReactiveUI.Reactive" Version="24.0.0-beta.3" />
+    <!--Reactive UI with System.Reactive support-->
+    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="6.0.0" />
+    <PackageVersion Include="ReactiveUI.Avalonia.Reactive" Version="12.1.0-beta.1" />
+    <PackageVersion Include="ReactiveUI.Drawing.Reactive" Version="24.0.0-beta.3" />
+    <PackageVersion Include="ReactiveUI.Maui.Reactive" Version="24.0.0-beta.3" />
+    <PackageVersion Include="ReactiveUI.WinForms.Reactive" Version="24.0.0-beta.3" />
+    <PackageVersion Include="ReactiveUI.WinUI.Reactive" Version="24.0.0-beta.3" />
+    <PackageVersion Include="ReactiveUI.WPF.Reactive" Version="24.0.0-beta.3" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Splat" Version="20.0.0" />
     <PackageVersion Include="Splat.Microsoft.Extensions.DependencyInjection" Version="20.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,11 @@
     <PackageVersion Include="ReactiveUI.Maui" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.Primitives" Version="6.0.0" />
     <PackageVersion Include="ReactiveUI.Primitives.Core" Version="6.0.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.Maui.Reactive" Version="6.0.0" />
     <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="6.0.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.WinForms.Reactive" Version="6.0.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.WinUI.Reactive" Version="6.0.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.Wpf.Reactive" Version="6.0.0" />
     <PackageVersion Include="ReactiveUI.WinForms" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.WinUI" Version="24.0.0-beta.3" />
     <PackageVersion Include="ReactiveUI.WPF" Version="24.0.0-beta.3" />

--- a/README.md
+++ b/README.md
@@ -1,353 +1,990 @@
-NOTE: The namespacing has been changed to ReactiveMarbles.Extensions.Hosting. Please update your references to the new namespace.
+# Extensions.Hosting
 
-# ReactiveMarbles.Extensions.Hosting
-Extensions for Microsoft.Extensions.Hosting that bring WPF, WinForms, WinUI, ReactiveUI, plug-ins, single-instance control, and common host utilities to desktop apps.
+`Extensions.Hosting` adds Generic Host integration for desktop UI frameworks, ReactiveUI/Splat, plug-ins, Windows service hosting, single-instance applications, and Identity/Entity Framework Core helpers.
 
-This repository supports both classic IHostBuilder and the newer IHostApplicationBuilder hosting model introduced in .NET 8+. Existing IHostBuilder APIs remain unchanged; equivalent IHostApplicationBuilder overloads are available where appropriate.
+The public namespaces use `ReactiveMarbles.Extensions.Hosting.*`.
 
-Supported targets include .NET Framework 4.6.2/4.8, .NET Standard 2.0, and .NET 8/9/10 (Windows where applicable).
+## Package Matrix
 
-## Quick start
+| Package | Main namespace | Purpose |
+| --- | --- | --- |
+| `CP.Extensions.Hosting.MainUIThread` | `ReactiveMarbles.Extensions.Hosting.UiThread` | Shared UI context and UI-thread base types used by the platform host packages. |
+| `CP.Extensions.Hosting.Wpf` | `ReactiveMarbles.Extensions.Hosting.Wpf` | WPF host integration, application/window registration, and WPF lifetime linking. |
+| `CP.Extensions.Hosting.WinForms` | `ReactiveMarbles.Extensions.Hosting.WinForms` | WinForms host integration, form/shell registration, and WinForms lifetime linking. |
+| `CP.Extensions.Hosting.WinUI` | `ReactiveMarbles.Extensions.Hosting.WinUI` | WinUI host integration for `Application` and main `Window` types. |
+| `CP.Extensions.Hosting.Avalonia` | `ReactiveMarbles.Extensions.Hosting.Avalonia` | Avalonia host integration, `AppBuilder` configuration, application/window registration, and Avalonia lifetime linking. |
+| `CP.Extensions.Hosting.Maui` | `ReactiveMarbles.Extensions.Hosting.Maui` | .NET MAUI host integration, `MauiAppBuilder` configuration, application/page registration, and MAUI lifetime linking. |
+| `CP.Extensions.Hosting.SingleInstance` | `ReactiveMarbles.Extensions.Hosting.AppServices` | Mutex-backed single-instance enforcement and direct named resource mutex helpers. |
+| `CP.Extensions.Hosting.Plugins` | `ReactiveMarbles.Extensions.Hosting.Plugins` | Plug-in discovery, assembly loading, ordering, and hosted-service plug-in base types. |
+| `CP.Extensions.Hosting.Plugins.Reactive` | `ReactiveMarbles.Extensions.Hosting.Reactive.Plugins` | Reactive package variant of the plug-in API with the same source and API shape. |
+| `CP.Extensions.Hosting.PluginService` | `ReactiveMarbles.Extensions.Hosting.PluginService` | Service-host bootstrapper, plug-in service discovery defaults, and `ServiceBase` lifetime support. |
+| `CP.Extensions.Hosting.PluginService.Reactive` | `ReactiveMarbles.Extensions.Hosting.Reactive.PluginService` | Reactive package variant of the service-host API, referencing `CP.Extensions.Hosting.Plugins.Reactive`. |
+| `CP.Extensions.Hosting.ReactiveUI.Wpf` | `ReactiveMarbles.Extensions.Hosting.ReactiveUI` | ReactiveUI/Splat integration for WPF using the standard ReactiveUI package set. |
+| `CP.Extensions.Hosting.ReactiveUI.Wpf.Reactive` | `ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI` | Reactive package variant of the WPF ReactiveUI/Splat integration. |
+| `CP.Extensions.Hosting.ReactiveUI.WinForms` | `ReactiveMarbles.Extensions.Hosting.ReactiveUI` | ReactiveUI/Splat integration for WinForms. |
+| `CP.Extensions.Hosting.ReactiveUI.WinForms.Reactive` | `ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI` | Reactive package variant of the WinForms ReactiveUI/Splat integration. |
+| `CP.Extensions.Hosting.ReactiveUI.WinUI` | `ReactiveMarbles.Extensions.Hosting.ReactiveUI` | ReactiveUI/Splat integration for WinUI. |
+| `CP.Extensions.Hosting.ReactiveUI.WinUI.Reactive` | `ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI` | Reactive package variant of the WinUI ReactiveUI/Splat integration. |
+| `CP.Extensions.Hosting.ReactiveUI.Avalonia` | `ReactiveMarbles.Extensions.Hosting.ReactiveUI` | ReactiveUI/Splat integration for Avalonia. |
+| `CP.Extensions.Hosting.ReactiveUI.Avalonia.Reactive` | `ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI` | Reactive package variant of the Avalonia ReactiveUI/Splat integration. |
+| `CP.Extensions.Hosting.ReactiveUI.Maui` | `ReactiveMarbles.Extensions.Hosting.ReactiveUI` | ReactiveUI/Splat integration for .NET MAUI. |
+| `CP.Extensions.Hosting.ReactiveUI.Maui.Reactive` | `ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI` | Reactive package variant of the MAUI ReactiveUI/Splat integration. |
+| `CP.Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer` | `ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore` | SQL Server DbContext and ASP.NET Core Identity registration helpers. |
+| `CP.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite` | `ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite` | SQLite DbContext and ASP.NET Core Identity registration helpers. |
 
-Choose a hosting model:
-- IHostBuilder (generic host): Host.CreateDefaultBuilder(args)
-- IHostApplicationBuilder (new app builder): Host.CreateApplicationBuilder(args)
+## Normal And Reactive Packages
 
-### Example: WPF app with IHostBuilder
+The normal packages use the standard `ReactiveMarbles.Extensions.Hosting.*` namespaces. The `.Reactive` packages are source-linked sibling projects compiled with `REACTIVE_SHIM` and use `ReactiveMarbles.Extensions.Hosting.Reactive.*` namespaces where a namespace split is needed.
+
+Use the normal packages when the application uses the standard ReactiveUI/ReactiveUI.Primitives package set. Use the `.Reactive` packages when the application uses `ReactiveUI.Primitives.*.Reactive` or `ReactiveUI.*.Reactive` packages. The hosting APIs are intentionally the same; migration usually means changing the package reference and namespace.
+
+Do not add direct Rx.NET package references to application projects for this repository's hosting APIs. Use the ReactiveUI.Primitives package family, and use the `.Reactive` package variants only when a reactive bridge package is required.
+
+```xml
+<ItemGroup>
+  <PackageReference Include="CP.Extensions.Hosting.Plugins" />
+  <PackageReference Include="CP.Extensions.Hosting.ReactiveUI.Wpf" />
+</ItemGroup>
+```
+
+```xml
+<ItemGroup>
+  <PackageReference Include="CP.Extensions.Hosting.Plugins.Reactive" />
+  <PackageReference Include="CP.Extensions.Hosting.ReactiveUI.Wpf.Reactive" />
+</ItemGroup>
+```
+
+```csharp
+// Normal package
+using ReactiveMarbles.Extensions.Hosting.Plugins;
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+
+// Reactive package
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+using ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+```
+
+For ReactiveUI.Primitives application code, project-file using aliases keep view models small and avoid repeated namespace noise:
+
+```xml
+<ItemGroup>
+  <Using Include="ReactiveUI.Primitives" />
+  <Using Include="ReactiveUI.Primitives.RxVoid" Alias="Unit" />
+  <Using Include="ReactiveUI.Primitives.Signals" />
+</ItemGroup>
+```
+
+## Target Frameworks
+
+The libraries target .NET Framework where the platform supports it, current .NET TFMs, and `net11.0` preview TFMs. Windows desktop packages use Windows-specific TFMs.
+
+| Area | Target frameworks |
+| --- | --- |
+| Shared, plug-ins, single instance | `net462`, `net472`, `net48`, `net481`, `net8.0`, `net9.0`, `net10.0`, `net11.0` |
+| WPF, WinForms, PluginService | .NET Framework TFMs plus `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, `net11.0-windows` |
+| ReactiveUI WPF/WinForms | .NET Framework TFMs plus `net8.0-windows10.0.19041`, `net9.0-windows10.0.19041`, `net10.0-windows10.0.19041`, `net11.0-windows10.0.19041` |
+| WinUI and ReactiveUI WinUI | `net8.0-windows10.0.19041`, `net9.0-windows10.0.19041`, `net10.0-windows10.0.19041`, `net11.0-windows10.0.19041` |
+| Avalonia and ReactiveUI Avalonia | `net8.0`, `net9.0`, `net10.0`, `net11.0` |
+| MAUI and ReactiveUI MAUI | `net10.0`, `net11.0`, Android, iOS, Mac Catalyst, macOS, tvOS, and Windows where supported |
+| Identity EF Core helpers | `net8.0`, `net9.0`, `net10.0`, `net11.0` |
+
+The repository uses Central Package Management in `Directory.Packages.props`. Notable centrally managed versions include `StyleSharp.Analyzers` `3.16.0`, `ReactiveUI.Primitives` `6.0.0`, `ReactiveUI` `24.0.0-beta.3`, and `ReactiveUI.Avalonia` `12.1.0-beta.1`.
+
+## Host Builder Styles
+
+Most packages support both Generic Host builder styles:
+
 ```csharp
 using Microsoft.Extensions.Hosting;
-using ReactiveMarbles.Extensions.Hosting.Wpf;
 
-var host = Host.CreateDefaultBuilder(args)
-    .ConfigureWpf(wpf =>
+var host = new HostBuilder()
+    .ConfigureServices(services =>
     {
-        // Optional: register Application type and windows via the WpfBuilder
-        wpf.ApplicationType = typeof(App);
-        wpf.WindowTypes.Add(typeof(MainWindow));
-        wpf.ConfigureContextAction = ctx => ctx.ShutdownMode = ShutdownMode.OnMainWindowClose;
+        // Classic IHostBuilder configuration.
     })
-    .UseWpfLifetime(ShutdownMode.OnMainWindowClose)
     .Build();
-
-await host.RunAsync();
 ```
 
-### Example: WPF app with IHostApplicationBuilder
 ```csharp
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// Modern IHostApplicationBuilder configuration.
+
+using var host = builder.Build();
+await host.RunAsync().ConfigureAwait(false);
+```
+
+The extension methods are fluent. Platform packages usually register a context, a UI thread adapter, and an `IHostedService` that starts the UI loop with the host.
+
+## Shared UI Thread Infrastructure
+
+Package: `CP.Extensions.Hosting.MainUIThread`
+
+Namespace: `ReactiveMarbles.Extensions.Hosting.UiThread`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `IUiContext.IsLifetimeLinked` | When `true`, the host is stopped when the UI application exits. |
+| `IUiContext.IsRunning` | Tracks whether the UI application has started and is still running. |
+| `BaseUiContext` | Simple base implementation of `IUiContext`. |
+| `BaseUiThread<TContext>` | Base class for UI-thread adapters where `TContext : class, IUiContext`. |
+| `BaseUiThread<TContext>.Start()` | Signals or starts the UI loop. |
+| `BaseUiThread<TContext>.Dispose()` | Releases startup synchronization resources. |
+| `BaseUiThread<TContext>.PreUiThreadStart()` | Override point that runs before the UI loop starts. |
+| `BaseUiThread<TContext>.UiThreadStart()` | Override point that runs the platform message loop. |
+| `BaseUiThread<TContext>.HandleApplicationExit()` | Marks the UI context stopped and requests host shutdown when lifetime is linked. |
+
+### Custom UI Adapter Example
+
+Most applications consume a platform package instead of deriving from `BaseUiThread<TContext>` directly. Use the base class when adding a new UI framework adapter.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using ReactiveMarbles.Extensions.Hosting.UiThread;
+
+public sealed class CustomUiContext : BaseUiContext
+{
+    public object? Dispatcher { get; set; }
+}
+
+public sealed class CustomUiThread(IServiceProvider services)
+    : BaseUiThread<CustomUiContext>(services)
+{
+    protected override void PreUiThreadStart()
+    {
+        UiContext.Dispatcher = new object();
+    }
+
+    protected override void UiThreadStart()
+    {
+        try
+        {
+            // Run the UI framework message loop here.
+        }
+        finally
+        {
+            HandleApplicationExit();
+        }
+    }
+}
+```
+
+## WPF Hosting
+
+Package: `CP.Extensions.Hosting.Wpf`
+
+Namespace: `ReactiveMarbles.Extensions.Hosting.Wpf`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `ConfigureWpf(Action<IWpfBuilder>? configureDelegate = null)` | Registers WPF hosting services and optional application/window types. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `UseWpfLifetime(ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)` | Links host shutdown to the WPF application lifetime. Call after `ConfigureWpf`. |
+| `IWpfBuilder.UseApplication<TApplication>()` | Registers a WPF `Application` type. |
+| `IWpfBuilder.UseCurrentApplication<TApplication>(TApplication currentApplication)` | Registers an existing WPF `Application` instance. |
+| `IWpfBuilder.UseWindow<TWindow>()` | Registers a WPF `Window` type. If the window implements `IWpfShell`, it is also registered as the shell. |
+| `IWpfBuilder.ConfigureContext(Action<IWpfContext> configureAction)` | Customizes the WPF context before it is used. |
+| `IWpfContext.ShutdownMode` | WPF shutdown behavior. |
+| `IWpfContext.WpfApplication` | Current WPF application instance. |
+| `IWpfContext.Dispatcher` | WPF dispatcher for UI-thread work. |
+| `IWpfShell` | Marker interface for a shell window. |
+
+### Example
+
+```csharp
+using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ReactiveMarbles.Extensions.Hosting.Wpf;
 
-var builder = Host.CreateApplicationBuilder(args)
-    .ConfigureWpf(wpf =>
-    {
-        wpf.ApplicationType = typeof(App);
-        wpf.WindowTypes.Add(typeof(MainWindow));
-        wpf.ConfigureContextAction = ctx => ctx.ShutdownMode = ShutdownMode.OnMainWindowClose;
-    })
-    .UseWpfLifetime(ShutdownMode.OnMainWindowClose);
+public sealed partial class App : Application
+{
+    private IHost? _host;
 
-await builder.Build().RunAsync();
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        _host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<MainViewModel>();
+            })
+            .ConfigureWpf(wpf =>
+            {
+                wpf.UseCurrentApplication(this);
+                wpf.UseWindow<MainWindow>();
+                wpf.ConfigureContext(context =>
+                    context.ShutdownMode = ShutdownMode.OnLastWindowClose);
+            })
+            .UseWpfLifetime()
+            .Build();
+
+        _ = _host.RunAsync();
+        base.OnStartup(e);
+    }
+}
+
+public sealed partial class MainWindow : Window, IWpfShell
+{
+    public MainWindow(MainViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+    }
+}
 ```
 
----
+## WinForms Hosting
 
-## Packages and APIs
-The following sections outline the main features, their APIs for both hosting models, and example usage.
+Package: `CP.Extensions.Hosting.WinForms`
 
-### WPF (CP.Extensions.Hosting.Wpf)
-Namespace: ReactiveMarbles.Extensions.Hosting.Wpf
-- ConfigureWpf
-  - IHostBuilder ConfigureWpf(this IHostBuilder, Action<IWpfBuilder>?)
-  - IHostApplicationBuilder ConfigureWpf(this IHostApplicationBuilder, Action<IWpfBuilder>?)
-  - Use IWpfBuilder to set:
-    - Type? ApplicationType
-    - Application? Application (optional existing instance)
-    - IList<Type> WindowTypes
-    - Action<IWpfContext>? ConfigureContextAction
-- UseWpfLifetime
-  - IHostBuilder UseWpfLifetime(this IHostBuilder, ShutdownMode = OnLastWindowClose)
-  - IHostApplicationBuilder UseWpfLifetime(this IHostApplicationBuilder, ShutdownMode = OnLastWindowClose)
-- IWpfContext
-  - ShutdownMode ShutdownMode { get; set; }
-  - Application? WpfApplication { get; set; }
-  - Dispatcher Dispatcher { get; }
-  - bool IsLifetimeLinked { get; set; } (set internally when using UseWpfLifetime)
+Namespace: `ReactiveMarbles.Extensions.Hosting.WinForms`
 
-Example (builder model): see Quick start above.
+### API
 
-### WinForms (CP.Extensions.Hosting.WinForms)
-Namespace: ReactiveMarbles.Extensions.Hosting.WinForms
-- ConfigureWinForms
-  - IHostBuilder ConfigureWinForms(this IHostBuilder, Action<IWinFormsContext>?)
-  - IHostApplicationBuilder ConfigureWinForms(this IHostApplicationBuilder, Action<IWinFormsContext>?)
-- ConfigureWinForms<TView>() where TView : Form
-  - IHostBuilder ConfigureWinForms<TView>(...)
-  - IHostApplicationBuilder ConfigureWinForms<TView>(...)
-  - Registers the main form and, if it implements IWinFormsShell, also registers it as IWinFormsShell
-- ConfigureWinFormsShell<TShell>() where TShell : Form, IWinFormsShell
-  - IHostBuilder ConfigureWinFormsShell<TShell>()
-  - IHostApplicationBuilder ConfigureWinFormsShell<TShell>()
-- UseWinFormsLifetime
-  - IHostBuilder UseWinFormsLifetime(this IHostBuilder)
-  - IHostApplicationBuilder UseWinFormsLifetime(this IHostApplicationBuilder)
-- IWinFormsContext
-  - bool EnableVisualStyles { get; set; }
-  - Dispatcher? Dispatcher { get; set; } (WinForms dispatcher abstraction)
+| API | Description |
+| --- | --- |
+| `ConfigureWinForms(Action<IWinFormsContext>? configureAction = null)` | Registers WinForms hosting services. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `ConfigureWinForms<TView>(Action<IWinFormsContext>? configureAction = null)` | Registers a `Form` as a singleton. If it implements `IWinFormsShell`, it is also registered as the shell. |
+| `ConfigureWinFormsShell<TShell>()` | Registers a shell form where `TShell : Form, IWinFormsShell`. |
+| `UseWinFormsLifetime()` | Links host shutdown to the WinForms message loop. |
+| `IWinFormsContext.EnableVisualStyles` | Enables or disables WinForms visual styles before the UI starts. |
+| `IWinFormsContext.Dispatcher` | Optional dispatcher used for marshaling work. |
+| `IWinFormsShell` | Marker interface for the main form. |
 
-Example (application builder):
+### Example
+
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ReactiveMarbles.Extensions.Hosting.WinForms;
+using System.Windows.Forms;
 
-var builder = Host.CreateApplicationBuilder(args)
-    .ConfigureWinForms(ctx =>
+[STAThread]
+public static class Program
+{
+    public static async Task Main(string[] args)
     {
-        ctx.EnableVisualStyles = true;
-    })
-    .ConfigureWinFormsShell<MainForm>()
-    .UseWinFormsLifetime();
+        using var host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<MainPresenter>();
+            })
+            .ConfigureWinForms<MainForm>(context => context.EnableVisualStyles = true)
+            .UseWinFormsLifetime()
+            .Build();
 
-await builder.Build().RunAsync();
+        await host.RunAsync().ConfigureAwait(false);
+    }
+}
+
+public sealed class MainForm : Form, IWinFormsShell
+{
+    public MainForm(MainPresenter presenter)
+    {
+        Text = presenter.Title;
+    }
+}
 ```
 
-### WinUI (CP.Extensions.Hosting.WinUI)
-Namespace: ReactiveMarbles.Extensions.Hosting.WinUI
-- ConfigureWinUI<TApp, TAppWindow>() where TApp : Microsoft.UI.Xaml.Application where TAppWindow : Microsoft.UI.Xaml.Window
-  - IHostBuilder ConfigureWinUI<TApp, TAppWindow>()
-  - IHostApplicationBuilder ConfigureWinUI<TApp, TAppWindow>()
-- IWinUIContext
-  - Window? AppWindow { get; set; }
-  - Type? AppWindowType { get; set; }
-  - DispatcherQueue? Dispatcher { get; set; }
-  - Application? WinUIApplication { get; set; }
+## WinUI Hosting
 
-Example (application builder):
+Package: `CP.Extensions.Hosting.WinUI`
+
+Namespace: `ReactiveMarbles.Extensions.Hosting.WinUI`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `ConfigureWinUI<TApp, TAppWindow>()` | Registers the WinUI `Application` and main `Window` types, the WinUI context, and the hosted service. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `IWinUIContext.AppWindow` | Current WinUI window instance. |
+| `IWinUIContext.AppWindowType` | Window type to create. Set by `ConfigureWinUI<TApp, TAppWindow>()`. |
+| `IWinUIContext.Dispatcher` | `DispatcherQueue` for UI-thread work. |
+| `IWinUIContext.WinUIApplication` | Current WinUI application instance. |
+| `IWinUIService` | Marker interface for WinUI services. |
+
+### Example
+
 ```csharp
 using Microsoft.Extensions.Hosting;
+using Microsoft.UI.Xaml;
 using ReactiveMarbles.Extensions.Hosting.WinUI;
 
-var builder = Host.CreateApplicationBuilder(args)
-    .ConfigureWinUI<App, MainWindow>();
+public partial class App : Application
+{
+    private readonly IHost _host;
 
-await builder.Build().RunAsync();
+    public App()
+    {
+        _host = new HostBuilder()
+            .ConfigureWinUI<App, MainWindow>()
+            .Build();
+    }
+}
+
+public sealed partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}
 ```
 
-### ReactiveUI integration
-Namespaces: ReactiveMarbles.Extensions.Hosting.ReactiveUI (per UI stack)
-- ConfigureSplatForMicrosoftDependencyResolver
-  - IHostBuilder ConfigureSplatForMicrosoftDependencyResolver(this IHostBuilder)
-  - IHostApplicationBuilder ConfigureSplatForMicrosoftDependencyResolver(this IHostApplicationBuilder)
-- Variants:
-  - WPF: Adds WithWpf() builder stage
-  - WinForms: Adds WithWinForms() builder stage
-  - WinUI: Adds WithWinUI() builder stage
-- MapSplatLocator
-  - IHost MapSplatLocator(this IHost host, Action<IServiceProvider?> containerFactory)
+## Avalonia Hosting
 
-Example (WPF + ReactiveUI with application builder):
+Package: `CP.Extensions.Hosting.Avalonia`
+
+Namespace: `ReactiveMarbles.Extensions.Hosting.Avalonia`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `ConfigureAvalonia(Action<IAvaloniaBuilder>? configureDelegate = null)` | Registers Avalonia hosting services and optional application/window types. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `UseAvaloniaLifetime(ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)` | Links host shutdown to the Avalonia desktop lifetime. |
+| `IAvaloniaBuilder.UseApplication<TApplication>()` | Registers an Avalonia `Application` type. |
+| `IAvaloniaBuilder.UseCurrentApplication<TApplication>(TApplication currentApplication)` | Registers an existing Avalonia application instance. |
+| `IAvaloniaBuilder.UseWindow<TWindow>()` | Registers an Avalonia `Window` type. If it implements `IAvaloniaShell`, it is also registered as the shell. |
+| `IAvaloniaBuilder.ConfigureContext(Action<IAvaloniaContext> configureAction)` | Customizes the Avalonia context. |
+| `IAvaloniaBuilder.ConfigureAppBuilder(Action<AppBuilder> configureAction)` | Customizes Avalonia `AppBuilder` before startup. |
+| `IAvaloniaContext.ShutdownMode` | Avalonia shutdown behavior. |
+| `IAvaloniaContext.AvaloniaApplication` | Current Avalonia application. |
+| `IAvaloniaContext.ApplicationLifetime` | Avalonia desktop lifetime. |
+| `IAvaloniaContext.Dispatcher` | Avalonia dispatcher. |
+| `IAvaloniaShell` | Marker interface for the main window. |
+
+### Example
+
 ```csharp
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Avalonia;
+
+public static class Program
+{
+    [STAThread]
+    public static int Main(string[] args)
+    {
+        using var host = new HostBuilder()
+            .ConfigureAvalonia(avalonia =>
+            {
+                avalonia.UseApplication<App>();
+                avalonia.UseWindow<MainWindow>();
+                avalonia.ConfigureAppBuilder(appBuilder =>
+                    appBuilder.UsePlatformDetect().LogToTrace());
+            })
+            .UseAvaloniaLifetime(ShutdownMode.OnLastWindowClose)
+            .Build();
+
+        host.Run();
+        return 0;
+    }
+}
+
+public sealed class MainWindow : Window, IAvaloniaShell
+{
+}
+```
+
+## MAUI Hosting
+
+Package: `CP.Extensions.Hosting.Maui`
+
+Namespace: `ReactiveMarbles.Extensions.Hosting.Maui`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `ConfigureMaui(Action<IMauiBuilder>? configureDelegate = null)` | Registers MAUI hosting services, builds a `MauiApp`, and registers application/page types. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `UseMauiLifetime()` | Links host shutdown to the MAUI lifetime. |
+| `ConfigureMauiShell<TShell>()` | Registers a singleton shell page where `TShell : Page, IMauiShell`. |
+| `IMauiBuilder.AddSingletonPage<TPage>()` | Registers a MAUI `Page` as a singleton. If it implements `IMauiShell`, it is also registered as the shell. |
+| `IMauiBuilder.UseMauiApp<TApplication>(Action<MauiAppBuilder>? configureMauiApp = null)` | Registers a MAUI `Application` type and configures the underlying `MauiAppBuilder`. |
+| `IMauiBuilder.UseMauiApp<TApplication>(TApplication currentApplication, Action<MauiAppBuilder>? configureMauiApp = null)` | Registers an existing MAUI application instance. |
+| `IMauiBuilder.ConfigureContext(Action<IMauiContext> configureAction)` | Customizes the MAUI context. |
+| `IMauiBuilder.MauiAppBuilder` | Underlying MAUI builder for fonts, handlers, services, and app configuration. |
+| `IMauiContext.MauiApplication` | Current MAUI application. |
+| `IMauiContext.Dispatcher` | MAUI dispatcher. |
+| `IMauiShell` | Marker interface for the main shell page. |
+
+### Example
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Maui;
+
+public static class MauiProgram
+{
+    public static IHost CreateHost()
+    {
+        return Host.CreateDefaultBuilder()
+            .ConfigureMaui(maui =>
+            {
+                maui.UseMauiApp<App>(builder =>
+                {
+                    builder.ConfigureFonts(fonts =>
+                    {
+                        fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                    });
+                });
+
+                maui.AddSingletonPage<AppShell>();
+            })
+            .UseMauiLifetime()
+            .Build();
+    }
+}
+
+public sealed class AppShell : Shell, IMauiShell
+{
+}
+```
+
+## ReactiveUI And Splat Integration
+
+Packages:
+
+- `CP.Extensions.Hosting.ReactiveUI.Wpf`
+- `CP.Extensions.Hosting.ReactiveUI.WinForms`
+- `CP.Extensions.Hosting.ReactiveUI.WinUI`
+- `CP.Extensions.Hosting.ReactiveUI.Avalonia`
+- `CP.Extensions.Hosting.ReactiveUI.Maui`
+- `.Reactive` siblings for each package
+
+Normal namespace: `ReactiveMarbles.Extensions.Hosting.ReactiveUI`
+
+Reactive namespace: `ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `ConfigureSplatForMicrosoftDependencyResolver()` on `IHostBuilder` | Registers Splat to use Microsoft.Extensions.DependencyInjection and initializes ReactiveUI for the target platform. |
+| `ConfigureSplatForMicrosoftDependencyResolver()` on `IHostApplicationBuilder` | Same behavior for the modern builder API. |
+| `MapSplatLocator(Action<IServiceProvider?> containerFactory)` on `IHost` | Maps Splat to the built host service provider and invokes a custom service-provider callback. |
+
+Each platform package initializes the matching ReactiveUI builder extension:
+
+| Package | ReactiveUI builder call |
+| --- | --- |
+| WPF | `WithWpf()` |
+| WinForms | `WithWinForms()` |
+| WinUI | `WithWinUI()` |
+| Avalonia | `WithAvalonia()` |
+| MAUI | `WithMaui()` |
+
+### WPF Example
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
 using ReactiveMarbles.Extensions.Hosting.Wpf;
+using ReactiveUI;
 
-var builder = Host.CreateApplicationBuilder(args)
+var host = new HostBuilder()
     .ConfigureSplatForMicrosoftDependencyResolver()
-    .ConfigureWpf(wpf =>
+    .ConfigureServices(services =>
     {
-        wpf.ApplicationType = typeof(App);
-        wpf.WindowTypes.Add(typeof(MainWindow));
+        services.AddSingleton<MainWindowViewModel>();
+        services.AddTransient<IViewFor<MainWindowViewModel>, MainWindow>();
     })
-    .UseWpfLifetime();
+    .ConfigureWpf(wpf => wpf.UseApplication<App>().UseWindow<MainWindow>())
+    .UseWpfLifetime()
+    .Build();
 
-await builder.Build().RunAsync();
+host.MapSplatLocator(serviceProvider =>
+{
+    // Register additional Splat services that need the built provider.
+});
+
+await host.RunAsync().ConfigureAwait(false);
 ```
 
-### Plug-in system (CP.Extensions.Hosting.Plugins)
-Namespace: ReactiveMarbles.Extensions.Hosting.Plugins
-- ConfigurePlugins
-  - IHostBuilder ConfigurePlugins(this IHostBuilder, Action<IPluginBuilder?> configure)
-  - IHostApplicationBuilder ConfigurePlugins(this IHostApplicationBuilder, Action<IPluginBuilder?> configure)
-- IPluginBuilder key options (typical):
-  - UseContentRoot (bool): also scan content root
-  - IncludeFrameworks(params string[] globs)
-  - IncludePlugins(params string[] globs)
-  - AddScanDirectories(params string[] directories)
-  - PluginMatcher / FrameworkMatcher (advanced globbing)
-  - AssemblyScanFunc: Func<Assembly, IEnumerable<IPlugin?>> for discovery
+### Reactive Package Example
 
-Example (application builder):
+The API is the same. Use the `.Reactive` package and namespace.
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+
+var host = new HostBuilder()
+    .ConfigureSplatForMicrosoftDependencyResolver()
+    .ConfigureWpf(wpf => wpf.UseApplication<App>().UseWindow<MainWindow>())
+    .UseWpfLifetime()
+    .Build();
+```
+
+### ReactiveUI.Primitives View Model Example
+
+```csharp
+using ReactiveUI;
+
+public sealed class SearchViewModel : ReactiveObject
+{
+    private string? _searchText;
+    private IReadOnlyList<string> _results = [];
+
+    public string? SearchText
+    {
+        get => _searchText;
+        set => this.RaiseAndSetIfChanged(ref _searchText, value);
+    }
+
+    public IReadOnlyList<string> Results
+    {
+        get => _results;
+        private set => this.RaiseAndSetIfChanged(ref _results, value);
+    }
+
+    public void Search(IEnumerable<string> source)
+    {
+        var filter = SearchText ?? string.Empty;
+        Results = source
+            .Where(item => item.Contains(filter, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+    }
+}
+```
+
+## Single-Instance Applications
+
+Package: `CP.Extensions.Hosting.SingleInstance`
+
+Namespace: `ReactiveMarbles.Extensions.Hosting.AppServices`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `ConfigureSingleInstance(Action<IMutexBuilder> configureAction)` | Registers mutex-backed single-instance enforcement. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `ConfigureSingleInstance(string mutexId)` | Convenience overload that sets only the mutex id. |
+| `IMutexBuilder.MutexId` | Unique named mutex identifier. |
+| `IMutexBuilder.IsGlobal` | Uses the `Global\` mutex namespace when `true`; otherwise uses `Local\`. |
+| `IMutexBuilder.WhenNotFirstInstance` | Callback invoked with `IHostEnvironment` and `ILogger` when another instance already owns the mutex. |
+| `ResourceMutex.Create(ILogger? logger, string? mutexId, string? resourceName = null, bool global = false)` | Creates and locks a named mutex directly. |
+| `ResourceMutex.IsLocked` | Indicates whether the mutex was acquired. |
+| `ResourceMutex.Lock()` | Attempts to acquire the mutex. |
+| `ResourceMutex.Dispose()` | Releases the mutex on the owning thread. |
+
+### Host Example
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Hosting.AppServices;
+
+var host = new HostBuilder()
+    .ConfigureSingleInstance(singleInstance =>
+    {
+        singleInstance.MutexId = "{D7F93D6D-6B4D-4F58-8E76-E68C51D9E92C}";
+        singleInstance.IsGlobal = false;
+        singleInstance.WhenNotFirstInstance = (environment, logger) =>
+        {
+            logger.LogWarning(
+                "Application {ApplicationName} is already running.",
+                environment.ApplicationName);
+        };
+    })
+    .Build();
+
+await host.RunAsync().ConfigureAwait(false);
+```
+
+### Direct ResourceMutex Example
+
+```csharp
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Hosting.AppServices;
+
+using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+var logger = loggerFactory.CreateLogger("Mutex");
+
+using var mutex = ResourceMutex.Create(
+    logger,
+    "import-job",
+    resourceName: "Nightly import",
+    global: false);
+
+if (!mutex.IsLocked)
+{
+    return;
+}
+
+// Run the protected work.
+```
+
+## Plug-ins
+
+Packages:
+
+- `CP.Extensions.Hosting.Plugins`
+- `CP.Extensions.Hosting.Plugins.Reactive`
+
+Normal namespace: `ReactiveMarbles.Extensions.Hosting.Plugins`
+
+Reactive namespace: `ReactiveMarbles.Extensions.Hosting.Reactive.Plugins`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `ConfigurePlugins(Action<IPluginBuilder?> configurePlugin)` | Configures plug-in scanning and loading. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `IPlugin.ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)` | Called for each discovered plug-in so it can register services. |
+| `IPluginBuilder.PluginDirectories` | Root directories scanned for plug-in assemblies. |
+| `IPluginBuilder.FrameworkDirectories` | Root directories scanned for framework assemblies. |
+| `IPluginBuilder.UseContentRoot` | Adds the host content root to the scan directories when enabled. |
+| `IPluginBuilder.FailIfNoPlugins` | Throws during startup when no plug-ins are discovered. Defaults to `false`. |
+| `IPluginBuilder.FrameworkMatcher` | Glob matcher for framework assemblies. |
+| `IPluginBuilder.PluginMatcher` | Glob matcher for plug-in assemblies. |
+| `IPluginBuilder.ValidatePlugin` | Predicate used before loading a plug-in assembly path. |
+| `IPluginBuilder.AssemblyScanFunc` | Assembly scanning delegate. Defaults to scanning exported public plug-in types. |
+| `AddScanDirectories(params string[] directories)` | Adds directories to both framework and plug-in scan roots. |
+| `IncludeFrameworks(params string[] frameworkGlobs)` | Adds framework include globs. |
+| `ExcludeFrameworks(params string[] frameworkGlobs)` | Adds framework exclude globs. |
+| `IncludePlugins(params string[] pluginGlobs)` | Adds plug-in include globs. |
+| `ExcludePlugins(params string[] pluginGlobs)` | Adds plug-in exclude globs. |
+| `RequirePlugins(bool failIfNone = true)` | Sets `FailIfNoPlugins`. |
+| `PluginScanner.ByNamingConvention(Assembly pluginAssembly)` | Finds a conventional `{AssemblyName}.Plugin` type. |
+| `PluginScanner.ScanForPluginInstances(Assembly pluginAssembly)` | Finds public concrete classes implementing `IPlugin`. |
+| `PluginOrderAttribute` | Orders discovered plug-ins. Lower values run earlier. Constructors accept no value, an `int`, or an enum/object value. |
+| `PluginBase<T>`, `PluginBase<T1,T2>`, `PluginBase<T1,T2,T3>` | Base plug-ins that register one, two, or three hosted services. |
+| `HostedServiceBase<T>` | Base hosted service with logging, cleanup, and lifetime callback hooks. |
+
+`HostedServiceBase<T>` exposes:
+
+| Member | Description |
+| --- | --- |
+| `CleanUp` | Disposable collection cleaned when the service stops or is disposed. |
+| `Logger` | Logger passed to the base constructor. |
+| `IsDisposed` | Indicates whether the cleanup collection has been disposed. |
+| `OnStarted()` | Override to start work after the application starts. |
+| `OnStopping()` | Override to stop work and dispose resources. Call the base implementation unless you intentionally replace cleanup behavior. |
+| `OnStopped()` | Override to run final stopped logic. |
+
+### Host Scanning Example
+
 ```csharp
 using Microsoft.Extensions.Hosting;
 using ReactiveMarbles.Extensions.Hosting.Plugins;
 
-var builder = Host.CreateApplicationBuilder(args)
+var host = new HostBuilder()
     .ConfigurePlugins(plugins =>
     {
-        plugins.UseContentRoot = true;
-        // Add framework assemblies and plugin patterns
-        plugins.IncludeFrameworks(@"\\netstandard2.0\\*.FrameworkLib.dll");
-        plugins.IncludePlugins(@"\\Plugins\\{runtime}\\ReactiveMarbles.Plugin.*.dll");
-    });
+        plugins?.AddScanDirectories(AppContext.BaseDirectory);
+        plugins?.IncludeFrameworks("frameworks/**/*.dll");
+        plugins?.IncludePlugins("plugins/**/*.Plugin.dll");
+        plugins?.ExcludePlugins("plugins/**/*.Disabled.dll");
+        plugins?.RequirePlugins();
+        if (plugins is not null)
+        {
+            plugins.AssemblyScanFunc = PluginScanner.ScanForPluginInstances;
+        }
+    })
+    .Build();
 
-await builder.Build().RunAsync();
+await host.RunAsync().ConfigureAwait(false);
 ```
 
-### Single instance (CP.Extensions.Hosting.SingleInstance)
-Namespace: ReactiveMarbles.Extensions.Hosting.AppServices
-- ConfigureSingleInstance
-  - IHostBuilder ConfigureSingleInstance(this IHostBuilder, Action<IMutexBuilder> configure)
-  - IHostApplicationBuilder ConfigureSingleInstance(this IHostApplicationBuilder, Action<IMutexBuilder> configure)
-  - IHostBuilder ConfigureSingleInstance(this IHostBuilder, string mutexId)
-  - IHostApplicationBuilder ConfigureSingleInstance(this IHostApplicationBuilder, string mutexId)
-- IMutexBuilder
-  - string MutexId { get; set; }
-  - Action<IHostEnvironment, ILogger>? WhenNotFirstInstance { get; set; }
+### Plug-in Assembly Example
 
-Example (application builder):
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using ReactiveMarbles.Extensions.Hosting.AppServices;
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Hosting.Plugins;
 
-var builder = Host.CreateApplicationBuilder(args)
-    .ConfigureSingleInstance(cfg =>
+[PluginOrder(10)]
+public sealed class Plugin : IPlugin
+{
+    public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
     {
-        cfg.MutexId = "{ea031523-3a63-45e5-85f2-6fa75fbf37ed}";
-        cfg.WhenNotFirstInstance = (env, logger) =>
-            logger.LogWarning("Application {0} already running.", env.ApplicationName);
-    });
+        serviceCollection.AddHostedService<ImportHostedService>();
+    }
+}
 
-await builder.Build().RunAsync();
+public sealed class ImportHostedService(
+    ILogger<ImportHostedService> logger,
+    IHostApplicationLifetime lifetime)
+    : HostedServiceBase<ImportHostedService>(logger, lifetime)
+{
+    public override Task OnStarted()
+    {
+        Logger.LogInformation("Import service started.");
+        return Task.CompletedTask;
+    }
+}
 ```
 
-### Service host utilities (CP.Extensions.Hosting.PluginService)
-Namespace: ReactiveMarbles.Extensions.Hosting.PluginService
-- UseServiceBaseLifetime
-  - IHostBuilder UseServiceBaseLifetime(this IHostBuilder)
-  - IHostApplicationBuilder UseServiceBaseLifetime(this IHostApplicationBuilder)
-- UseConsoleLifetime (IHostApplicationBuilder only)
-  - IHostApplicationBuilder UseConsoleLifetime(this IHostApplicationBuilder)
-- RunAsServiceAsync
-  - Task RunAsServiceAsync(this IHostBuilder, CancellationToken = default)
-  - Task RunAsServiceAsync(this HostApplicationBuilder, CancellationToken = default)
-- ServiceHost
-  - Task Create(Type type, string[] args, Func<IHostBuilder?, IHostBuilder?>? configureHostBuilder = null, Action<IHost>? configureHost = null, string nameSpace = "ReactiveMarbles.Plugin", string? targetRuntime = null)
-  - Task CreateApplication(Type type, string[] args, Func<IHostApplicationBuilder?, IHostApplicationBuilder?>? configureHostBuilder = null, Action<IHost>? configureHost = null, string nameSpace = "ReactiveMarbles.Plugin", string? targetRuntime = null)
+### Plug-in Base Example
 
-Example (service/console dual mode using IHostApplicationBuilder):
 ```csharp
-using Microsoft.Extensions.Hosting;
-using ReactiveMarbles.Extensions.Hosting.PluginService;
+using ReactiveMarbles.Extensions.Hosting.Plugins;
 
-var builder = Host.CreateApplicationBuilder(args)
-    .UseContentRoot(Directory.GetCurrentDirectory())
-    .ConfigureLogging()
-    .ConfigureConfiguration(args)
-    .UseConsoleLifetime(); // or .UseServiceBaseLifetime() for Windows Service
-
-await builder.Build().RunAsync();
+public sealed class Plugin
+    : PluginBase<ImportHostedService, ExportHostedService>
+{
+}
 ```
 
-Example (helper):
+### Reactive Plug-in Example
+
+Only the package and namespace change.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+
+public sealed class Plugin : IPlugin
+{
+    public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddSingleton<ReactivePluginService>();
+    }
+}
+```
+
+## Plug-in Service Hosting
+
+Packages:
+
+- `CP.Extensions.Hosting.PluginService`
+- `CP.Extensions.Hosting.PluginService.Reactive`
+
+Normal namespace: `ReactiveMarbles.Extensions.Hosting.PluginService`
+
+Reactive namespace: `ReactiveMarbles.Extensions.Hosting.Reactive.PluginService`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `ServiceHost.Logger` | Gets the `ILogger` created by the service host after startup. |
+| `ServiceHost.Create(Type type, string[] args, Func<IHostBuilder?, IHostBuilder?>? hostBuilder = default, Action<IHost>? configureHost = default, string nameSpace = "ReactiveMarbles.Plugin", string? targetRuntime = null)` | Creates, configures, and runs a classic `IHostBuilder` service host. |
+| `ServiceHost.CreateApplication(Type type, string[] args, Func<IHostApplicationBuilder?, IHostApplicationBuilder?>? hostBuilder = default, Action<IHost>? configureHost = default, string nameSpace = "ReactiveMarbles.Plugin", string? targetRuntime = null)` | Creates, configures, and runs a modern `IHostApplicationBuilder` service host. |
+| `UseServiceBaseLifetime()` on `IHostBuilder` | Registers `ServiceBaseLifetime` as `IHostLifetime`. |
+| `UseServiceBaseLifetime()` on `IHostApplicationBuilder` | Registers `ServiceBaseLifetime` as `IHostLifetime`. |
+| `UseConsoleLifetime()` on `IHostApplicationBuilder` | Registers `ConsoleLifetime` as `IHostLifetime`. |
+| `RunAsServiceAsync(CancellationToken cancellationToken = default)` on `IHostBuilder` | Builds and runs with `ServiceBaseLifetime`. |
+| `RunAsServiceAsync(CancellationToken cancellationToken = default)` on `HostApplicationBuilder` | Builds and runs with `ServiceBaseLifetime`. |
+| `ServiceBaseLifetime` | `IHostLifetime` implementation backed by `System.ServiceProcess.ServiceBase`. |
+
+`ServiceHost` configures:
+
+- Content root as the current directory.
+- Logging from configuration plus console, event log, log4net, and debug providers.
+- Host configuration from `hostsettings.json`, environment variables with the `PREFIX_` prefix, and command line.
+- Application configuration from `appsettings.json`, `appsettings.{Environment}.json`, environment variables with the `PREFIX_` prefix, and command line.
+- Plug-in scanning from the process directory, framework assemblies matching `\netstandard2.0\*.FrameworkLib.dll`, and plug-ins matching `\Plugins\{runtime}\{nameSpace}*.dll`.
+- Windows service lifetime when a debugger is not attached and `--console` is not supplied; console lifetime otherwise.
+
+### Console Or Service Entry Point
+
+```csharp
+using ReactiveMarbles.Extensions.Hosting.PluginService;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+await ServiceHost.Create(
+    typeof(Program),
+    args,
+    hostBuilder: builder => builder?.ConfigureServices(services =>
+    {
+        services.AddSingleton<SharedService>();
+    }),
+    configureHost: host =>
+    {
+        ServiceHost.Logger?.LogInformation("Host configured.");
+    },
+    nameSpace: "Contoso.Plugin",
+    targetRuntime: "win-x64")
+    .ConfigureAwait(false);
+```
+
+### Modern Builder Entry Point
+
 ```csharp
 using ReactiveMarbles.Extensions.Hosting.PluginService;
 
 await ServiceHost.CreateApplication(
     typeof(Program),
     args,
-    hb => hb // external builder customization
-            .ConfigurePlugins(pb =>
-            { 
-                /* plugin globs */
-                pb.RequirePlugins(true); // fail if none found - optional default false
-            }),
-    host => { /* use host.Services */ },
-    nameSpace: "ReactiveMarbles.Plugin");
+    hostBuilder: builder =>
+    {
+        builder?.Services.AddSingleton<SharedService>();
+        return builder;
+    })
+    .ConfigureAwait(false);
 ```
 
-### Identity + Entity Framework Core
-Namespaces:
-- ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore (SqlServer)
-- ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite (Sqlite)
+### Direct Service Lifetime Example
 
-APIs (service collection extensions used inside UseWebHostServices):
-- IServiceCollection UseEntityFrameworkCoreSqlServer<TContext, TUser, TRole>(WebHostBuilderContext, string connectionStringName, ServiceLifetime = Scoped)
-- IServiceCollection UseEntityFrameworkCoreSqlServer<TContext, TUser>(WebHostBuilderContext, string connectionStringName, ServiceLifetime = Scoped)
-- IServiceCollection UseEntityFrameworkCoreSqlite<TContext, TUser, TRole>(WebHostBuilderContext, string connectionStringName, ServiceLifetime = Scoped)
-- IServiceCollection UseEntityFrameworkCoreSqlite<TContext, TUser>(WebHostBuilderContext, string connectionStringName, ServiceLifetime = Scoped)
+```csharp
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using ReactiveMarbles.Extensions.Hosting.PluginService;
 
-Host/web host wiring:
-- IHostBuilder UseWebHostServices(this IHostBuilder, Action<WebHostBuilderContext, IServiceCollection> configureServices, bool validateScopes = false)
-- IHostBuilder UseWebHostServices(this IHostBuilder, Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, bool validateScopes = false)
-- IHostBuilder UseWebHostServices(this IHostBuilder, Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, Func<IApplicationBuilder, IApplicationBuilder> configureApp, bool validateScopes = false)
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
+builder.UseServiceBaseLifetime();
 
-Example:
+await builder.Build().RunAsync().ConfigureAwait(false);
+```
+
+### Reactive Service Host Example
+
+```csharp
+using ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+
+await ServiceHost.CreateApplication(typeof(Program), args)
+    .ConfigureAwait(false);
+```
+
+## Identity And Entity Framework Core
+
+SQL Server package: `CP.Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer`
+
+SQL Server namespace: `ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore`
+
+SQLite package: `CP.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite`
+
+SQLite namespace: `ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite`
+
+### SQL Server API
+
+| API | Description |
+| --- | --- |
+| `IConfiguration.HasConnectionString(string connectionStringName)` | Returns `true` when the named connection string exists and is not empty. |
+| `IConfiguration.GetRequiredConnectionString(string connectionStringName)` | Gets the named connection string or throws a descriptive `InvalidOperationException`. |
+| `IHostApplicationBuilder.AddSqlServerDbContext<TContext>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQL Server `DbContext`. |
+| `IHostApplicationBuilder.AddSqlServerWithIdentity<TContext,TUser,TRole>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQL Server EF Core plus ASP.NET Core Identity with roles. |
+| `IHostApplicationBuilder.AddSqlServerWithIdentity<TContext,TUser>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQL Server EF Core plus ASP.NET Core Identity without a custom role type. |
+| `IHostBuilder.UseWebHostServices(...)` | Adds minimal ASP.NET Core web-host services. Three overloads support service-only, web-host customization, and web-host plus app-pipeline customization. |
+| `IServiceCollection.UseEntityFrameworkCoreSqlServer<TContext,TUser,TRole>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQL Server EF Core plus Identity with roles in a web-host service callback. |
+| `IServiceCollection.UseEntityFrameworkCoreSqlServer<TContext,TUser>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQL Server EF Core plus Identity without a custom role type. |
+| `IServiceCollection.AddSqlServerDbContext<TContext>(IConfiguration configuration, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQL Server `DbContext` from configuration. |
+| `IServiceCollection.AddSqlServerDbContextWithConnectionString<TContext>(string connectionString, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQL Server `DbContext` from a direct connection string. |
+
+### SQLite API
+
+| API | Description |
+| --- | --- |
+| `IHostApplicationBuilder.AddSqliteDbContext<TContext>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQLite `DbContext`. |
+| `IHostApplicationBuilder.AddSqliteWithIdentity<TContext,TUser,TRole>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQLite EF Core plus ASP.NET Core Identity with roles. |
+| `IHostApplicationBuilder.AddSqliteWithIdentity<TContext,TUser>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQLite EF Core plus ASP.NET Core Identity without a custom role type. |
+| `IHostBuilder.UseWebHostServices(...)` | Adds minimal ASP.NET Core web-host services. Three overloads match the SQL Server package. |
+| `IServiceCollection.UseEntityFrameworkCoreSqlite<TContext,TUser,TRole>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQLite EF Core plus Identity with roles in a web-host service callback. |
+| `IServiceCollection.UseEntityFrameworkCoreSqlite<TContext,TUser>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQLite EF Core plus Identity without a custom role type. |
+| `IServiceCollection.AddSqliteDbContext<TContext>(IConfiguration configuration, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQLite `DbContext` from configuration. |
+| `IServiceCollection.AddSqliteDbContextWithConnectionString<TContext>(string connectionString, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQLite `DbContext` from a direct connection string. |
+| `CreateInMemoryConnectionString(string? databaseName = null)` | Creates a SQLite in-memory connection string. |
+| `CreateFileConnectionString(string filePath)` | Creates a SQLite file connection string. |
+
+### Modern Builder Example
+
 ```csharp
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore;
 
-var host = Host.CreateDefaultBuilder(args)
-    .UseWebHostServices((whb, services) =>
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddSqlServerWithIdentity<AppDbContext, IdentityUser, IdentityRole>(
+    "DefaultConnection");
+
+using var host = builder.Build();
+await host.RunAsync().ConfigureAwait(false);
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : IdentityDbContext<IdentityUser, IdentityRole, string>(options)
+{
+}
+```
+
+### Web Host Services Example
+
+```csharp
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite;
+
+var host = new HostBuilder()
+    .UseWebHostServices((context, services) =>
     {
-        services.UseEntityFrameworkCoreSqlServer<AppDbContext, IdentityUser, IdentityRole>(whb, "DefaultConnection");
+        services.UseEntityFrameworkCoreSqlite<AppDbContext, IdentityUser>(
+            context,
+            "DefaultConnection");
     })
     .Build();
 
-await host.RunAsync();
+await host.RunAsync().ConfigureAwait(false);
 ```
 
-### Reactive examples
-- WPF + ReactiveUI + Single instance:
+### Direct SQLite Connection Example
+
 ```csharp
-var builder = Host.CreateApplicationBuilder(args)
+using Microsoft.Extensions.DependencyInjection;
+using ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite;
+
+var services = new ServiceCollection();
+var connectionString =
+    HostBuilderEntityFrameworkCoreExtensions.CreateInMemoryConnectionString("tests");
+
+services.AddSqliteDbContextWithConnectionString<AppDbContext>(connectionString);
+```
+
+## Recommended Composition
+
+The packages are designed to compose as small host extensions. A desktop app can combine single-instance enforcement, ReactiveUI/Splat, platform lifetime, and plug-in loading in one host.
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.AppServices;
+using ReactiveMarbles.Extensions.Hosting.Plugins;
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+
+var host = new HostBuilder()
     .ConfigureSplatForMicrosoftDependencyResolver()
-    .ConfigureWpf(wpf =>
+    .ConfigureSingleInstance("{1E938C68-6B3E-4105-BE52-2432FE80F19C}")
+    .ConfigurePlugins(plugins =>
     {
-        wpf.ApplicationType = typeof(App);
-        wpf.WindowTypes.Add(typeof(MainWindow));
+        plugins?.AddScanDirectories(AppContext.BaseDirectory);
+        plugins?.IncludePlugins("plugins/**/*.dll");
     })
+    .ConfigureWpf(wpf => wpf.UseApplication<App>().UseWindow<MainWindow>())
     .UseWpfLifetime()
-    .ConfigureSingleInstance("{ea031523-3a63-45e5-85f2-6fa75fbf37ed}");
+    .Build();
 
-await builder.Build().RunAsync();
+await host.RunAsync().ConfigureAwait(false);
 ```
 
-### Notes
-- WPF/WinForms/WinUI components target Windows only.
-- When using IHostApplicationBuilder, prefer chaining extension methods that return IHostApplicationBuilder so you can call Build() on the final HostApplicationBuilder instance.
-- Plugin scanning uses glob patterns. Ensure your plugin folders are copied to output and the patterns match your runtime folder (e.g., Plugins\net9.0-windows\Your.Plugin.*.dll).
+## Build And Test
 
----
+The repository uses the XML `.slnx` solution format and Microsoft Testing Platform with TUnit.
 
-## Legacy snippets (IHostBuilder only)
-
-#### ReactiveMarbles.Extensions.Hosting.Plugins
-```csharp
-.ConfigurePlugins(pluginBuilder =>
-{
-    Console.ForegroundColor = ConsoleColor.Yellow;
-    Console.WriteLine("Running using dotNet {0}", Environment.Version);
-
-    var process = Process.GetCurrentProcess();
-    var fullPath = process.MainModule?.FileName?.Replace(process.MainModule.ModuleName!, string.Empty);
-    Console.WriteLine("Add Scan Directories: {0}", fullPath);
-    pluginBuilder?.AddScanDirectories(fullPath!);
-
-    pluginBuilder?.IncludeFrameworks(@"\netstandard2.0\*.FrameworkLib.dll");
-
-    var runtime = Path.GetFileName(AppContext.BaseDirectory);
-    Console.WriteLine(@"Include Plugins from: \Plugins\{0}\{1}*.dll", runtime, "ReactiveMarbles.Plugin");
-    pluginBuilder?.IncludePlugins(@$"\Plugins\{runtime}\{{YourPluginNamespace}}*.dll");
-    Console.ResetColor();
-})
+```powershell
+cd src
+dotnet workload restore
+dotnet restore Extensions.Hosting.slnx
+dotnet build Extensions.Hosting.slnx -c Release -warnaserror
+dotnet test --solution Extensions.Hosting.slnx -c Release
+dotnet test --solution Extensions.Hosting.slnx --coverage --coverage-output-format cobertura
 ```
 
-#### ReactiveMarbles.Extensions.Hosting.PluginService
-```csharp
-await ServiceHost.Create(
-    typeof(Program),
-    args,
-    hb => hb, // Configure the HostBuilder
-    host => {}, // Configure the Host
-    nameSpace: "ReactiveMarbles.Plugin").ConfigureAwait(false);
+Run full builds on Windows because WPF, WinForms, WinUI, Windows service, and .NET Framework target frameworks are part of the solution.

--- a/src/Extensions.Hosting.PluginService.Reactive/Extensions.Hosting.PluginService.Reactive.csproj
+++ b/src/Extensions.Hosting.PluginService.Reactive/Extensions.Hosting.PluginService.Reactive.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462;net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>CP.Extensions.Hosting.PluginService.Reactive</PackageId>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.PluginService\**\*.cs" Exclude="..\Extensions.Hosting.PluginService\bin\**;..\Extensions.Hosting.PluginService\obj\**" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Extensions.Hosting.Plugins.Reactive\Extensions.Hosting.Plugins.Reactive.csproj" />
+    <ProjectReference Include="..\Extensions.Logging.Log4Net\Extensions.Logging.Log4Net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Extensions.Hosting.PluginService/DefaultLogger.cs
+++ b/src/Extensions.Hosting.PluginService/DefaultLogger.cs
@@ -4,7 +4,11 @@
 
 using Microsoft.Extensions.Logging;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.PluginService;
+#endif
 
 /// <summary>Provides a default implementation of a logger that wraps an existing <see cref="ILogger"/> instance.</summary>
 /// <param name="logger">The underlying <see cref="ILogger{DefaultLogger}"/> instance to use for logging operations. Cannot be null.</param>

--- a/src/Extensions.Hosting.PluginService/ServiceBaseLifetime.cs
+++ b/src/Extensions.Hosting.PluginService/ServiceBaseLifetime.cs
@@ -5,7 +5,11 @@
 using System.ServiceProcess;
 using Microsoft.Extensions.Hosting;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.PluginService;
+#endif
 
 /// <summary>Provides an <see cref="IHostLifetime"/> implementation backed by <see cref="ServiceBase"/>.</summary>
 /// <seealso cref="ServiceBase" />

--- a/src/Extensions.Hosting.PluginService/ServiceBaseLifetimeHostExtensions.cs
+++ b/src/Extensions.Hosting.PluginService/ServiceBaseLifetimeHostExtensions.cs
@@ -6,7 +6,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.Internal;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.PluginService;
+#endif
 
 /// <summary>Provides extension methods for configuring host lifetimes to enable running .NET applications as Windows services or with console lifetime support.</summary>
 /// <remarks>These extensions allow integration of service-based or console-based lifetimes into host builders,

--- a/src/Extensions.Hosting.PluginService/ServiceHost.cs
+++ b/src/Extensions.Hosting.PluginService/ServiceHost.cs
@@ -7,10 +7,18 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+#if REACTIVE_SHIM
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
 using ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
 using ReactiveMarbles.Extensions.Logging;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.PluginService;
+#endif
 
 /// <summary>Provides static methods for configuring and running a host or application host with plugin and logging support.</summary>
 /// <remarks>The ServiceHost class simplifies the setup of .NET hosts, including configuration, logging, and

--- a/src/Extensions.Hosting.ReactiveUI.Avalonia.Reactive/Extensions.Hosting.ReactiveUI.Avalonia.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Avalonia.Reactive/Extensions.Hosting.ReactiveUI.Avalonia.Reactive.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Splat" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="ReactiveUI.Avalonia" />
+    <PackageReference Include="ReactiveUI.Avalonia.Reactive" />
     <PackageReference Include="ReactiveUI.Primitives.Reactive" />
   </ItemGroup>
 

--- a/src/Extensions.Hosting.ReactiveUI.Avalonia.Reactive/Extensions.Hosting.ReactiveUI.Avalonia.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Avalonia.Reactive/Extensions.Hosting.ReactiveUI.Avalonia.Reactive.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>CP.Extensions.Hosting.ReactiveUI.Avalonia.Reactive</PackageId>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.ReactiveUI.Avalonia\**\*.cs" Exclude="..\Extensions.Hosting.ReactiveUI.Avalonia\bin\**;..\Extensions.Hosting.ReactiveUI.Avalonia\obj\**" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Extensions.Hosting.Avalonia\Extensions.Hosting.Avalonia.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Splat" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="ReactiveUI.Avalonia" />
+    <PackageReference Include="ReactiveUI.Primitives.Reactive" />
+  </ItemGroup>
+
+</Project>

--- a/src/Extensions.Hosting.ReactiveUI.Avalonia/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Avalonia/HostBuilderReactiveUiExtensions.cs
@@ -3,8 +3,13 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
+#if REACTIVE_SHIM
+using ReactiveUI.Avalonia.Reactive;
+using ReactiveUI.Reactive.Builder;
+#else
 using ReactiveUI.Avalonia;
 using ReactiveUI.Builder;
+#endif
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 

--- a/src/Extensions.Hosting.ReactiveUI.Avalonia/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Avalonia/HostBuilderReactiveUiExtensions.cs
@@ -8,7 +8,11 @@ using ReactiveUI.Builder;
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
 
 /// <summary>Provides extension methods for configuring ReactiveUI with Microsoft dependency injection in .NET host builder scenarios.</summary>
 /// <remarks>These extension methods enable seamless integration of ReactiveUI and Splat with the Microsoft

--- a/src/Extensions.Hosting.ReactiveUI.Maui.Reactive/Extensions.Hosting.ReactiveUI.Maui.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Maui.Reactive/Extensions.Hosting.ReactiveUI.Maui.Reactive.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net11.0;net10.0-android;net11.0-android;net10.0-ios;net10.0-tvos;net10.0-macos;net10.0-maccatalyst;net11.0-ios;net11.0-tvos;net11.0-macos;net11.0-maccatalyst;</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0;net11.0-windows10.0.19041.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseMaui>true</UseMaui>
+    <PackageId>CP.Extensions.Hosting.ReactiveUI.Maui.Reactive</PackageId>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.ReactiveUI.Maui\**\*.cs" Exclude="..\Extensions.Hosting.ReactiveUI.Maui\bin\**;..\Extensions.Hosting.ReactiveUI.Maui\obj\**" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Splat" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="ReactiveUI.Maui" />
+    <PackageReference Include="ReactiveUI.Primitives.Maui.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net10')) ">
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Core" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net11')) ">
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Extensions.Hosting.Maui\Extensions.Hosting.Maui.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Extensions.Hosting.ReactiveUI.Maui.Reactive/Extensions.Hosting.ReactiveUI.Maui.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Maui.Reactive/Extensions.Hosting.ReactiveUI.Maui.Reactive.csproj
@@ -17,8 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Splat" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="ReactiveUI.Maui" />
-    <PackageReference Include="ReactiveUI.Primitives.Maui.Reactive" />
+    <PackageReference Include="ReactiveUI.Maui.Reactive" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net10')) ">

--- a/src/Extensions.Hosting.ReactiveUI.Maui/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Maui/HostBuilderReactiveUiExtensions.cs
@@ -7,7 +7,11 @@ using ReactiveUI.Builder;
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
 
 /// <summary>Provides extension methods for configuring ReactiveUI integration with Microsoft dependency injection in .NET host builders.</summary>
 /// <remarks>These extensions enable seamless setup of ReactiveUI and Splat with Microsoft.Extensions.Hosting and

--- a/src/Extensions.Hosting.ReactiveUI.Maui/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Maui/HostBuilderReactiveUiExtensions.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
+#if REACTIVE_SHIM
+using ReactiveUI.Reactive.Builder;
+#else
 using ReactiveUI.Builder;
+#endif
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 

--- a/src/Extensions.Hosting.ReactiveUI.WinForms.Reactive/Extensions.Hosting.ReactiveUI.WinForms.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms.Reactive/Extensions.Hosting.ReactiveUI.WinForms.Reactive.csproj
@@ -17,9 +17,8 @@
   <ItemGroup>
     <PackageReference Include="Splat" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="ReactiveUI.Drawing" />
-    <PackageReference Include="ReactiveUI.WinForms" />
-    <PackageReference Include="ReactiveUI.Primitives.WinForms.Reactive" />
+    <PackageReference Include="ReactiveUI.Drawing.Reactive" />
+    <PackageReference Include="ReactiveUI.WinForms.Reactive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.WinForms.Reactive/Extensions.Hosting.ReactiveUI.WinForms.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms.Reactive/Extensions.Hosting.ReactiveUI.WinForms.Reactive.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!--ReactiveUI only supports windows 10.0.19041 plus-->
+    <TargetFrameworks>net462;net472;net48;net481;net8.0-windows10.0.19041;net9.0-windows10.0.19041;net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageDescription>This extension adds reactive ReactiveUI support to generic host based WinForms applications.</PackageDescription>
+    <PackageId>CP.Extensions.Hosting.ReactiveUI.WinForms.Reactive</PackageId>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.ReactiveUI.WinForms\**\*.cs" Exclude="..\Extensions.Hosting.ReactiveUI.WinForms\bin\**;..\Extensions.Hosting.ReactiveUI.WinForms\obj\**" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Splat" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="ReactiveUI.Drawing" />
+    <PackageReference Include="ReactiveUI.WinForms" />
+    <PackageReference Include="ReactiveUI.Primitives.WinForms.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Extensions.Hosting.WinForms\Extensions.Hosting.WinForms.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
+#if REACTIVE_SHIM
+using ReactiveUI.Reactive.Builder;
+#else
 using ReactiveUI.Builder;
+#endif
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 

--- a/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
@@ -7,7 +7,11 @@ using ReactiveUI.Builder;
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
 
 /// <summary>Provides extension methods for configuring ReactiveUI with Microsoft dependency injection in .NET host builders.</summary>
 /// <remarks>These extensions enable integration of ReactiveUI's dependency resolution with the

--- a/src/Extensions.Hosting.ReactiveUI.WinUI.Reactive/Extensions.Hosting.ReactiveUI.WinUI.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI.Reactive/Extensions.Hosting.ReactiveUI.WinUI.Reactive.csproj
@@ -19,8 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Splat" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="ReactiveUI.WinUI" />
-    <PackageReference Include="ReactiveUI.Primitives.WinUI.Reactive" />
+    <PackageReference Include="ReactiveUI.WinUI.Reactive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.WinUI.Reactive/Extensions.Hosting.ReactiveUI.WinUI.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI.Reactive/Extensions.Hosting.ReactiveUI.WinUI.Reactive.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!--ReactiveUI only supports windows 10.0.19041 plus-->
+    <TargetFrameworks>net8.0-windows10.0.19041;net9.0-windows10.0.19041;net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+    <PackageDescription>This extension adds reactive ReactiveUI support to generic host based WinUI applications.</PackageDescription>
+    <PackageId>CP.Extensions.Hosting.ReactiveUI.WinUI.Reactive</PackageId>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.ReactiveUI.WinUI\**\*.cs" Exclude="..\Extensions.Hosting.ReactiveUI.WinUI\bin\**;..\Extensions.Hosting.ReactiveUI.WinUI\obj\**" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Splat" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="ReactiveUI.WinUI" />
+    <PackageReference Include="ReactiveUI.Primitives.WinUI.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Extensions.Hosting.WinUI\Extensions.Hosting.WinUI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
@@ -7,7 +7,11 @@ using ReactiveUI.Builder;
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
 
 /// <summary>Provides extension methods for configuring ReactiveUI integration with Microsoft dependency injection in .NET host builders.</summary>
 /// <remarks>These extensions enable seamless setup of ReactiveUI and Splat with Microsoft.Extensions.Hosting and

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
@@ -4,6 +4,10 @@
 
 using Microsoft.Extensions.Hosting;
 using ReactiveUI.Builder;
+
+#if REACTIVE_SHIM
+using ReactiveUI.Reactive.Builder;
+#endif
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 

--- a/src/Extensions.Hosting.ReactiveUI.Wpf.Reactive/Extensions.Hosting.ReactiveUI.Wpf.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf.Reactive/Extensions.Hosting.ReactiveUI.Wpf.Reactive.csproj
@@ -17,9 +17,8 @@
   <ItemGroup>
     <PackageReference Include="Splat" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="ReactiveUI.Drawing" />
-    <PackageReference Include="ReactiveUI.WPF" />
-    <PackageReference Include="ReactiveUI.Primitives.Wpf.Reactive" />
+    <PackageReference Include="ReactiveUI.Drawing.Reactive" />
+    <PackageReference Include="ReactiveUI.WPF.Reactive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.Wpf.Reactive/Extensions.Hosting.ReactiveUI.Wpf.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf.Reactive/Extensions.Hosting.ReactiveUI.Wpf.Reactive.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!--ReactiveUI only supports windows 10.0.19041 plus-->
+    <TargetFrameworks>net462;net472;net48;net481;net8.0-windows10.0.19041;net9.0-windows10.0.19041;net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageDescription>This extension adds reactive ReactiveUI support to generic host based WPF applications.</PackageDescription>
+    <PackageId>CP.Extensions.Hosting.ReactiveUI.Wpf.Reactive</PackageId>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.ReactiveUI.Wpf\**\*.cs" Exclude="..\Extensions.Hosting.ReactiveUI.Wpf\bin\**;..\Extensions.Hosting.ReactiveUI.Wpf\obj\**" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Splat" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="ReactiveUI.Drawing" />
+    <PackageReference Include="ReactiveUI.WPF" />
+    <PackageReference Include="ReactiveUI.Primitives.Wpf.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Extensions.Hosting.Wpf\Extensions.Hosting.Wpf.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
+#if REACTIVE_SHIM
+using ReactiveUI.Reactive.Builder;
+#else
 using ReactiveUI.Builder;
+#endif
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
@@ -7,7 +7,11 @@ using ReactiveUI.Builder;
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
 namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
 
 /// <summary>Provides extension methods for configuring ReactiveUI with Microsoft dependency injection in .NET host builder scenarios.</summary>
 /// <remarks>These extension methods enable seamless integration of ReactiveUI and Splat with the Microsoft

--- a/src/Extensions.Hosting.slnx
+++ b/src/Extensions.Hosting.slnx
@@ -33,11 +33,17 @@
   <Project Path="Extensions.Hosting.Plugins/Extensions.Hosting.Plugins.csproj" />
   <Project Path="Extensions.Hosting.Plugins.Reactive/Extensions.Hosting.Plugins.Reactive.csproj" />
   <Project Path="Extensions.Hosting.PluginService/Extensions.Hosting.PluginService.csproj" />
+  <Project Path="Extensions.Hosting.PluginService.Reactive/Extensions.Hosting.PluginService.Reactive.csproj" />
   <Project Path="Extensions.Hosting.ReactiveUI.Avalonia/Extensions.Hosting.ReactiveUI.Avalonia.csproj" Id="711b6a7d-e7b8-4903-9015-43116783fc45" />
+  <Project Path="Extensions.Hosting.ReactiveUI.Avalonia.Reactive/Extensions.Hosting.ReactiveUI.Avalonia.Reactive.csproj" />
   <Project Path="Extensions.Hosting.ReactiveUI.Maui/Extensions.Hosting.ReactiveUI.Maui.csproj" />
+  <Project Path="Extensions.Hosting.ReactiveUI.Maui.Reactive/Extensions.Hosting.ReactiveUI.Maui.Reactive.csproj" />
   <Project Path="Extensions.Hosting.ReactiveUI.WinForms/Extensions.Hosting.ReactiveUI.WinForms.csproj" />
+  <Project Path="Extensions.Hosting.ReactiveUI.WinForms.Reactive/Extensions.Hosting.ReactiveUI.WinForms.Reactive.csproj" />
   <Project Path="Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj" />
+  <Project Path="Extensions.Hosting.ReactiveUI.WinUI.Reactive/Extensions.Hosting.ReactiveUI.WinUI.Reactive.csproj" />
   <Project Path="Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj" />
+  <Project Path="Extensions.Hosting.ReactiveUI.Wpf.Reactive/Extensions.Hosting.ReactiveUI.Wpf.Reactive.csproj" />
   <Project Path="Extensions.Hosting.SingleInstance/Extensions.Hosting.SingleInstance.csproj" />
   <Project Path="Extensions.Hosting.WinForms/Extensions.Hosting.WinForms.csproj" />
   <Project Path="Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj" />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the missing `.Reactive` sibling projects for the ReactiveUI platform integration packages and PluginService.

## What is the new behavior?

- Adds linked-source `.Reactive` projects for ReactiveUI Avalonia, MAUI, WinForms, WinUI, and WPF integration packages.
- Adds `Extensions.Hosting.PluginService.Reactive` so PluginService can bind to `Extensions.Hosting.Plugins.Reactive` and expose the reactive plugin namespace.
- Uses `REACTIVE_SHIM` conditional namespaces so shared source compiles as either the original package surface or `ReactiveMarbles.Extensions.Hosting.Reactive.*`.
- Adds central package versions for the required `ReactiveUI.Primitives.*.Reactive` platform packages.

## What is the current behavior?

Only `Extensions.Hosting.Plugins.Reactive` exists. The ReactiveUI platform integration projects and PluginService still only have non-reactive package surfaces.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

PR #258 had already been merged and its branch deleted, so this follow-up is on `CP_add-reactive-platform-shims`.

Validation performed locally:

- `dotnet restore Extensions.Hosting.slnx`
- `dotnet build Extensions.Hosting.slnx -c Release -warnaserror --no-restore /m:1 '/clp:ErrorsOnly;Summary'`
- `dotnet test --solution Extensions.Hosting.slnx -c Release --coverage --coverage-output-format cobertura --results-directory .\TestResults -- --output Detailed`

MTP coverage summary remains 100.00% line coverage for the configured covered `Extensions.Hosting.*` modules.

GitHub CI: `BuildOnly / windows-latest` passed on commit `328e3e5`.