### PR TITLE
fix(build): skip symbols packages during NuGet publish

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -411,8 +411,29 @@ jobs:
       - name: Push to NuGet
         shell: bash
         run: |
-          for pkg in ./signed/*.nupkg; do
-            dotnet nuget push "$pkg" --source https://api.nuget.org/v3/index.json --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
+          set -euo pipefail
+          shopt -s nullglob
+
+          packages=(./signed/*.nupkg)
+          push_packages=()
+          for pkg in "${packages[@]}"; do
+            case "$pkg" in
+              *.symbols.nupkg)
+                echo "Skipping legacy symbols package: $pkg"
+                ;;
+              *)
+                push_packages+=("$pkg")
+                ;;
+            esac
+          done
+
+          [ "${#push_packages[@]}" -gt 0 ] || { echo "::error::no publishable packages matched: ./signed/*.nupkg"; exit 1; }
+
+          for pkg in "${push_packages[@]}"; do
+            dotnet nuget push "$pkg" \
+              --source https://api.nuget.org/v3/index.json \
+              --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+              --skip-duplicate
           done
 
   create-release:

--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -225,7 +225,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: unsigned-nuget
-          path: packages/*.nupkg
+          path: |
+            packages/*.nupkg
+            !packages/*.symbols.nupkg
           if-no-files-found: error
 
   sign:
@@ -382,7 +384,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: signed-nuget
-          path: signed/*.nupkg
+          path: |
+            signed/*.nupkg
+            !signed/*.symbols.nupkg
           if-no-files-found: error
 
   publish-nuget:
@@ -415,21 +419,9 @@ jobs:
           shopt -s nullglob
 
           packages=(./signed/*.nupkg)
-          push_packages=()
+          [ "${#packages[@]}" -gt 0 ] || { echo "::error::no publishable packages matched: ./signed/*.nupkg"; exit 1; }
+
           for pkg in "${packages[@]}"; do
-            case "$pkg" in
-              *.symbols.nupkg)
-                echo "Skipping legacy symbols package: $pkg"
-                ;;
-              *)
-                push_packages+=("$pkg")
-                ;;
-            esac
-          done
-
-          [ "${#push_packages[@]}" -gt 0 ] || { echo "::error::no publishable packages matched: ./signed/*.nupkg"; exit 1; }
-
-          for pkg in "${push_packages[@]}"; do
             dotnet nuget push "$pkg" \
               --source https://api.nuget.org/v3/index.json \
               --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,7 +25,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>
-    <IncludeSymbols>true</IncludeSymbols>
 
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI/release workflow bug fix for NuGet package publishing and release artifact preparation.

## What is the new behavior?

`Directory.Build.props` no longer requests legacy `*.symbols.nupkg` generation for every package. The release workflow also excludes `*.symbols.nupkg` from the unsigned and signed NuGet artifacts before the signing job and before release/publish handoff.

The NuGet publish job now receives only primary signed `.nupkg` packages and still uses `--skip-duplicate` so reruns continue when a prior attempt already published one or more packages.

## What is the current behavior?

The release pack step generated legacy `.symbols.nupkg` packages because the shared props set `IncludeSymbols=true` without a shared `SymbolPackageFormat`. The original signing job downloaded all `packages/*.nupkg` artifacts and signed every `signed/*.nupkg`, including legacy symbols packages. The publish job then attempted to push those symbols packages as normal packages, causing NuGet HTTP 409 duplicate ID/version failures after the primary package had already been published.

## Checklist

- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Failed run: https://github.com/reactivemarbles/Extensions.Hosting/actions/runs/29130836781/job/86549119186

Validation:
- Packed `Extensions.Hosting.Avalonia` for `net8.0` and confirmed only the primary `.nupkg` was produced.
- Checked effective MSBuild properties for `IncludeSymbols`, `SymbolPackageFormat`, `DebugType`, and `EmbedUntrackedSources`.
- Simulated the publish package selection with primary and symbols packages.
- Ran `git diff --check`.