### PR TITLE
feat!: release Extensions.Hosting 4.0 lifecycle and reactive hosting updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 # Default settings
 #############################################
 [*]
+end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
@@ -182,170 +183,161 @@ csharp_space_between_square_brackets = false
 dotnet_diagnostic.AvoidAsyncVoid.severity = suggestion
 
 ###################
-# Microsoft .NET Analyzers (CA) - Design Rules
+# Microsoft.CodeAnalysis.NetAnalyzers (CA)
 ###################
+# Design
 dotnet_diagnostic.CA1000.severity = none # Do not declare static members on generic types — common factory pattern
 dotnet_diagnostic.CA1001.severity = error # Types that own disposable fields should be disposable
 dotnet_diagnostic.CA1002.severity = none # Do not expose generic lists — we deliberately expose List<T>; interface-based collections are an older convention we don't follow
-dotnet_diagnostic.CA1003.severity = error # Use generic event handler instances
+dotnet_diagnostic.CA1003.severity = none # Use generic event handler instances — covered by SST2304
 dotnet_diagnostic.CA1005.severity = none # Avoid excessive parameters on generic types — we deliberately expose 3+ type-parameter types (tuple-style handles, raw engine signals); the ergonomic guidance conflicts with that design
 dotnet_diagnostic.CA1008.severity = error # Enums should have zero value
 dotnet_diagnostic.CA1010.severity = none # Collections should implement generic interface — we deliberately expose concrete collection types; interface-based collections are an older convention we don't follow
-dotnet_diagnostic.CA1012.severity = error # Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = none # Abstract types should not have public constructors — covered by SST1428
 dotnet_diagnostic.CA1014.severity = none # Mark assemblies with CLSCompliantAttribute — we don't ship CLS-compliant assemblies
 dotnet_diagnostic.CA1016.severity = error # Mark assemblies with AssemblyVersionAttribute
 dotnet_diagnostic.CA1017.severity = none # Mark assemblies with ComVisibleAttribute — we don't ship COM-visible assemblies
 dotnet_diagnostic.CA1018.severity = error # Mark attributes with AttributeUsageAttribute
-dotnet_diagnostic.CA1019.severity = error # Define accessors for attribute arguments
+dotnet_diagnostic.CA1019.severity = none # Define accessors for attribute arguments — conflicts with SST2324, which caps an internal attribute's accessor at internal
 dotnet_diagnostic.CA1021.severity = none # Avoid out parameters - disabled - needed for the zero-allocation idiom in Try/Find APIs and other performance-critical paths
 dotnet_diagnostic.CA1024.severity = error # Use properties where appropriate
 dotnet_diagnostic.CA1027.severity = error # Mark enums with FlagsAttribute
-dotnet_diagnostic.CA1028.severity = error # Enum storage should be Int32
+dotnet_diagnostic.CA1028.severity = none # Enum storage should be Int32 — covered by SST2313
 dotnet_diagnostic.CA1030.severity = none # Use events where appropriate — we use Rx observables instead of CLR events
 dotnet_diagnostic.CA1031.severity = none # Do not catch general exception types — required at logging/dispose/IO boundaries
-dotnet_diagnostic.CA1032.severity = error # Implement standard exception constructors
+dotnet_diagnostic.CA1032.severity = none # Implement standard exception constructors — covered by SST1488
 dotnet_diagnostic.CA1033.severity = none # Interface methods should be callable by child types — explicit interface implementations are a deliberate design choice
 dotnet_diagnostic.CA1034.severity = none # Nested types should not be visible — public nested types are sometimes the cleanest API (e.g. interface-scoped exception helpers)
 dotnet_diagnostic.CA1036.severity = none # Override methods on comparable types — relational operators rarely meaningful for our types
 dotnet_diagnostic.CA1040.severity = none # Avoid empty interfaces — duplicate of SST1437 (canonical); marker interfaces (IActivatableView etc.) are deliberate public API
-dotnet_diagnostic.CA1041.severity = error # Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1041.severity = none # Provide ObsoleteAttribute message — covered by SST2308
 dotnet_diagnostic.CA1043.severity = error # Use integral or string argument for indexers
-dotnet_diagnostic.CA1044.severity = error # Properties should not be write only
+dotnet_diagnostic.CA1044.severity = none # Properties should not be write only — covered by SST1421
 dotnet_diagnostic.CA1045.severity = none # Do not pass types by reference — we deliberately use ref-passing static helpers so they carry only the data they touch; data-oriented layout is the default here
 dotnet_diagnostic.CA1046.severity = error # Do not overload operator equals on reference types
-dotnet_diagnostic.CA1047.severity = error # Do not declare protected member in sealed type
-dotnet_diagnostic.CA1048.severity = error # Do not declare virtual members in sealed types
-dotnet_diagnostic.CA1050.severity = error # Declare types in namespaces
+dotnet_diagnostic.CA1047.severity = none # Do not declare protected member in sealed type — covered by SST1427
+dotnet_diagnostic.CA1048.severity = none # Do not declare virtual members in sealed types — covered by SST1491
+dotnet_diagnostic.CA1050.severity = none # Declare types in namespaces — covered by SST2312
 dotnet_diagnostic.CA1051.severity = none # Duplicate of SST1401 (canonical) — do not declare visible instance fields
-dotnet_diagnostic.CA1052.severity = error # Static holder types should be sealed
-dotnet_diagnostic.CA1053.severity = error # Static holder types should not have constructors
+dotnet_diagnostic.CA1052.severity = none # Static holder types should be sealed — covered by SST1432
+dotnet_diagnostic.CA1053.severity = none # Static holder types should not have constructors — covered by SST1432
 dotnet_diagnostic.CA1054.severity = suggestion # URI parameters should not be strings
 dotnet_diagnostic.CA1055.severity = suggestion # URI return values should not be strings
 dotnet_diagnostic.CA1056.severity = suggestion # URI properties should not be strings
 dotnet_diagnostic.CA1058.severity = error # Types should not extend certain base types
 dotnet_diagnostic.CA1059.severity = error # Members should not expose certain concrete types
 dotnet_diagnostic.CA1060.severity = error # Move P/Invokes to NativeMethods class
-dotnet_diagnostic.CA1061.severity = error # Do not hide base class methods
+dotnet_diagnostic.CA1061.severity = none # Do not hide base class methods — covered by SST2427
 dotnet_diagnostic.CA1062.severity = none # Validate arguments of public methods - Nullable=enable + we own every consumer, so the compiler already guarantees non-null params
-dotnet_diagnostic.CA1063.severity = error # Implement IDisposable correctly
+dotnet_diagnostic.CA1063.severity = none # Implement IDisposable correctly — covered by SST2300
 dotnet_diagnostic.CA1064.severity = error # Exceptions should be public
-dotnet_diagnostic.CA1065.severity = error # Do not raise exceptions in unexpected locations
+dotnet_diagnostic.CA1065.severity = none # Do not raise exceptions in unexpected locations — covered by SST1485
 dotnet_diagnostic.CA1066.severity = error # Implement IEquatable when overriding Equals
 dotnet_diagnostic.CA1067.severity = error # Override Equals when implementing IEquatable
 dotnet_diagnostic.CA1068.severity = error # CancellationToken parameters must come last
 dotnet_diagnostic.CA1069.severity = error # Enums should not have duplicate values
 dotnet_diagnostic.CA1070.severity = error # Do not declare event fields as virtual
 
-###################
-# Microsoft .NET Analyzers (CA) - Globalization Rules
-###################
+# Globalization
 dotnet_diagnostic.CA1303.severity = none # Do not pass literals as localized parameters — we don't ship localized resources
+dotnet_diagnostic.CA1307.severity = none # Covered by PSH1207 (canonical)
 dotnet_diagnostic.CA1308.severity = none # Normalize strings to uppercase — ToLowerInvariant is correct for filesystem path / cache key normalization
+dotnet_diagnostic.CA1310.severity = none # Covered by PSH1207 (canonical)
 
-###################
-# Microsoft .NET Analyzers (CA) - Interoperability Rules
-###################
+# Interoperability
 dotnet_diagnostic.CA1401.severity = error # P/Invokes should not be visible
 
-###################
-# Microsoft .NET Analyzers (CA) - Maintainability Rules
-###################
-dotnet_diagnostic.CA1500.severity = error # Variable names should not match field names
-dotnet_diagnostic.CA1501.severity = none # Avoid excessive inheritance — disabled because the analyzer noticeably slows down the build
-dotnet_diagnostic.CA1502.severity = none # Avoid excessive complexity — disabled because the analyzer noticeably slows down the build
+# Maintainability
+dotnet_diagnostic.CA1500.severity = none # Variable names should not match field names — covered by SST1484
+dotnet_diagnostic.CA1501.severity = none # Covered by SST1446 (canonical)
+dotnet_diagnostic.CA1502.severity = none # Covered by SST1442 (canonical)
 dotnet_diagnostic.CA1505.severity = error # Avoid unmaintainable code
 dotnet_diagnostic.CA1506.severity = none # Avoid excessive class coupling — adds little signal here, mostly trips on legitimate orchestration code
-dotnet_diagnostic.CA1507.severity = error # Use nameof in place of string
+dotnet_diagnostic.CA1507.severity = none # Use nameof in place of string — covered by SST1463
 dotnet_diagnostic.CA1508.severity = error # Avoid dead conditional code
 dotnet_diagnostic.CA1509.severity = error # Invalid entry in code metrics configuration file
-dotnet_diagnostic.CA1510.severity = none # Use ArgumentNullException throw helper — disabled because we target older TFMs and use ArgumentExceptionHelper for cross-platform parity
-dotnet_diagnostic.CA1511.severity = none # Use ArgumentException throw helper — disabled because we target older TFMs and use ArgumentExceptionHelper for cross-platform parity
-dotnet_diagnostic.CA1512.severity = none # Use ArgumentOutOfRangeException throw helper — disabled because we target older TFMs and use ArgumentExceptionHelper for cross-platform parity
-dotnet_diagnostic.CA1513.severity = none # Use ObjectDisposedException throw helper — disabled because we target older TFMs and use ArgumentExceptionHelper for cross-platform parity
-dotnet_diagnostic.CA1514.severity = error # Avoid redundant length argument
+dotnet_diagnostic.CA1510.severity = none # Covered by PSH1409 (canonical)
+dotnet_diagnostic.CA1511.severity = none # Covered by PSH1409 (canonical)
+dotnet_diagnostic.CA1512.severity = none # Covered by PSH1409 (canonical)
+dotnet_diagnostic.CA1513.severity = none # Covered by PSH1409 (canonical)
+dotnet_diagnostic.CA1514.severity = none # Avoid redundant length argument — covered by PSH1220
 dotnet_diagnostic.CA1515.severity = none # Consider making public types internal — interferes with tests and reflection-discovered types (BenchmarkDotNet, TUnit, etc.)
 dotnet_diagnostic.CA1516.severity = error # Use cross-platform intrinsics
 
-###################
-# Microsoft .NET Analyzers (CA) - Naming Rules
-###################
+# Naming
 dotnet_diagnostic.CA1710.severity = suggestion # Identifiers should have correct suffix
 dotnet_diagnostic.CA1724.severity = none # Type Names Should Not Match Namespaces — namespace/type name overlap is intentional API surface
 
-###################
-# Microsoft .NET Analyzers (CA) - Performance Rules
-###################
-dotnet_diagnostic.CA1802.severity = error # Use literals where appropriate
-dotnet_diagnostic.CA1805.severity = error # Do not initialize unnecessarily
+# Performance
+dotnet_diagnostic.CA1802.severity = none # Use literals where appropriate — covered by PSH1402
+dotnet_diagnostic.CA1805.severity = none # Do not initialize unnecessarily — covered by PSH1403
 dotnet_diagnostic.CA1806.severity = error # Do not ignore method results
 dotnet_diagnostic.CA1810.severity = none # Initialize reference type static fields inline — explicit static constructors are deliberate in some types
 dotnet_diagnostic.CA1812.severity = error # Avoid uninstantiated internal classes
-dotnet_diagnostic.CA1813.severity = error # Avoid unsealed attributes
-dotnet_diagnostic.CA1814.severity = error # Prefer jagged arrays over multidimensional
-dotnet_diagnostic.CA1815.severity = error # Override equals and operator equals on value types
+dotnet_diagnostic.CA1813.severity = none # Avoid unsealed attributes — covered by PSH1401
+dotnet_diagnostic.CA1814.severity = none # Prefer jagged arrays over multidimensional — covered by PSH1020
+dotnet_diagnostic.CA1815.severity = none # Override equals and operator equals on value types — covered by PSH1005
 dotnet_diagnostic.CA1819.severity = none # Properties should not return arrays — incompatible with the RxUI/sqlite-net mapping style we use throughout the codebase
-dotnet_diagnostic.CA1820.severity = error # Test for empty strings using string length
-dotnet_diagnostic.CA1821.severity = error # Remove empty finalizers
-dotnet_diagnostic.CA1822.severity = error # Mark members as static
-dotnet_diagnostic.CA1823.severity = error # Avoid unused private fields
+dotnet_diagnostic.CA1820.severity = none # Test for empty strings using string length — covered by PSH1204
+dotnet_diagnostic.CA1821.severity = none # Remove empty finalizers — covered by PSH1002
+dotnet_diagnostic.CA1822.severity = none # Mark members as static — covered by PSH1414
+dotnet_diagnostic.CA1823.severity = none # Avoid unused private fields — covered by SST1441
 dotnet_diagnostic.CA1824.severity = error # Mark assemblies with NeutralResourcesLanguageAttribute
-dotnet_diagnostic.CA1825.severity = error # Avoid zero-length array allocations
-dotnet_diagnostic.CA1826.severity = error # Use property instead of Linq Enumerable method
-dotnet_diagnostic.CA1827.severity = error # Do not use Count/LongCount when Any can be used
-dotnet_diagnostic.CA1828.severity = error # Do not use CountAsync/LongCountAsync when AnyAsync can be used
-dotnet_diagnostic.CA1829.severity = error # Use Length/Count property instead of Enumerable.Count method
-dotnet_diagnostic.CA1830.severity = error # Prefer strongly-typed Append and Insert method overloads on StringBuilder
-dotnet_diagnostic.CA1831.severity = error # Use AsSpan instead of Range-based indexers for string when appropriate
-dotnet_diagnostic.CA1832.severity = error # Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array
-dotnet_diagnostic.CA1833.severity = error # Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array
-dotnet_diagnostic.CA1834.severity = error # Use StringBuilder.Append(char) for single character strings
-dotnet_diagnostic.CA1835.severity = error # Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes
-dotnet_diagnostic.CA1836.severity = error # Prefer IsEmpty over Count when available
-dotnet_diagnostic.CA1837.severity = error # Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
+dotnet_diagnostic.CA1825.severity = none # Avoid zero-length array allocations — covered by PSH1001
+dotnet_diagnostic.CA1826.severity = none # Use property instead of Linq Enumerable method — covered by PSH1103
+dotnet_diagnostic.CA1827.severity = none # Do not use Count/LongCount when Any can be used — covered by PSH1119
+dotnet_diagnostic.CA1828.severity = none # Do not use CountAsync/LongCountAsync when AnyAsync can be used — covered by PSH1126
+dotnet_diagnostic.CA1829.severity = none # Use Length/Count property instead of Enumerable.Count — covered by PSH1103
+dotnet_diagnostic.CA1830.severity = none # Prefer strongly-typed Append/Insert overloads on StringBuilder — covered by PSH1202
+dotnet_diagnostic.CA1831.severity = none # Use AsSpan instead of Range-based indexers for string — covered by PSH1212
+dotnet_diagnostic.CA1832.severity = none # Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array — covered by PSH1019
+dotnet_diagnostic.CA1833.severity = none # Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array — conflicts with PSH1019, which owns the array range-indexer rewrite and refuses it for mutable Span/Memory targets
+dotnet_diagnostic.CA1834.severity = none # Use StringBuilder.Append(char) for single character strings — covered by PSH1202
+dotnet_diagnostic.CA1835.severity = none # Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes — covered by PSH1314
+dotnet_diagnostic.CA1836.severity = none # Prefer IsEmpty over Count when available — covered by PSH1117
+dotnet_diagnostic.CA1837.severity = none # Use Environment.ProcessId — covered by PSH1405
 dotnet_diagnostic.CA1838.severity = error # Avoid StringBuilder parameters for P/Invokes
-dotnet_diagnostic.CA1839.severity = error # Use Environment.ProcessPath instead of Process.GetCurrentProcess().MainModule.FileName
-dotnet_diagnostic.CA1840.severity = error # Use Environment.CurrentManagedThreadId instead of Thread.CurrentThread.ManagedThreadId
-dotnet_diagnostic.CA1841.severity = error # Prefer Dictionary.Contains methods
-dotnet_diagnostic.CA1842.severity = error # Do not use 'WhenAll' with a single task
-dotnet_diagnostic.CA1843.severity = error # Do not use 'WaitAll' with a single task
+dotnet_diagnostic.CA1839.severity = none # Use Environment.ProcessPath — covered by PSH1405
+dotnet_diagnostic.CA1840.severity = none # Use Environment.CurrentManagedThreadId — covered by PSH1405
+dotnet_diagnostic.CA1841.severity = none # Prefer Dictionary.Contains methods — covered by PSH1407
+dotnet_diagnostic.CA1842.severity = none # Do not use 'WhenAll' with a single task — covered by PSH1301
+dotnet_diagnostic.CA1843.severity = none # Do not use 'WaitAll' with a single task — covered by PSH1301
 dotnet_diagnostic.CA1844.severity = error # Provide memory-based overrides of async methods when subclassing 'Stream'
-dotnet_diagnostic.CA1845.severity = error # Use span-based 'string.Concat'
-dotnet_diagnostic.CA1846.severity = error # Prefer AsSpan over Substring
-dotnet_diagnostic.CA1847.severity = none # Use char literal for a single character lookup — disabled because the string.Contains(char) overload doesn't exist on .NET Framework / netstandard2.0 and we target both
+dotnet_diagnostic.CA1845.severity = none # Use span-based 'string.Concat' — covered by PSH1222
+dotnet_diagnostic.CA1846.severity = none # Prefer AsSpan over Substring — covered by PSH1212
+dotnet_diagnostic.CA1847.severity = none # Covered by PSH1201 (canonical)
 dotnet_diagnostic.CA1848.severity = error # Use the LoggerMessage delegates
-dotnet_diagnostic.CA1849.severity = error # Call async methods when in an async method
-dotnet_diagnostic.CA1850.severity = error # Prefer static HashData method over ComputeHash
+dotnet_diagnostic.CA1849.severity = none # Call async methods when in an async method — covered by PSH1313
+dotnet_diagnostic.CA1850.severity = none # Prefer static HashData method over ComputeHash — covered by PSH1400
 dotnet_diagnostic.CA1851.severity = error # Possible multiple enumerations of IEnumerable collection
-dotnet_diagnostic.CA1852.severity = error # Seal internal types
+dotnet_diagnostic.CA1852.severity = none # Seal internal types — covered by PSH1411
 dotnet_code_quality.CA1852.api_surface = private, internal # only flag non-public classes; public classes stay open for inheritance
-dotnet_diagnostic.CA1853.severity = error # Unnecessary call to 'Dictionary.ContainsKey(key)'
-dotnet_diagnostic.CA1854.severity = error # Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+dotnet_diagnostic.CA1853.severity = none # Unnecessary call to 'Dictionary.ContainsKey(key)' — covered by PSH1105
+dotnet_diagnostic.CA1854.severity = none # Prefer the IDictionary.TryGetValue method — covered by PSH1104
 dotnet_diagnostic.CA1855.severity = error # Prefer 'Clear' over 'Fill'
 dotnet_diagnostic.CA1856.severity = error # Incorrect usage of ConstantExpected attribute
 dotnet_diagnostic.CA1857.severity = error # A constant is expected for the parameter
-dotnet_diagnostic.CA1858.severity = error # Use 'StartsWith' instead of 'IndexOf'
+dotnet_diagnostic.CA1858.severity = none # Use 'StartsWith' instead of 'IndexOf' — covered by PSH1221
 dotnet_diagnostic.CA1859.severity = error # Use concrete types when possible for improved performance
-dotnet_diagnostic.CA1860.severity = error # Avoid using 'Enumerable.Any()' extension method
-dotnet_diagnostic.CA1861.severity = error # Avoid constant arrays as arguments
-dotnet_diagnostic.CA1862.severity = error # Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
-dotnet_diagnostic.CA1863.severity = error # Use 'CompositeFormat'
-dotnet_diagnostic.CA1864.severity = error # Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
-dotnet_diagnostic.CA1865.severity = none # Use char overload (string.StartsWith) — disabled because the string.StartsWith(char) overload doesn't exist on .NET Framework / netstandard2.0 and we target both
-dotnet_diagnostic.CA1866.severity = none # Use char overload (string.EndsWith) — disabled because the string.EndsWith(char) overload doesn't exist on .NET Framework / netstandard2.0 and we target both
-dotnet_diagnostic.CA1867.severity = none # Use char overload (string.IndexOf / string.LastIndexOf) — disabled because the char overloads don't exist on .NET Framework / netstandard2.0 and we target both
-dotnet_diagnostic.CA1868.severity = error # Unnecessary call to 'Contains' for sets
-dotnet_diagnostic.CA1869.severity = error # Cache and reuse 'JsonSerializerOptions' instances
-dotnet_diagnostic.CA1870.severity = error # Use a cached 'SearchValues' instance
+dotnet_diagnostic.CA1860.severity = none # Avoid using 'Enumerable.Any()' extension method — covered by PSH1103
+dotnet_diagnostic.CA1861.severity = none # Avoid constant arrays as arguments — covered by PSH1004
+dotnet_diagnostic.CA1862.severity = none # Use the 'StringComparison' overloads for case-insensitive comparisons — covered by PSH1200
+dotnet_diagnostic.CA1863.severity = none # Use 'CompositeFormat' — covered by PSH1223
+dotnet_diagnostic.CA1864.severity = none # Prefer the 'IDictionary.TryAdd' method — covered by PSH1115
+dotnet_diagnostic.CA1865.severity = none # Covered by PSH1201 (canonical)
+dotnet_diagnostic.CA1866.severity = none # Covered by PSH1201 (canonical)
+dotnet_diagnostic.CA1867.severity = none # Covered by PSH1201 (canonical)
+dotnet_diagnostic.CA1868.severity = none # Unnecessary call to 'Contains' for sets — covered by PSH1105
+dotnet_diagnostic.CA1869.severity = none # Cache and reuse 'JsonSerializerOptions' instances — covered by PSH1416
+dotnet_diagnostic.CA1870.severity = none # Use a cached 'SearchValues' instance — covered by PSH1213
 dotnet_diagnostic.CA1871.severity = error # Do not pass a nullable struct to 'ArgumentNullException.ThrowIfNull'
-dotnet_diagnostic.CA1872.severity = error # Prefer 'Convert.ToHexString' and 'Convert.ToHexStringLower' over call chains based on 'BitConverter.ToString'
-dotnet_diagnostic.CA1873.severity = error # Avoid potentially expensive evaluation of arguments to 'Debug.Assert'
-dotnet_diagnostic.CA1874.severity = error # Use 'Regex.IsMatch'
-dotnet_diagnostic.CA1875.severity = error # Use 'Regex.Count'
-dotnet_diagnostic.CA1877.severity = error # Use 'Encoding.GetString' instead of 'Encoding.GetChars'
+dotnet_diagnostic.CA1872.severity = none # Prefer 'Convert.ToHexString' and 'Convert.ToHexStringLower' over call chains based on 'BitConverter.ToString' — covered by PSH1224
+dotnet_diagnostic.CA1873.severity = none # Avoid potentially expensive evaluation of arguments to 'Debug.Assert' — covered by PSH1417
+dotnet_diagnostic.CA1874.severity = none # Use 'Regex.IsMatch' — covered by PSH1406
+dotnet_diagnostic.CA1875.severity = none # Use 'Regex.Count' — covered by PSH1406
+dotnet_diagnostic.CA1877.severity = none # Use 'Encoding.GetString' instead of 'Encoding.GetChars' — covered by PSH1225
 
-###################
-# Microsoft .NET Analyzers (CA) - Reliability Rules
-###################
+# Reliability
 dotnet_diagnostic.CA2000.severity = suggestion # Dispose objects before losing scope
 dotnet_diagnostic.CA2002.severity = error # Do not lock on objects with weak identity
 dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task — Rx and library callers drive synchronization context themselves
@@ -368,41 +360,39 @@ dotnet_diagnostic.CA2024.severity = error # Do not use 'StreamReader.EndOfStream
 dotnet_diagnostic.CA2025.severity = error # Do not pass 'IDisposable' instances into unawaited tasks
 dotnet_diagnostic.CA2026.severity = error # Do not use methods or types annotated with [RequiresDynamicCode] in code that uses [RequiresDynamicCode]
 
-###################
-# Microsoft .NET Analyzers (CA) - Usage Rules
-###################
+# Usage
 dotnet_diagnostic.CA1801.severity = error # Review unused parameters
 dotnet_code_quality.CA1801.api_surface = private, internal # only flag non-public APIs so we don't break public signatures
 dotnet_diagnostic.CA1816.severity = error # Call GC.SuppressFinalize correctly
-dotnet_diagnostic.CA2200.severity = error # Rethrow to preserve stack details
+dotnet_diagnostic.CA2200.severity = none # Rethrow to preserve stack details — covered by SST1430
 dotnet_diagnostic.CA2201.severity = error # Do not raise reserved exception types
 dotnet_diagnostic.CA2207.severity = error # Initialize value type static fields inline
 dotnet_diagnostic.CA2208.severity = none # Instantiate argument exceptions correctly — too sensitive: flags valid context-forwarding nameof(arg.Property) patterns
-dotnet_diagnostic.CA2211.severity = error # Non-constant fields should not be visible
+dotnet_diagnostic.CA2211.severity = none # Non-constant fields should not be visible — covered by SST1499
 dotnet_diagnostic.CA2213.severity = error # Disposable fields should be disposed
-dotnet_diagnostic.CA2214.severity = error # Do not call overridable methods in constructors
+dotnet_diagnostic.CA2214.severity = none # Do not call overridable methods in constructors — covered by SST1483
 dotnet_diagnostic.CA2215.severity = error # Dispose methods should call base class dispose
-dotnet_diagnostic.CA2216.severity = error # Disposable types should declare finalizer
-dotnet_diagnostic.CA2217.severity = error # Do not mark enums with FlagsAttribute
+dotnet_diagnostic.CA2216.severity = none # Disposable types should declare finalizer — conflicts with SST2317, which owns the owned-native-handle shape and prescribes a SafeHandle instead of a finalizer
+dotnet_diagnostic.CA2217.severity = none # Do not mark enums with FlagsAttribute — covered by SST2303
 dotnet_diagnostic.CA2218.severity = error # Override GetHashCode on overriding Equals
 dotnet_diagnostic.CA2219.severity = error # Do not raise exceptions in finally clauses
-dotnet_diagnostic.CA2224.severity = error # Override Equals on overloading operator equals
+dotnet_diagnostic.CA2224.severity = none # Override Equals on overloading operator equals — covered by SST2302
 dotnet_diagnostic.CA2225.severity = error # Operator overloads have named alternates
 dotnet_diagnostic.CA2226.severity = error # Operators should have symmetrical overloads
 dotnet_diagnostic.CA2227.severity = none # Collection properties should be read only — settable collection properties are common in our DTOs and config types
 dotnet_diagnostic.CA2231.severity = error # Overload operator equals on overriding ValueType.Equals
 dotnet_diagnostic.CA2234.severity = error # Pass System.Uri objects instead of strings
 dotnet_diagnostic.CA2241.severity = error # Provide correct arguments to formatting methods
-dotnet_diagnostic.CA2242.severity = error # Test for NaN correctly
+dotnet_diagnostic.CA2242.severity = none # Test for NaN correctly — covered by SST1473
 dotnet_diagnostic.CA2243.severity = error # Attribute string literals should parse correctly
 dotnet_diagnostic.CA2244.severity = error # Do not duplicate indexed element initializations
-dotnet_diagnostic.CA2245.severity = error # Do not assign a property to itself
+dotnet_diagnostic.CA2245.severity = none # Do not assign a property to itself — covered by SST1189
 dotnet_diagnostic.CA2246.severity = error # Do not assign a symbol and its member in the same statement
 dotnet_diagnostic.CA2247.severity = error # Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum
 dotnet_diagnostic.CA2248.severity = error # Provide correct enum argument to Enum.HasFlag
 dotnet_diagnostic.CA2249.severity = error # Use String.Contains instead of String.IndexOf for substring checks
 dotnet_diagnostic.CA2250.severity = error # Use ThrowIfCancellationRequested
-dotnet_diagnostic.CA2251.severity = error # Use String.Equals over String.Compare
+dotnet_diagnostic.CA2251.severity = none # Covered by PSH1216 (canonical)
 dotnet_diagnostic.CA2252.severity = error # Opt in to preview features before using them
 dotnet_diagnostic.CA2253.severity = error # Named placeholders should not be numeric values
 dotnet_diagnostic.CA2254.severity = error # Template should be a static expression
@@ -423,9 +413,7 @@ dotnet_diagnostic.CA2268.severity = error # Use 'string.Equals(string, string, S
 # Skipped (deprecated ISerializable formatter): CA2229 Implement serialization constructors,
 # CA2235 Mark all non-serializable fields, CA2237 Mark ISerializable types with SerializableAttribute.
 
-###################
-# Microsoft .NET Analyzers (CA) - Security Rules
-###################
+# Security
 
 # SQL Injection & Command Injection
 dotnet_diagnostic.CA2100.severity = error # Review SQL queries for security vulnerabilities
@@ -548,15 +536,9 @@ dotnet_diagnostic.CA2153.severity = error # Do not catch corrupted state excepti
 dotnet_diagnostic.CA5367.severity = error # Do not serialize types with pointer fields
 
 ###################
-# SonarAnalyzer (Sxxxx) — global suppressions
+# Microsoft .NET SDK Diagnostics (SYSLIB)
 ###################
-dotnet_diagnostic.S1075.severity = none # Hardcoded URI — canonical SourceLink hosts are the point
-dotnet_diagnostic.S2436.severity = none # Too many generic parameters — needed for the projector overload
-dotnet_diagnostic.S4036.severity = none # PATH-relative process spawn — benchmark only, trusted env
-
-###################
-# Microsoft .NET Runtime Obsoletions (SYSLIB0xxx)
-###################
+# Runtime obsoletions
 dotnet_diagnostic.SYSLIB0001.severity = error # The UTF-7 encoding is insecure and should not be used
 dotnet_diagnostic.SYSLIB0002.severity = error # PrincipalPermissionAttribute is not honored by the runtime and must not be used
 dotnet_diagnostic.SYSLIB0003.severity = error # Code Access Security (CAS) is not supported or honored by the runtime
@@ -619,9 +601,7 @@ dotnet_diagnostic.SYSLIB0059.severity = error # SystemEvents.EventsThreadShutdow
 dotnet_diagnostic.SYSLIB0060.severity = error # Constructors of DirectoryServices.ActiveDirectory.ConfigurationContext are obsolete
 dotnet_diagnostic.SYSLIB0061.severity = error # CryptographyConfig.AddOID and AddAlgorithm methods are obsolete
 
-###################
-# Microsoft .NET Source Generator Diagnostics (SYSLIB1xxx)
-###################
+# Source generators
 # LoggerMessage source generator
 dotnet_diagnostic.SYSLIB1001.severity = error # Logging method names cannot start with _
 dotnet_diagnostic.SYSLIB1002.severity = error # Don't include log level parameters as templates in the logging message
@@ -709,8 +689,9 @@ dotnet_diagnostic.SYSLIB1103.severity = error # Configuration binding source gen
 dotnet_diagnostic.SYSLIB1104.severity = error # Configuration binding source generator: language version is too low
 
 ###################
-# Microsoft .NET Style Rules (IDExxxx) - Language Rules
+# Microsoft .NET Code Style Analyzers (IDE)
 ###################
+# Language rules
 # EnforceCodeStyleInBuild=true (set in Directory.Build.props) promotes these
 # IDE rules into `dotnet build` so they fire at compile time, not just in the
 # IDE. We enable the ones that are unambiguous wins and skip the rules that
@@ -718,128 +699,128 @@ dotnet_diagnostic.SYSLIB1104.severity = error # Configuration binding source gen
 # etc.) so we don't double-report.
 
 # Bug catchers — always error.
-dotnet_diagnostic.IDE0035.severity = error # Remove unreachable code
-dotnet_diagnostic.IDE0043.severity = error # Format string contains invalid placeholder
-dotnet_diagnostic.IDE0051.severity = none # Remove unused private member — covered by SST1440
+dotnet_diagnostic.IDE0035.severity = none # Remove unreachable code — covered by SST1453
+dotnet_diagnostic.IDE0043.severity = none # Format string contains invalid placeholder — covered by SST1454
 dotnet_diagnostic.IDE0052.severity = none # Remove unread private member — covered by SST1441
-dotnet_diagnostic.IDE0076.severity = error # Remove invalid global SuppressMessage attribute
-dotnet_diagnostic.IDE0077.severity = error # Avoid legacy format target in global SuppressMessage attribute
-dotnet_diagnostic.IDE0080.severity = none # Remove unnecessary suppression operator — covered by SST2209
 
 # Simplification / cleanup.
-dotnet_diagnostic.IDE0001.severity = none # Simplify name — covered by SST1116
 dotnet_diagnostic.IDE0002.severity = none # Simplify member access — covered by SST1117
 dotnet_diagnostic.IDE0004.severity = none # Remove unnecessary cast — covered by SST1175
-dotnet_diagnostic.IDE0005.severity = none # Remove unnecessary import - DUPLICATE S1128 (slower: 2.364s vs 551ms)
 dotnet_diagnostic.IDE0016.severity = none # Use throw expression — covered by SST2207
-dotnet_diagnostic.IDE0017.severity = none # Use object initializers — covered by SST1193
-dotnet_diagnostic.IDE0018.severity = none # Inline variable declaration — covered by SST2208
-dotnet_diagnostic.IDE0019.severity = none # Use pattern matching to avoid 'as' followed by a 'null' check — covered by SST2005
-dotnet_diagnostic.IDE0020.severity = none # Use pattern matching to avoid 'is' check followed by a cast — covered by SST2007
+dotnet_diagnostic.IDE0019.severity = none # Use pattern matching to avoid 'as' followed by a 'null' check — covered by SST2005/SST2274
 dotnet_diagnostic.IDE0028.severity = none # Use collection initializers — covered by SST1194
-dotnet_diagnostic.IDE0029.severity = none # Use coalesce expression — covered by SST1195
-dotnet_diagnostic.IDE0030.severity = none # Use coalesce expression (nullable types) — covered by SST1195/SST2227
 dotnet_diagnostic.IDE0031.severity = none # Use null propagation — covered by SST1196
-dotnet_diagnostic.IDE0032.severity = none # Use auto property — covered by SST1420
-dotnet_diagnostic.IDE0033.severity = none # Use explicitly provided tuple name — covered by SST1142
-dotnet_diagnostic.IDE0034.severity = none # Simplify default expression — covered by SST1188
-dotnet_diagnostic.IDE0037.severity = none # Use inferred member name — covered by SST1173/SST2216
 dotnet_diagnostic.IDE0038.severity = none # Use pattern matching ('is' check without a cast) — covered by SST2007
-dotnet_diagnostic.IDE0041.severity = none # Use 'is null' check — covered by SST1149/SST2231
+dotnet_diagnostic.IDE0041.severity = none # Use 'is null' check — covered by SST1149/SST2231/SST2282
 dotnet_diagnostic.IDE0042.severity = none # Deconstruct variable declaration — covered by SST2214
 dotnet_diagnostic.IDE0044.severity = none # Add readonly modifier — covered by SST1424
-dotnet_diagnostic.IDE0046.severity = none # Use conditional expression for return — covered by SST1197
-dotnet_diagnostic.IDE0047.severity = error # Remove unnecessary parentheses
+dotnet_diagnostic.IDE0047.severity = none # Remove unnecessary parentheses — covered by SST1459
 dotnet_diagnostic.IDE0049.severity = none # Use language keywords instead of framework type names for type references — covered by SST1121
-dotnet_diagnostic.IDE0054.severity = none # Use compound assignment — covered by SST1185
-dotnet_diagnostic.IDE0056.severity = none # Use index operator — covered by SST2203
 dotnet_diagnostic.IDE0057.severity = none # Use range operator — covered by SST2204
 dotnet_diagnostic.IDE0059.severity = none # Remove unnecessary value assignment — covered by SST2222
-dotnet_diagnostic.IDE0062.severity = error # Make local function static
-dotnet_diagnostic.IDE0063.severity = error # Use simple 'using' statement
-dotnet_diagnostic.IDE0064.severity = error # Make struct fields writable — flag readonly-but-mutable struct fields where intent diverges from declaration
+dotnet_diagnostic.IDE0064.severity = none # Make struct fields writable — flag readonly-but-mutable struct fields where intent diverges from declaration
 dotnet_diagnostic.IDE0066.severity = none # Use switch expression — covered by SST2201
-dotnet_diagnostic.IDE0070.severity = none # Use 'System.HashCode.Combine' — covered by SST2217
-dotnet_diagnostic.IDE0071.severity = none # Simplify interpolation — covered by SST2220
-dotnet_diagnostic.IDE0072.severity = none # Add missing cases to switch expression — covered by SST2206
-dotnet_diagnostic.IDE0074.severity = none # Use compound assignment — covered by SST1185
 dotnet_diagnostic.IDE0075.severity = none # Simplify conditional expression — covered by SST1182
 dotnet_diagnostic.IDE0078.severity = none # Use pattern matching — covered by SST2006/SST2231
-dotnet_diagnostic.IDE0082.severity = none # Convert typeof to nameof — covered by SST1199
-dotnet_diagnostic.IDE0083.severity = none # Use pattern matching ('not' operator) — covered by SST2006
-dotnet_diagnostic.IDE0084.severity = error # Use pattern matching ('IsNot' operator)
-dotnet_diagnostic.IDE0090.severity = none # Simplify 'new' expression — covered by SST2202
-dotnet_diagnostic.IDE0100.severity = none # Remove unnecessary equality operator — covered by SST1143
-dotnet_diagnostic.IDE0110.severity = none # Remove unnecessary discard — covered by SST2213
-dotnet_diagnostic.IDE0120.severity = none # Simplify LINQ expression — covered by SST2229/SST2233
-dotnet_diagnostic.IDE0150.severity = none # Prefer 'null' check over type check — covered by SST2231
-dotnet_diagnostic.IDE0161.severity = error # Use file-scoped namespace declaration
-dotnet_diagnostic.IDE0170.severity = error # Simplify property pattern
-dotnet_diagnostic.IDE0180.severity = none # Use tuple to swap values — covered by SST2215
-dotnet_diagnostic.IDE0200.severity = error # Remove unnecessary lambda expression
-dotnet_diagnostic.IDE0220.severity = none # Add explicit cast in foreach loop — covered by SST2225
+dotnet_diagnostic.IDE0084.severity = none # Use pattern matching ('IsNot' operator)
+dotnet_diagnostic.IDE0120.severity = none # Simplify LINQ expression — covered by PSH1100/PSH1101
 dotnet_diagnostic.IDE0221.severity = none # Add explicit cast — covered by SST2226
-dotnet_diagnostic.IDE0240.severity = none # Remove redundant nullable directive — covered by SST2210
-dotnet_diagnostic.IDE0241.severity = none # Remove unnecessary nullable directive — covered by SST2211
-dotnet_diagnostic.IDE0250.severity = error # Make struct 'readonly'
-dotnet_diagnostic.IDE0251.severity = error # Make member 'readonly'
+dotnet_diagnostic.IDE0250.severity = none # Make struct 'readonly' — covered by PSH1014
 dotnet_diagnostic.IDE0260.severity = none # Use pattern matching — covered by SST2006/SST2231
-dotnet_diagnostic.IDE0270.severity = none # Use coalesce expression — covered by SST2227
 
 # Disabled — conflict with an existing SA/CA rule or project convention.
-dotnet_diagnostic.IDE0003.severity = none # Remove 'this' qualifier — we don't follow the this. prefix style (SA1101 = none)
 dotnet_diagnostic.IDE0007.severity = none # Use var — we don't force var in either direction
 dotnet_diagnostic.IDE0008.severity = none # Use explicit type — we don't force var in either direction
 dotnet_diagnostic.IDE0009.severity = none # Member access should be qualified — SA1101 = none
-dotnet_diagnostic.IDE0010.severity = none # Add missing cases to switch statement — too noisy for default/fallthrough patterns
-dotnet_diagnostic.IDE0011.severity = none # Add braces — RCS1001 / RCS1007 already handle this
-dotnet_diagnostic.IDE0021.severity = none # Use expression body for constructors — preference not enforced
-dotnet_diagnostic.IDE0022.severity = none # Use expression body for methods — preference not enforced
-dotnet_diagnostic.IDE0023.severity = none # Use expression body for conversion operators — preference not enforced
-dotnet_diagnostic.IDE0024.severity = none # Use expression body for operators — preference not enforced
-dotnet_diagnostic.IDE0025.severity = none # Use expression body for properties — preference not enforced
-dotnet_diagnostic.IDE0026.severity = none # Use expression body for indexers — preference not enforced
-dotnet_diagnostic.IDE0027.severity = none # Use expression body for accessors — preference not enforced
-dotnet_diagnostic.IDE0036.severity = none # Order modifiers — SA1206 handles
-dotnet_diagnostic.IDE0039.severity = none # Use local function — covered by SST2228
-dotnet_diagnostic.IDE0040.severity = none # Add accessibility modifiers — SA1400 handles
-dotnet_diagnostic.IDE0045.severity = none # Use conditional expression for assignment — covered by SST1198
+dotnet_diagnostic.IDE0021.severity = none # Use expression body for constructors — covered by SST2276 (opt-in)
+dotnet_diagnostic.IDE0022.severity = none # Use expression body for methods — covered by SST2275
+dotnet_diagnostic.IDE0023.severity = none # Use expression body for conversion operators — covered by SST2278 (opt-in)
+dotnet_diagnostic.IDE0024.severity = none # Use expression body for operators — covered by SST2277 (opt-in)
+dotnet_diagnostic.IDE0025.severity = none # Use expression body for properties — covered by SST2279
+dotnet_diagnostic.IDE0026.severity = none # Use expression body for indexers — covered by SST2280
 dotnet_diagnostic.IDE0048.severity = none # Add parentheses for clarity — preference not enforced
-dotnet_diagnostic.IDE0053.severity = none # Use expression body for lambdas — preference not enforced
 dotnet_diagnostic.IDE0055.severity = none # Formatting — StyleCop SA rules own formatting
 dotnet_diagnostic.IDE0058.severity = none # Remove unnecessary expression value — covered by SST2221
 dotnet_diagnostic.IDE0060.severity = none # Remove unused parameter — CA1801 handles (with api_surface config)
-dotnet_diagnostic.IDE0061.severity = none # Use expression body for local function — preference not enforced
-dotnet_diagnostic.IDE0065.severity = none # 'using' directive placement — SA1200 = none (we put usings outside file-scoped namespaces)
-dotnet_diagnostic.IDE0073.severity = none # Require file header — SA1633 handles
+dotnet_diagnostic.IDE0061.severity = none # Use expression body for local function — covered by SST2281
 dotnet_diagnostic.IDE0079.severity = none # Remove unnecessary suppression — can misfire on multi-TFM suppressions
 dotnet_diagnostic.IDE0130.severity = none # Namespace does not match folder structure — we don't enforce strict mirror
 dotnet_diagnostic.IDE0160.severity = none # Use block-scoped namespace — we use file-scoped (IDE0161)
 dotnet_diagnostic.IDE0210.severity = none # Convert to top-level statements — we use Main style
 dotnet_diagnostic.IDE0211.severity = none # Convert to 'Program.Main' style — we use Main style
-dotnet_diagnostic.IDE0280.severity = none # Use nameof — CA1507 / RCS1015 handle this
-dotnet_diagnostic.IDE0290.severity = none # Use primary constructor — subjective, not enforced
 dotnet_diagnostic.IDE0300.severity = none # Use collection expression for array — covered by SST2101
-dotnet_diagnostic.IDE0301.severity = none # Use collection expression for empty — covered by SST2100
-dotnet_diagnostic.IDE0302.severity = none # Use collection expression for stackalloc — covered by SST2102
-dotnet_diagnostic.IDE0303.severity = none # Use collection expression for Create — covered by SST2103
-dotnet_diagnostic.IDE0304.severity = none # Use collection expression for builder — covered by SST2104
-dotnet_diagnostic.IDE0305.severity = none # Use collection expression for fluent — covered by SST2105
 dotnet_diagnostic.IDE0306.severity = none # Use collection expression for new — covered by SST2101
-dotnet_diagnostic.IDE0320.severity = error # Make anonymous function static — eliminates the closure-capture display class allocation
+dotnet_diagnostic.IDE0320.severity = none # Make anonymous function static — covered by PSH1000
 dotnet_diagnostic.IDE0050.severity = none # Convert anonymous type to tuple — covered by SST2224
-dotnet_diagnostic.IDE0230.severity = none # Use UTF-8 string literal — covered by SST2212
 dotnet_diagnostic.IDE0310.severity = none # Convert lambda expression to method group — handled by RCS1207
-dotnet_diagnostic.IDE0340.severity = none # Use unbound generic type — covered by SST2232
-dotnet_diagnostic.IDE0350.severity = none # Use implicitly typed lambda — covered by SST2218
 dotnet_diagnostic.IDE0360.severity = none # Simplify property accessor — covered by SST2219
 dotnet_diagnostic.IDE0370.severity = none # Remove unnecessary suppression (null-forgiving operator) — disabled for the same reason as RCS1249: multi-TFM nullability annotations can differ per platform
-dotnet_diagnostic.IDE0380.severity = error # Remove unnecessary unsafe modifier
-dotnet_diagnostic.IDE1005.severity = error # Use conditional delegate call
 
-###################
-# Microsoft .NET Style Rules (IDE1xxx / IDE3xxx) - Naming & Miscellaneous
-###################
+# Language and unnecessary code rules.
+dotnet_diagnostic.IDE0001.severity = none # Simplify name
+dotnet_diagnostic.IDE0003.severity = none # Name can be simplified
+dotnet_diagnostic.IDE0005.severity = none # Remove unnecessary import
+dotnet_diagnostic.IDE0010.severity = none # Add missing cases to switch statement
+dotnet_diagnostic.IDE0011.severity = none # Add braces
+dotnet_diagnostic.IDE0017.severity = none # Use object initializers
+dotnet_diagnostic.IDE0018.severity = none # Inline variable declaration
+dotnet_diagnostic.IDE0020.severity = none # Use pattern matching to avoid is check followed by a cast (with variable)
+dotnet_diagnostic.IDE0027.severity = none # Use expression body for accessors
+dotnet_diagnostic.IDE0029.severity = none # Null check can be simplified
+dotnet_diagnostic.IDE0030.severity = none # Null check can be simplified
+dotnet_diagnostic.IDE0032.severity = none # Use auto property
+dotnet_diagnostic.IDE0033.severity = none # Use explicitly provided tuple name
+dotnet_diagnostic.IDE0034.severity = none # Simplify default expression
+dotnet_diagnostic.IDE0036.severity = none # Order modifiers
+dotnet_diagnostic.IDE0037.severity = none # Use inferred member name
+dotnet_diagnostic.IDE0039.severity = none # Use local function instead of lambda
+dotnet_diagnostic.IDE0040.severity = none # Add accessibility modifiers
+dotnet_diagnostic.IDE0045.severity = none # Use conditional expression for assignment
+dotnet_diagnostic.IDE0046.severity = none # Use conditional expression for return
+dotnet_diagnostic.IDE0051.severity = none # Remove unused private member
+dotnet_diagnostic.IDE0053.severity = none # Use expression body for lambdas
+dotnet_diagnostic.IDE0054.severity = none # Use compound assignment
+dotnet_diagnostic.IDE0056.severity = none # Use index operator
+dotnet_diagnostic.IDE0062.severity = none # Make local function static
+dotnet_diagnostic.IDE0063.severity = none # Use simple using statement
+dotnet_diagnostic.IDE0065.severity = none # Using directive placement
+dotnet_diagnostic.IDE0070.severity = none # Use System.HashCode.Combine
+dotnet_diagnostic.IDE0071.severity = none # Simplify interpolation
+dotnet_diagnostic.IDE0072.severity = none # Add missing cases to switch expression
+dotnet_diagnostic.IDE0073.severity = none # Use file header
+dotnet_diagnostic.IDE0074.severity = none # Use coalesce compound assignment
+dotnet_diagnostic.IDE0076.severity = none # Remove invalid global SuppressMessageAttribute
+dotnet_diagnostic.IDE0077.severity = none # Avoid legacy format target in global SuppressMessageAttribute
+dotnet_diagnostic.IDE0080.severity = none # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = none # Convert typeof to nameof
+dotnet_diagnostic.IDE0083.severity = none # Use pattern matching (not operator)
+dotnet_diagnostic.IDE0090.severity = none # Simplify new expression
+dotnet_diagnostic.IDE0100.severity = none # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = none # Remove unnecessary discard
+dotnet_diagnostic.IDE0150.severity = none # Prefer null check over type check
+dotnet_diagnostic.IDE0161.severity = none # Use file-scoped namespace
+dotnet_diagnostic.IDE0170.severity = none # Simplify property pattern
+dotnet_diagnostic.IDE0180.severity = none # Use tuple to swap values
+dotnet_diagnostic.IDE0200.severity = none # Remove unnecessary lambda expression
+dotnet_diagnostic.IDE0220.severity = none # Add explicit cast in foreach loop
+dotnet_diagnostic.IDE0230.severity = none # Use UTF-8 string literal
+dotnet_diagnostic.IDE0240.severity = none # Nullable directive is redundant
+dotnet_diagnostic.IDE0241.severity = none # Nullable directive is unnecessary
+dotnet_diagnostic.IDE0251.severity = none # Member can be made readonly
+dotnet_diagnostic.IDE0270.severity = none # Null check can be simplified
+dotnet_diagnostic.IDE0280.severity = none # Use nameof
+dotnet_diagnostic.IDE0290.severity = none # Use primary constructor
+dotnet_diagnostic.IDE0301.severity = none # Use collection expression for empty
+dotnet_diagnostic.IDE0302.severity = none # Use collection expression for stackalloc
+dotnet_diagnostic.IDE0303.severity = none # Use collection expression for Create()
+dotnet_diagnostic.IDE0304.severity = none # Use collection expression for builder
+dotnet_diagnostic.IDE0305.severity = none # Use collection expression for fluent
+dotnet_diagnostic.IDE0340.severity = none # Use unbound generic type
+dotnet_diagnostic.IDE0350.severity = none # Use implicitly typed lambda
+dotnet_diagnostic.IDE0380.severity = none # Remove unnecessary unsafe modifier
+dotnet_diagnostic.IDE1005.severity = none # Use conditional delegate call
+
+# Naming and miscellaneous
 # Naming conventions — SA1300 family already enforces PascalCase / interface
 # prefix / field casing (with our _underscore convention on SA1306/1309/1311
 # deliberately disabled). Leaving IDE1006 off because configuring
@@ -849,37 +830,41 @@ dotnet_diagnostic.IDE1006.severity = none # Naming rule violation — SA1300 fam
 dotnet_diagnostic.IDE3000.severity = none # Disabled per project convention — not enforced
 
 ###################
-# Roslynator Analyzers (RCS1xxx) - Code Simplification
+# Roslynator.CSharp.Analyzers (RCS)
 ###################
-dotnet_diagnostic.RCS1001.severity = error # Add braces (when expression spans over multiple lines)
-dotnet_diagnostic.RCS1003.severity = error # Add braces to if-else (when expression spans over multiple lines)
+# Code simplification
+dotnet_diagnostic.RCS1001.severity = none # Add braces (when expression spans over multiple lines) — covered by SST1519
+dotnet_diagnostic.RCS1003.severity = none # Add braces to if-else (when expression spans over multiple lines) — covered by SST1519
 dotnet_diagnostic.RCS1005.severity = error # Simplify nested using statement
-dotnet_diagnostic.RCS1006.severity = error # Merge 'else' with nested 'if'
+dotnet_diagnostic.RCS1006.severity = none # Merge 'else' with nested 'if' — covered by SST1465
 dotnet_diagnostic.RCS1007.severity = error # Add braces
 dotnet_diagnostic.RCS1031.severity = none # Remove unnecessary braces in switch section -- we don't mind braces in switch statements
 dotnet_diagnostic.RCS1032.severity = error # Remove redundant parentheses
-dotnet_diagnostic.RCS1033.severity = error # Remove redundant boolean literal
-dotnet_diagnostic.RCS1039.severity = error # Remove argument list from attribute
+dotnet_diagnostic.RCS1033.severity = none # Remove redundant boolean literal — covered by SST1143
+dotnet_diagnostic.RCS1039.severity = none # Remove argument list from attribute — covered by SST1411
+dotnet_diagnostic.RCS1040.severity = none # Remove empty statement — covered by SST1180
 dotnet_diagnostic.RCS1042.severity = none # Remove enum default underlying type — covered by SST1177
 dotnet_diagnostic.RCS1043.severity = error # Remove 'partial' modifier from type with a single part
-dotnet_diagnostic.RCS1049.severity = error # Simplify boolean comparison
+dotnet_diagnostic.RCS1049.severity = none # Simplify boolean comparison — covered by SST1143
 dotnet_diagnostic.RCS1058.severity = none # Use compound assignment — covered by SST1185
-dotnet_diagnostic.RCS1061.severity = error # Merge 'if' with nested 'if'
+dotnet_diagnostic.RCS1061.severity = none # Merge 'if' with nested 'if' — covered by SST2013
 dotnet_diagnostic.RCS1068.severity = none # Simplify logical negation — covered by SST1172/SST2006
-dotnet_diagnostic.RCS1069.severity = error # Remove unnecessary case label
+dotnet_diagnostic.RCS1069.severity = none # Remove unnecessary case label — covered by SST1466
 dotnet_diagnostic.RCS1070.severity = none # Remove redundant default switch section — covered by SST1179
 dotnet_diagnostic.RCS1071.severity = none # Remove redundant base constructor call — covered by SST1178
-dotnet_diagnostic.RCS1073.severity = error # Convert 'if' to 'return' statement
+dotnet_diagnostic.RCS1072.severity = none # Remove empty namespace declaration — covered by SST1435
+dotnet_diagnostic.RCS1073.severity = none # Convert 'if' to 'return' statement — covered by SST1197
 dotnet_diagnostic.RCS1074.severity = none # Remove redundant constructor — covered by SST1433
-dotnet_diagnostic.RCS1078.severity = error # Use "" or 'string.Empty'
-dotnet_diagnostic.RCS1084.severity = error # Use coalesce expression instead of conditional expression
-dotnet_diagnostic.RCS1085.severity = error # Use auto-implemented property
+dotnet_diagnostic.RCS1078.severity = none # Use "" or 'string.Empty' — conflicts with SST1122, which owns the string.Empty direction
+dotnet_diagnostic.RCS1084.severity = none # Use coalesce expression instead of conditional expression — covered by SST1195
+dotnet_diagnostic.RCS1085.severity = none # Use auto-implemented property — covered by SST1420
 dotnet_diagnostic.RCS1089.severity = error # Use --/++ operator instead of assignment
 dotnet_diagnostic.RCS1097.severity = error # Remove redundant 'ToString' call
 dotnet_diagnostic.RCS1103.severity = error # Convert 'if' to assignment
 dotnet_diagnostic.RCS1104.severity = none # Simplify conditional expression — covered by SST1182
 dotnet_diagnostic.RCS1105.severity = error # Unnecessary interpolation
-dotnet_diagnostic.RCS1107.severity = error # Remove redundant 'ToCharArray' call
+dotnet_diagnostic.RCS1106.severity = none # Remove empty destructor — covered by PSH1002
+dotnet_diagnostic.RCS1107.severity = none # Remove redundant 'ToCharArray' call — covered by PSH1217
 dotnet_diagnostic.RCS1114.severity = error # Remove redundant delegate creation
 dotnet_diagnostic.RCS1124.severity = error # Inline local variable
 dotnet_diagnostic.RCS1126.severity = error # Add braces to if-else
@@ -887,144 +872,138 @@ dotnet_diagnostic.RCS1128.severity = error # Use coalesce expression
 dotnet_diagnostic.RCS1129.severity = none # Remove redundant field initialization — covered by SST1176
 dotnet_diagnostic.RCS1132.severity = none # Remove redundant overriding member — covered by SST1181
 dotnet_diagnostic.RCS1133.severity = error # Remove redundant Dispose/Close call
-dotnet_diagnostic.RCS1134.severity = error # Remove redundant statement
+dotnet_diagnostic.RCS1134.severity = none # Remove redundant statement — covered by SST1174
 dotnet_diagnostic.RCS1143.severity = error # Simplify coalesce expression
 dotnet_diagnostic.RCS1145.severity = error # Remove redundant 'as' operator
 dotnet_diagnostic.RCS1146.severity = error # Use conditional access
 dotnet_diagnostic.RCS1151.severity = none # Remove redundant cast — covered by SST1175
 dotnet_diagnostic.RCS1171.severity = error # Simplify lazy initialization
 dotnet_diagnostic.RCS1173.severity = error # Use coalesce expression instead of 'if'
-dotnet_diagnostic.RCS1174.severity = error # Remove redundant async/await
+dotnet_diagnostic.RCS1174.severity = none # Remove redundant async/await — covered by PSH1311
 dotnet_diagnostic.RCS1179.severity = error # Unnecessary assignment
 dotnet_diagnostic.RCS1180.severity = error # Inline lazy initialization
 dotnet_diagnostic.RCS1188.severity = none # Remove redundant auto-property initialization — covered by SST1176
 dotnet_diagnostic.RCS1192.severity = none # Unnecessary usage of verbatim string literal — covered by SST1184
 dotnet_diagnostic.RCS1199.severity = error # Unnecessary null check
 dotnet_diagnostic.RCS1206.severity = error # Use conditional access instead of conditional expression
-dotnet_diagnostic.RCS1207.severity = error # Use anonymous function or method group
-dotnet_diagnostic.RCS1211.severity = error # Remove unnecessary 'else'
+dotnet_diagnostic.RCS1207.severity = none # Use anonymous function or method group — conflicts with SST2239, which owns the method-group direction
+dotnet_diagnostic.RCS1211.severity = none # Remove unnecessary 'else' — covered by SST1464
 dotnet_diagnostic.RCS1212.severity = error # Remove redundant assignment
 dotnet_diagnostic.RCS1214.severity = none # Unnecessary interpolated string — covered by SST1183
 dotnet_diagnostic.RCS1216.severity = error # Unnecessary unsafe context
-dotnet_diagnostic.RCS1217.severity = error # Convert interpolated string to concatenation
+dotnet_diagnostic.RCS1217.severity = none # Convert interpolated string to concatenation — reverses SST2249, which owns the concatenation-to-interpolation direction
 dotnet_diagnostic.RCS1218.severity = error # Simplify code branching
-dotnet_diagnostic.RCS1220.severity = error # Use pattern matching instead of combination of 'is' and cast
+dotnet_diagnostic.RCS1220.severity = none # Use pattern matching instead of combination of 'is' and cast — covered by SST2007
 dotnet_diagnostic.RCS1221.severity = error # Use pattern matching instead of combination of 'as' and null check
-dotnet_diagnostic.RCS1238.severity = error # Avoid nested ?: operators
-dotnet_diagnostic.RCS1244.severity = error # Simplify 'default' expression
+dotnet_diagnostic.RCS1238.severity = none # Avoid nested ?: operators — covered by SST1147
+dotnet_diagnostic.RCS1244.severity = none # Simplify 'default' expression — covered by SST1188
 dotnet_diagnostic.RCS1249.severity = none # Unnecessary null-forgiving operator — disabled because multi-TFM nullability annotations can differ per platform, leading to false positives
 dotnet_diagnostic.RCS1251.severity = error # Remove unnecessary braces from record declaration
 dotnet_diagnostic.RCS1259.severity = error # Remove empty syntax (replaces RCS1066)
 dotnet_diagnostic.RCS1262.severity = error # Unnecessary raw string literal
-dotnet_diagnostic.RCS1265.severity = error # Remove redundant catch block
+dotnet_diagnostic.RCS1265.severity = none # Remove redundant catch block — covered by SST1470
 dotnet_diagnostic.RCS1268.severity = error # Simplify numeric comparison
 
-###################
-# Roslynator Analyzers (RCS1xxx) - Code Quality
-###################
-dotnet_diagnostic.RCS1013.severity = error # Use predefined type
+# Code quality
+dotnet_diagnostic.RCS1013.severity = none # Use predefined type — covered by SST1121
 dotnet_diagnostic.RCS1014.severity = error # Use explicitly/implicitly typed array
 dotnet_diagnostic.RCS1015.severity = error # Use nameof operator
-dotnet_diagnostic.RCS1016.severity = error # Use block body or expression body
-dotnet_diagnostic.RCS1020.severity = error # Simplify Nullable<T> to T?
+dotnet_diagnostic.RCS1016.severity = none # Use block body or expression body — conflicts with SST2219, which owns the expression-bodied accessor direction
+dotnet_diagnostic.RCS1020.severity = none # Covered by SST2234 (canonical)
 dotnet_diagnostic.RCS1021.severity = error # Convert lambda expression body to expression body
 dotnet_diagnostic.RCS1044.severity = none # Remove original exception from throw statement — covered by SST1430
 dotnet_diagnostic.RCS1046.severity = none # Asynchronous method name should end with 'Async' — TUnit test method naming convention doesn't follow the Async suffix — covered by SST1317
 dotnet_diagnostic.RCS1047.severity = error # Non-asynchronous method name should not end with 'Async'
-dotnet_diagnostic.RCS1048.severity = error # Use lambda expression instead of anonymous method
+dotnet_diagnostic.RCS1048.severity = none # Use lambda expression instead of anonymous method — covered by SST1130
 dotnet_diagnostic.RCS1050.severity = error # Include/omit parentheses when creating new object
-dotnet_diagnostic.RCS1051.severity = error # Add/remove parentheses from condition in conditional operator
+dotnet_diagnostic.RCS1051.severity = none # Add/remove parentheses from condition in conditional operator — conflicts with SST1459, which owns the non-grouping-parenthesis removal direction
 dotnet_diagnostic.RCS1056.severity = none # Avoid usage of using alias directive - used to avoid conflicts
-dotnet_diagnostic.RCS1059.severity = error # Avoid locking on publicly accessible instance
+dotnet_diagnostic.RCS1059.severity = none # Avoid locking on publicly accessible instance — covered by SST1901
 dotnet_diagnostic.RCS1075.severity = none # Avoid empty catch clause that catches System.Exception — covered by SST1429
 dotnet_diagnostic.RCS1079.severity = error # Throwing of new NotImplementedException
 dotnet_diagnostic.RCS1081.severity = error # Split variable declaration
 dotnet_diagnostic.RCS1093.severity = error # File contains no code
-dotnet_diagnostic.RCS1094.severity = error # Declare using directive on top level
-dotnet_diagnostic.RCS1096.severity = error # Use 'HasFlag' method or bitwise operator
+dotnet_diagnostic.RCS1094.severity = none # Declare using directive on top level — covered by SST1200
+dotnet_diagnostic.RCS1096.severity = none # Use 'HasFlag' method or bitwise operator — covered by PSH1016
 dotnet_diagnostic.RCS1098.severity = none # Constant values should be placed on right side of comparisons — covered by SST1186
-dotnet_diagnostic.RCS1099.severity = error # Default label should be the last label in a switch section
+dotnet_diagnostic.RCS1099.severity = none # Default label should be the last label in a switch section — covered by SST1466
 dotnet_diagnostic.RCS1102.severity = none # Make class static — covered by SST1432
 dotnet_diagnostic.RCS1108.severity = error # Add 'static' modifier to all partial class declarations
 dotnet_diagnostic.RCS1111.severity = error # Add braces to switch section with multiple statements
 dotnet_diagnostic.RCS1113.severity = error # Use 'string.IsNullOrEmpty' method
-dotnet_diagnostic.RCS1118.severity = error # Mark local variable as const
-dotnet_diagnostic.RCS1123.severity = error # Add parentheses when necessary
-dotnet_diagnostic.RCS1130.severity = error # Bitwise operation on enum without Flags attribute
+dotnet_diagnostic.RCS1118.severity = none # Mark local variable as const — covered by PSH1402
+dotnet_diagnostic.RCS1123.severity = none # Add parentheses when necessary — covered by SST1407
+dotnet_diagnostic.RCS1130.severity = none # Bitwise operation on enum without Flags attribute — covered by SST2458
 dotnet_diagnostic.RCS1135.severity = error # Declare enum member with zero value (when enum has FlagsAttribute)
-dotnet_diagnostic.RCS1136.severity = error # Merge switch sections with equivalent content
+dotnet_diagnostic.RCS1136.severity = none # Merge switch sections with equivalent content — covered by SST2414
 dotnet_diagnostic.RCS1154.severity = error # Sort enum members
-dotnet_diagnostic.RCS1155.severity = error # Use StringComparison when comparing strings
-dotnet_diagnostic.RCS1156.severity = error # Use string.Length instead of comparison with empty string
-dotnet_diagnostic.RCS1157.severity = error # Composite enum value contains undefined flag
+dotnet_diagnostic.RCS1155.severity = none # Use StringComparison when comparing strings — covered by PSH1207
+dotnet_diagnostic.RCS1156.severity = none # Use string.Length instead of comparison with empty string — covered by PSH1204
+dotnet_diagnostic.RCS1157.severity = none # Composite enum value contains undefined flag — covered by SST2303
 dotnet_diagnostic.RCS1159.severity = error # Use EventHandler<T>
 dotnet_diagnostic.RCS1160.severity = none # Abstract type should not have public constructors — covered by SST1428
 dotnet_diagnostic.RCS1161.severity = none # Enum should declare explicit values - do not need explicit values
 dotnet_diagnostic.RCS1162.severity = none # Avoid chain of assignments — covered by SST1187
-dotnet_diagnostic.RCS1166.severity = error # Value type object is never equal to null
+dotnet_diagnostic.RCS1166.severity = none # Value type object is never equal to null — covered by SST1469
 dotnet_diagnostic.RCS1168.severity = none # Parameter name differs from base name — covered by SST1318
 dotnet_diagnostic.RCS1169.severity = error # Make field read-only
 dotnet_diagnostic.RCS1170.severity = error # Use read-only auto-implemented property
 dotnet_diagnostic.RCS1172.severity = none # Use 'is' operator instead of 'as' operator — covered by SST2005
-dotnet_diagnostic.RCS1187.severity = error # Use constant instead of field
+dotnet_diagnostic.RCS1187.severity = none # Use constant instead of field — covered by PSH1402
 dotnet_diagnostic.RCS1191.severity = error # Declare enum value as combination of names
-dotnet_diagnostic.RCS1193.severity = error # Overriding member should not change 'params' modifier
+dotnet_diagnostic.RCS1193.severity = none # Overriding member should not change 'params' modifier — covered by SST2426
 dotnet_diagnostic.RCS1196.severity = error # Call extension method as instance method
-dotnet_diagnostic.RCS1200.severity = error # Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy'
+dotnet_diagnostic.RCS1200.severity = none # Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy' — covered by PSH1108
 dotnet_diagnostic.RCS1201.severity = error # Use method chaining
 dotnet_diagnostic.RCS1202.severity = error # Avoid NullReferenceException
 dotnet_diagnostic.RCS1204.severity = error # Use EventArgs.Empty
 dotnet_diagnostic.RCS1205.severity = error # Order named arguments according to the order of parameters
 dotnet_diagnostic.RCS1208.severity = error # Reduce 'if' nesting
 dotnet_diagnostic.RCS1209.severity = error # Order type parameter constraints
-dotnet_diagnostic.RCS1210.severity = error # Return completed task instead of returning null
+dotnet_diagnostic.RCS1210.severity = none # Return completed task instead of returning null — covered by PSH1312
 dotnet_diagnostic.RCS1215.severity = error # Expression is always equal to true/false
 dotnet_diagnostic.RCS1222.severity = error # Merge preprocessor directives
 dotnet_diagnostic.RCS1223.severity = suggestion # Mark publicly visible type with DebuggerDisplay attribute — only data types benefit; the rule is too broad to be an error
 dotnet_diagnostic.RCS1224.severity = error # Make method an extension method
 dotnet_diagnostic.RCS1225.severity = error # Make class sealed
-dotnet_diagnostic.RCS1227.severity = error # Validate arguments correctly
+dotnet_diagnostic.RCS1227.severity = none # Validate arguments correctly — covered by SST2404
 dotnet_diagnostic.RCS1229.severity = error # Use async/await when necessary
-dotnet_diagnostic.RCS1231.severity = suggestion # Make parameter ref read-only
-dotnet_diagnostic.RCS1233.severity = error # Use short-circuiting operator
+dotnet_diagnostic.RCS1231.severity = none # Make parameter ref read-only — covered by PSH1007
+dotnet_diagnostic.RCS1233.severity = none # Use short-circuiting operator — covered by SST1468
 dotnet_diagnostic.RCS1234.severity = error # Duplicate enum value
 dotnet_diagnostic.RCS1239.severity = error # Use 'for' statement instead of 'while' statement
 dotnet_diagnostic.RCS1240.severity = error # Operator is unnecessary
-dotnet_diagnostic.RCS1242.severity = error # Do not pass non-read-only struct by read-only reference
-dotnet_diagnostic.RCS1243.severity = error # Duplicate word in a comment
+dotnet_diagnostic.RCS1242.severity = none # Do not pass non-read-only struct by read-only reference — covered by PSH1003
+dotnet_diagnostic.RCS1243.severity = none # Duplicate word in a comment — covered by SST1658 (documentation comments)
 dotnet_diagnostic.RCS1247.severity = error # Fix documentation comment tag
-dotnet_diagnostic.RCS1248.severity = error # Normalize null check
-dotnet_diagnostic.RCS1250.severity = error # Use implicit/explicit object creation
+dotnet_diagnostic.RCS1248.severity = none # Normalize null check — conflicts with SST1149, which owns the 'is null' pattern direction
+dotnet_diagnostic.RCS1250.severity = none # Use implicit/explicit object creation — conflicts with SST2202, which owns the implicit-target-type direction
 dotnet_diagnostic.RCS1252.severity = error # Normalize usage of infinite loop
 dotnet_diagnostic.RCS1254.severity = error # Normalize format of enum flag value
 dotnet_diagnostic.RCS1255.severity = none # Simplify argument null check — conflicts with our ArgumentExceptionHelper helper pattern
 dotnet_diagnostic.RCS1257.severity = error # Use enum field explicitly
 dotnet_diagnostic.RCS1258.severity = error # Unnecessary enum flag
-dotnet_diagnostic.RCS1260.severity = error # Add/remove trailing comma
-dotnet_diagnostic.RCS1261.severity = error # Resource can be disposed asynchronously
+dotnet_diagnostic.RCS1260.severity = none # Add/remove trailing comma — conflicts with SST1413, which owns the trailing-comma direction
+dotnet_diagnostic.RCS1261.severity = none # Resource can be disposed asynchronously — covered by PSH1310
 dotnet_diagnostic.RCS1264.severity = error # Use 'var' or explicit type (replaces RCS1010, RCS1176, RCS1177)
-dotnet_diagnostic.RCS1266.severity = error # Use raw string literal
+dotnet_diagnostic.RCS1266.severity = none # Use raw string literal — covered by SST2243
 dotnet_diagnostic.RCS1267.severity = error # Use string interpolation instead of 'string.Concat'
 
-###################
-# Roslynator Analyzers (RCS1xxx) - Performance
-###################
-dotnet_diagnostic.RCS1077.severity = error # Optimize LINQ method call
-dotnet_diagnostic.RCS1080.severity = error # Use 'Count/Length' property instead of 'Any' method
-dotnet_diagnostic.RCS1112.severity = error # Combine 'Enumerable.Where' method chain
+# Performance
+dotnet_diagnostic.RCS1077.severity = none # Covered by the PSH1101-PSH1111 family (canonical)
+dotnet_diagnostic.RCS1080.severity = none # Covered by PSH1106 (canonical)
+dotnet_diagnostic.RCS1112.severity = none # Combine 'Enumerable.Where' method chain — covered by PSH1109
 dotnet_diagnostic.RCS1186.severity = error # Use Regex instance instead of static method
-dotnet_diagnostic.RCS1190.severity = error # Join string expressions
+dotnet_diagnostic.RCS1190.severity = none # Join string expressions — conflicts with SST2470, which reports the fused-literal seam this would create
 dotnet_diagnostic.RCS1195.severity = error # Use ^ operator
-dotnet_diagnostic.RCS1197.severity = error # Optimize StringBuilder.Append/AppendLine call
+dotnet_diagnostic.RCS1197.severity = none # Optimize StringBuilder.Append/AppendLine call — covered by PSH1203/PSH1214
 dotnet_diagnostic.RCS1198.severity = none # Avoid unnecessary boxing of value type — boxing is unavoidable bridging Rx and IEnumerable<object>
-dotnet_diagnostic.RCS1230.severity = error # Unnecessary explicit use of enumerator
+dotnet_diagnostic.RCS1230.severity = none # Unnecessary explicit use of enumerator — covered by SST1467
 dotnet_diagnostic.RCS1235.severity = error # Optimize method call
-dotnet_diagnostic.RCS1236.severity = error # Use exception filter
-dotnet_diagnostic.RCS1246.severity = error # Use element access
+dotnet_diagnostic.RCS1236.severity = none # Use exception filter — covered by SST2009
+dotnet_diagnostic.RCS1246.severity = none # Use element access — covered by PSH1106
 
-###################
-# Roslynator Analyzers (RCS1xxx) - Maintainability
-###################
+# Maintainability
 dotnet_diagnostic.RCS1158.severity = none # Static member in generic type should use a type parameter — common factory pattern — covered by SST1431
 dotnet_diagnostic.RCS1163.severity = none # Unused parameter — interface implementations and Rx selectors often have unused parameters
 dotnet_diagnostic.RCS1164.severity = none # Unused type parameter - DUPLICATE IDE0060 (UnusedParameter analyzer 210ms; IDE0060 bundled at lower cost)
@@ -1034,9 +1013,7 @@ dotnet_diagnostic.RCS1213.severity = none # Remove unused member declaration - D
 dotnet_diagnostic.RCS1241.severity = error # Implement non-generic counterpart
 dotnet_diagnostic.RCS1256.severity = none # Invalid argument null check — conflicts with our ArgumentExceptionHelper helper pattern
 
-###################
-# Roslynator Analyzers (RCS1xxx) - Documentation
-###################
+# Documentation
 dotnet_diagnostic.RCS1181.severity = error # Convert comment to documentation comment
 dotnet_diagnostic.RCS1189.severity = error # Add or remove region name
 dotnet_diagnostic.RCS1226.severity = none # Add paragraph to documentation comment — &lt;para&gt; wrapping is subjective and adds noise
@@ -1045,9 +1022,7 @@ dotnet_diagnostic.RCS1232.severity = error # Order elements in documentation com
 dotnet_diagnostic.RCS1253.severity = error # Format documentation comment summary
 dotnet_diagnostic.RCS1263.severity = none # Invalid reference in a documentation comment
 
-###################
-# Roslynator Analyzers (RCS1xxx) - Disabled (covered by CA/SA equivalent)
-###################
+# Disabled
 dotnet_diagnostic.RCS1018.severity = none # Add/remove accessibility modifiers — covered by SA1400
 dotnet_diagnostic.RCS1019.severity = none # Order modifiers — covered by SA1206 / SA1208
 dotnet_diagnostic.RCS1037.severity = none # Remove trailing white-space — covered by SA1028
@@ -1065,9 +1040,7 @@ dotnet_diagnostic.RCS1175.severity = none # Unused 'this' parameter — covered 
 dotnet_diagnostic.RCS1194.severity = none # Implement exception constructors — covered by CA1032
 dotnet_diagnostic.RCS1203.severity = none # Use AttributeUsageAttribute — covered by CA1018
 
-###################
-# Roslynator Formatting Analyzers (RCS0xxx) - covered by StyleCop SA equivalents
-###################
+# Formatting
 dotnet_diagnostic.RCS0001.severity = none # Add blank line after embedded statement — covered by StyleCop layout rules
 dotnet_diagnostic.RCS0002.severity = none # Add blank line after #region — covered by StyleCop SA1517 family
 dotnet_diagnostic.RCS0003.severity = none # Add blank line after using directive list — covered by SA1516
@@ -1122,8 +1095,13 @@ dotnet_diagnostic.RCS0063.severity = none # Remove unnecessary blank line — co
 ###################
 # StyleSharp Analyzers (SST)
 ###################
-file_header_template = Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.\nReactiveUI and Contributors licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for full license information.
+file_header_template = Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.\nReactiveUI Association Incorporated licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for full license information.
 stylesharp.summary_single_line_max_length = 120
+
+# SonarAnalyzer's S4022 only ever flagged storage narrower than int; uint, long and ulong
+# passed silently. Match that, so retiring S4022 for SST2313 does not fail a build on an
+# enum that was deliberately widened.
+stylesharp.SST2313.allowed_enum_storage = int, uint, long, ulong
 
 # Documentation coverage scope (SST1600/SST1601/SST1602/SST1654).
 # Require documentation on every element, including private members.
@@ -1134,11 +1112,18 @@ stylesharp.document_private_fields = true
 stylesharp.document_interfaces = all
 stylesharp.SST1305.allowed_hungarian_prefixes = rx
 stylesharp.instance_member_qualification = omit_this
-stylesharp.avoid_linq_on_hot_path = true
 stylesharp.max_cyclomatic_complexity = 10
 stylesharp.max_cognitive_complexity = 15
 stylesharp.max_property_cognitive_complexity = 3
-
+# SST1484 also reports a field that shadows one inherited from a base type.
+stylesharp.SST1484.check_base_types = true
+stylesharp.max_line_length = 200                           # SST1521 (characters; keeps the limit this repo has always enforced)
+stylesharp.max_file_lines = 1000                           # SST1522 (code lines; blank lines and comments do not count)
+# stylesharp.max_member_lines = 60                         # SST1523 (code lines)
+# stylesharp.max_switch_section_lines = 20                 # SST1524 (code lines)
+# stylesharp.include_internal = true                       # SST1499 (set false to report only fields visible outside the assembly)
+# stylesharp.require_parameterless = true                  # SST1488 (set false where every exception must carry a message)
+# stylesharp.include_non_public_types = true               # SST1488 (set false to check only externally visible exceptions)
 # Spacing
 dotnet_diagnostic.SST1000.severity = error # A control-flow keyword is not followed by a space
 dotnet_diagnostic.SST1001.severity = error # A comma is spaced incorrectly
@@ -1172,7 +1157,7 @@ dotnet_diagnostic.SST1028.severity = error # A line ends with trailing whitespac
 
 # Readability and maintainability
 dotnet_diagnostic.SST1100.severity = error # A base. prefix is used where the type does not override the member
-dotnet_diagnostic.SST1101.severity = none # An instance member is accessed without a this. prefix — we don't require this. prefixing
+dotnet_diagnostic.SST1101.severity = none # see docs/rules/SST1101.md
 dotnet_diagnostic.SST1102.severity = error # A query clause is separated from the previous clause by a blank line
 dotnet_diagnostic.SST1103.severity = error # Query clauses mix single-line and multi-line layout
 dotnet_diagnostic.SST1104.severity = error # A query clause shares the last line of a multi-line previous clause
@@ -1188,8 +1173,9 @@ dotnet_diagnostic.SST1115.severity = error # A blank line separates a parameter 
 dotnet_diagnostic.SST1116.severity = error # A qualified name can be shortened without changing the symbol it binds to
 dotnet_diagnostic.SST1117.severity = error # Instance member access follows the configured this. qualification style
 dotnet_diagnostic.SST1118.severity = none # A parameter should not span multiple lines
+dotnet_diagnostic.SST1119.severity = error # A numeric literal groups its digit separators irregularly
 dotnet_diagnostic.SST1120.severity = error # A comment contains no text
-dotnet_diagnostic.SST1121.severity = none # A framework type name is used instead of its built-in alias — duplicate of RCS1013
+dotnet_diagnostic.SST1121.severity = error # A framework type name is used instead of its built-in alias (opt-in rule, enabled here)
 dotnet_diagnostic.SST1122.severity = error # An empty string literal is used instead of string.Empty
 dotnet_diagnostic.SST1123.severity = error # A #region is placed inside a code element body
 dotnet_diagnostic.SST1124.severity = error # A #region directive is used
@@ -1205,6 +1191,7 @@ dotnet_diagnostic.SST1134.severity = error # An attribute shares a line with ano
 dotnet_diagnostic.SST1135.severity = error # A using directive names a namespace or type that is not fully qualified
 dotnet_diagnostic.SST1136.severity = error # Several enum members share a line
 dotnet_diagnostic.SST1137.severity = error # Sibling elements are indented differently from one another
+dotnet_diagnostic.SST1138.severity = error # A free-standing block declares nothing
 dotnet_diagnostic.SST1139.severity = error # A numeric literal is cast where a literal suffix would express the type
 dotnet_diagnostic.SST1140.severity = error # Wrapped conditional operators should start indented continuation lines
 dotnet_diagnostic.SST1141.severity = error # An explicit ValueTuple<...> is used where tuple syntax would do
@@ -1258,7 +1245,7 @@ dotnet_diagnostic.SST1188.severity = error # Use the 'default' literal instead o
 dotnet_diagnostic.SST1189.severity = error # Variables should not be self-assigned
 dotnet_diagnostic.SST1190.severity = error # Doubled negation operators should be removed
 dotnet_diagnostic.SST1191.severity = error # Long numeric literals should use digit separators
-dotnet_diagnostic.SST1192.severity = none  # Control characters in string literals should be escaped
+dotnet_diagnostic.SST1192.severity = none # Control characters in string literals should be escaped
 dotnet_diagnostic.SST1193.severity = error # Keep initial member values with construction
 dotnet_diagnostic.SST1194.severity = error # Keep initial collection values with construction
 dotnet_diagnostic.SST1195.severity = error # Write null fallback with ??
@@ -1268,7 +1255,7 @@ dotnet_diagnostic.SST1198.severity = error # Collapse assignment-only branches i
 dotnet_diagnostic.SST1199.severity = error # Prefer compile-time type names
 
 # Ordering
-dotnet_diagnostic.SST1200.severity = none # Using directives should be placed outside the namespace — usings live outside file-scoped namespaces
+dotnet_diagnostic.SST1200.severity = error # Using directives should be placed outside the namespace
 dotnet_diagnostic.SST1201.severity = error # Members should be ordered by kind
 dotnet_diagnostic.SST1202.severity = error # Members should be ordered by accessibility
 dotnet_diagnostic.SST1203.severity = error # Constants should appear before fields
@@ -1286,6 +1273,10 @@ dotnet_diagnostic.SST1214.severity = error # Static readonly fields should appea
 dotnet_diagnostic.SST1215.severity = error # Instance readonly fields should appear before instance non-readonly fields
 dotnet_diagnostic.SST1216.severity = error # Using static directives should be placed after regular usings and before aliases
 dotnet_diagnostic.SST1217.severity = error # Using static directives should be ordered alphabetically
+dotnet_diagnostic.SST1218.severity = error # Other members separate a method's overloads
+dotnet_diagnostic.SST1219.severity = error # A switch default clause is not placed last
+dotnet_diagnostic.SST1220.severity = error # An all-named argument list is in a different order than the parameters. Code fix reorders it to declaration order. Info.
+dotnet_diagnostic.SST1221.severity = error # `where` constraint clauses are not ordered to match the type-parameter list. Code fix reorders them. Info.
 
 # Naming
 dotnet_diagnostic.SST1300.severity = none # Types and members should be PascalCase — naming duplicates existing analyzers
@@ -1306,6 +1297,9 @@ dotnet_diagnostic.SST1315.severity = error # Union member names should match the
 dotnet_diagnostic.SST1316.severity = none # Tuple element names should use the configured casing — tuple naming is not enforced here
 dotnet_diagnostic.SST1317.severity = none # Asynchronous method names should end with 'Async' — conflicts with this project's Rx-compatibility and naming mechanism
 dotnet_diagnostic.SST1318.severity = error # Overriding parameter names should match the base declaration
+dotnet_diagnostic.SST1319.severity = error # An enumeration's type name is not PascalCase
+dotnet_diagnostic.SST1320.severity = error # A parameter name matches its method's name
+dotnet_diagnostic.SST1321.severity = none # Public APIs intentionally use Async to describe asynchronous observable behavior without returning an awaitable.
 
 # Maintainability
 dotnet_diagnostic.SST1400.severity = error # An element does not declare an access modifier
@@ -1341,7 +1335,7 @@ dotnet_diagnostic.SST1430.severity = error # Rethrow with 'throw;' to preserve t
 dotnet_diagnostic.SST1431.severity = error # Static members of a generic type should use a type parameter
 dotnet_diagnostic.SST1432.severity = error # Classes with only static members should be static
 dotnet_diagnostic.SST1433.severity = error # Redundant constructors should be removed
-dotnet_diagnostic.SST1434.severity = error # Empty finalizers should be removed
+dotnet_diagnostic.SST1434.severity = error # see docs/rules/SST1434.md
 dotnet_diagnostic.SST1435.severity = error # Empty namespace declarations should be removed
 dotnet_diagnostic.SST1436.severity = error # Empty types should not be declared
 dotnet_diagnostic.SST1437.severity = error # Empty interfaces should not be declared
@@ -1352,7 +1346,61 @@ dotnet_diagnostic.SST1441.severity = error # Private fields assigned but never r
 dotnet_diagnostic.SST1442.severity = error # A function has too many direct branch points
 dotnet_diagnostic.SST1443.severity = error # A function has too much nested control flow
 dotnet_diagnostic.SST1444.severity = error # A loop cannot naturally reach a second iteration
+dotnet_diagnostic.SST1445.severity = error # A using directive is unnecessary
+dotnet_diagnostic.SST1446.severity = error # An inheritance chain is deeper than the configured maximum
+dotnet_diagnostic.SST1447.severity = error # An equality override delegates to object reference semantics
+dotnet_diagnostic.SST1448.severity = error # An argument is passed explicitly to a caller-info parameter
+dotnet_diagnostic.SST1449.severity = error # Code writes directly to the console
 dotnet_diagnostic.SST1450.severity = error # Store files as UTF-8 without a byte order mark
+dotnet_diagnostic.SST1451.severity = error # A DateTime is created without a DateTimeKind
+dotnet_diagnostic.SST1452.severity = error # A generic type parameter is never used
+dotnet_diagnostic.SST1453.severity = error # Statements after an unconditional exit should be removed
+dotnet_diagnostic.SST1454.severity = error # Composite format placeholders should match the supplied arguments
+dotnet_diagnostic.SST1455.severity = error # Unsafe modifiers should be used only when unsafe syntax is present
+dotnet_diagnostic.SST1456.severity = error # Readonly fields should not store mutable source-defined structs
+dotnet_diagnostic.SST1457.severity = error # Global suppressions should point at real declarations
+dotnet_diagnostic.SST1458.severity = error # Global suppression targets should use declaration ids directly
+dotnet_diagnostic.SST1459.severity = error # Grouping parentheses should be removed when the parent syntax already isolates the expression
+dotnet_diagnostic.SST1460.severity = error # Non-mutating struct members should be readonly
+dotnet_diagnostic.SST1461.severity = error # Private parameters that are never read should be removed
+dotnet_diagnostic.SST1462.severity = error # Suppressions for diagnostics already disabled by config should be removed
+dotnet_diagnostic.SST1463.severity = error # Symbol-name strings should use nameof
+dotnet_diagnostic.SST1464.severity = error # An else clause follows a branch that always jumps and can be unwrapped
+dotnet_diagnostic.SST1465.severity = error # An else block that only wraps an if can collapse to else-if
+dotnet_diagnostic.SST1466.severity = error # A case label sharing a section with default is redundant
+dotnet_diagnostic.SST1467.severity = error # A hand-driven enumerator loop can use foreach
+dotnet_diagnostic.SST1468.severity = error # Boolean logic should use the short-circuiting && and || operators
+dotnet_diagnostic.SST1469.severity = error # A non-nullable value type is compared to null
+dotnet_diagnostic.SST1470.severity = error # A trailing catch clause that only rethrows should be removed
+dotnet_diagnostic.SST1471.severity = error # Magic numbers should be named constants
+dotnet_diagnostic.SST1472.severity = error # Signatures should not declare too many parameters
+dotnet_diagnostic.SST1473.severity = error # A floating-point value is compared for exact equality (zero comparison allowed by default)
+dotnet_diagnostic.SST1474.severity = error # Both sides of an operator are the same expression
+dotnet_diagnostic.SST1475.severity = error # A condition repeats an earlier one in the chain, so its branch cannot run
+dotnet_diagnostic.SST1476.severity = error # Every branch of a conditional has the same body
+dotnet_diagnostic.SST1477.severity = error # An integer division is widened to floating point after it has already truncated
+dotnet_diagnostic.SST1478.severity = error # A shift count is zero, negative, or at least the operand's width
+dotnet_diagnostic.SST1479.severity = error # A count or length is compared against a value it can never take
+dotnet_diagnostic.SST1480.severity = error # An exception is constructed and then discarded
+dotnet_diagnostic.SST1481.severity = error # A bitwise operation has a constant operand that makes it pointless
+dotnet_diagnostic.SST1482.severity = error # GetHashCode reads mutable state
+dotnet_diagnostic.SST1483.severity = error # A constructor calls an overridable member
+dotnet_diagnostic.SST1484.severity = error # A declaration shadows an outer field or property (inherited fields included)
+dotnet_diagnostic.SST1485.severity = error # A member that must not throw throws
+dotnet_diagnostic.SST1486.severity = error # The same string literal is repeated instead of being named
+dotnet_diagnostic.SST1487.severity = error # A collection element is assigned twice with nothing reading it in between
+dotnet_diagnostic.SST1488.severity = error # An exception type does not declare the standard constructors (parameterless waivable)
+dotnet_diagnostic.SST1489.severity = error # An exception type carries serialization members the target framework has obsoleted
+dotnet_diagnostic.SST1490.severity = error # A base list names an interface the rest of the list already implies
+dotnet_diagnostic.SST1491.severity = error # A modifier restates the declaration's default
+dotnet_diagnostic.SST1492.severity = error # A value is tested against what it is then assigned, so the guard decides nothing
+dotnet_diagnostic.SST1493.severity = error # A method's whole body is a constant
+dotnet_diagnostic.SST1494.severity = error # A trailing argument repeats the parameter's default
+dotnet_diagnostic.SST1495.severity = error # '==' compares references on a type that overrides Equals, so the two disagree
+dotnet_diagnostic.SST1496.severity = error # An abstract type declares nothing abstract
+dotnet_diagnostic.SST1497.severity = error # A local is declared and never read
+dotnet_diagnostic.SST1498.severity = error # Only a nested type uses a private member
+dotnet_diagnostic.SST1499.severity = error # A static field visible outside its type can still be changed (internal fields included by default)
 
 # Layout
 dotnet_diagnostic.SST1500.severity = error # A brace in a multi-line construct shares its line with other code
@@ -1376,6 +1424,19 @@ dotnet_diagnostic.SST1517.severity = error # The file begins with one or more bl
 dotnet_diagnostic.SST1518.severity = error # The file does not end with exactly one newline
 dotnet_diagnostic.SST1519.severity = error # A multi-line child statement of a control-flow keyword omits its braces
 dotnet_diagnostic.SST1520.severity = error # The clauses of an if/else chain use braces inconsistently
+dotnet_diagnostic.SST1521.severity = error # A line is longer than the configured maximum (default 120 characters)
+dotnet_diagnostic.SST1522.severity = error # A file has more code lines than the configured maximum (default 500)
+dotnet_diagnostic.SST1523.severity = error # A member has more code lines than the configured maximum (default 60)
+dotnet_diagnostic.SST1524.severity = error # A switch section has more code lines than the configured maximum (default 20)
+dotnet_diagnostic.SST1525.severity = error # A multi-statement `switch` section has no braces; the braces-on policy extends to switch sections. Code fix wraps it.
+dotnet_diagnostic.SST1526.severity = error # A wrapped binary expression places the operator inconsistently. Configurable (`before`/`after`, default before). Opt-in.
+dotnet_diagnostic.SST1527.severity = error # The `=>` of an expression-bodied member wraps inconsistently. Configurable. Opt-in.
+dotnet_diagnostic.SST1528.severity = error # The `=` of a wrapped initializer wraps inconsistently. Configurable. Opt-in.
+dotnet_diagnostic.SST1529.severity = error # A wrapped `?.`/`.` call chain places the break inconsistently. Configurable. Opt-in.
+dotnet_diagnostic.SST1530.severity = error # A newline sits between a type declaration and its base list. Code fix pulls the base list onto the declaration line. Opt-in.
+dotnet_diagnostic.SST1531.severity = error # A short object initializer is split across lines. Code fix collapses it when it fits. Opt-in.
+dotnet_diagnostic.SST1532.severity = error # A file mixes line endings. Configurable (`lf`/`crlf`, default lf). Opt-in.
+dotnet_diagnostic.SST1533.severity = error # A source file contains no code. Opt-in.
 
 # Documentation
 dotnet_diagnostic.SST1600.severity = error # Externally visible members should be documented
@@ -1386,7 +1447,7 @@ dotnet_diagnostic.SST1605.severity = error # Partial element documentation shoul
 dotnet_diagnostic.SST1606.severity = error # The summary should have text
 dotnet_diagnostic.SST1607.severity = error # Partial element summary should have text
 dotnet_diagnostic.SST1608.severity = error # Documentation should not use the default placeholder summary
-dotnet_diagnostic.SST1609.severity = none  # Property documentation should have a value
+dotnet_diagnostic.SST1609.severity = none # Property documentation should have a value
 dotnet_diagnostic.SST1610.severity = error # Property value documentation should have text
 dotnet_diagnostic.SST1611.severity = error # Parameters should be documented
 dotnet_diagnostic.SST1612.severity = error # Parameter documentation should match the parameters
@@ -1423,12 +1484,21 @@ dotnet_diagnostic.SST1654.severity = error # Extension blocks should be document
 dotnet_diagnostic.SST1655.severity = error # Extension block parameters should be documented
 dotnet_diagnostic.SST1656.severity = error # Extension block type parameters should be documented
 dotnet_diagnostic.SST1657.severity = error # Extension block documentation should reference a real parameter or type parameter
+dotnet_diagnostic.SST1658.severity = error # Documentation text repeats a word
+dotnet_diagnostic.SST1659.severity = error # A comment has no text at all
+dotnet_diagnostic.SST1660.severity = error # The `<param>` tags are not in parameter order. Code fix reorders them. Info.
+dotnet_diagnostic.SST1661.severity = error # A snippet uses `<c>`/`<code>` mismatched to single- vs multi-line content. Code fix swaps the tag. Info.
+dotnet_diagnostic.SST1662.severity = none # A thrown exception type has no `<exception>` documentation. Code fix adds the skeleton. Opt-in.
+dotnet_diagnostic.SST1663.severity = none # A `//` comment before a public member reads like a summary; use `///`. Code fix converts it. Opt-in.
+dotnet_diagnostic.SST1664.severity = none # A summary separates paragraphs with blank lines instead of `<para>`. Code fix wraps them. Opt-in.
 
 # Concurrency and modernization
-dotnet_diagnostic.SST1900.severity = error # A dedicated object lock field should be a System.Threading.Lock
+dotnet_diagnostic.SST1900.severity = error # see docs/rules/SST1900.md
 dotnet_diagnostic.SST1901.severity = error # A lock targets a field or property reachable from outside the declaring type
 dotnet_diagnostic.SST1902.severity = error # Do not lock on 'this', a Type, or a string
 dotnet_diagnostic.SST1903.severity = error # Do not lock on a newly-created object
+dotnet_diagnostic.SST1904.severity = error # A lock targets a non-readonly field
+dotnet_diagnostic.SST1905.severity = error # An async method or converted delegate returns void
 dotnet_diagnostic.SST2000.severity = suggestion # A null check plus throw should use ArgumentNullException.ThrowIfNull
 dotnet_diagnostic.SST2001.severity = error # Use ArgumentException.ThrowIfNullOrEmpty
 dotnet_diagnostic.SST2002.severity = error # Use ArgumentException.ThrowIfNullOrWhiteSpace
@@ -1437,6 +1507,17 @@ dotnet_diagnostic.SST2004.severity = suggestion # A range check should use an Ar
 dotnet_diagnostic.SST2005.severity = error # Use the 'is' type pattern instead of comparing an 'as' cast to null
 dotnet_diagnostic.SST2006.severity = error # Use the 'is not' pattern instead of negating an 'is' check
 dotnet_diagnostic.SST2007.severity = error # Use declaration patterns instead of an is check followed by a cast local
+dotnet_diagnostic.SST2008.severity = error # Negated pattern tests should use is-not patterns
+dotnet_diagnostic.SST2009.severity = error # A catch that tests then rethrows can use a when filter
+dotnet_diagnostic.SST2010.severity = error # A type reads the machine clock directly instead of through a TimeProvider
+dotnet_diagnostic.SST2011.severity = error # An instant is recorded from the local clock rather than in UTC
+dotnet_diagnostic.SST2012.severity = error # A GUID is constructed with the parameterless constructor instead of Guid.Empty
+dotnet_diagnostic.SST2013.severity = error # An if whose entire body is another if should be merged
+dotnet_diagnostic.SST2014.severity = error # A goto jumps to a label
+dotnet_diagnostic.SST2015.severity = error # A ++ or -- is buried inside a larger expression
+dotnet_diagnostic.SST2016.severity = error # A DateTime on a visible signature loses its offset at the boundary
+dotnet_diagnostic.SST2017.severity = error # A .Date or .TimeOfDay read proves the value is only a date, or only a time of day
+dotnet_diagnostic.SST2018.severity = error # A redundant null check sits beside an is type pattern
 
 # Modern language and library usage
 dotnet_diagnostic.SST1700.severity = error # An extension block declares no members
@@ -1447,10 +1528,13 @@ dotnet_diagnostic.SST1704.severity = error # A class declaring extension blocks 
 dotnet_diagnostic.SST1705.severity = error # A class mixes classic extension methods with extension blocks
 dotnet_diagnostic.SST1706.severity = error # An extension block targets a broad receiver type such as object or dynamic
 dotnet_diagnostic.SST1707.severity = error # Extension blocks should be ordered by receiver type
+dotnet_diagnostic.SST1708.severity = error # An extension method never uses its `this` receiver, so it need not be an extension.
+dotnet_diagnostic.SST1709.severity = none # A method in a `*Extensions` class whose first parameter lacks `this`. Code fix converts it to an extension block. Opt-in.
 dotnet_diagnostic.SST1800.severity = error # Record classes should be sealed
 dotnet_diagnostic.SST1801.severity = error # A positional record parameter does not match the configured casing
 dotnet_diagnostic.SST1802.severity = error # A record declares a settable rather than init-only instance property
 dotnet_diagnostic.SST1803.severity = error # A record struct is not declared readonly
+dotnet_diagnostic.SST1804.severity = error # A positional record has an empty `{ }` body where `;` would do. Code fix rewrites it. Info.
 dotnet_diagnostic.SST2100.severity = error # An empty collection creation can use []
 dotnet_diagnostic.SST2101.severity = error # An explicit collection creation can use [...]
 dotnet_diagnostic.SST2102.severity = error # A span-targeted stackalloc initializer can use a collection expression
@@ -1466,7 +1550,7 @@ dotnet_diagnostic.SST2205.severity = none # An enum switch statement omits named
 dotnet_diagnostic.SST2206.severity = error # An enum switch expression omits named enum values
 dotnet_diagnostic.SST2207.severity = error # A null guard and return can keep the throw in the returned expression
 dotnet_diagnostic.SST2208.severity = error # An out variable can be declared at the call site
-dotnet_diagnostic.SST2209.severity = none  # A null-forgiving operator has no local effect
+dotnet_diagnostic.SST2209.severity = none # A null-forgiving operator has no local effect
 dotnet_diagnostic.SST2210.severity = error # A nullable directive repeats the current file-local state
 dotnet_diagnostic.SST2211.severity = error # A nullable restore directive has no file-local state to restore
 dotnet_diagnostic.SST2212.severity = error # Literal UTF-8 byte data can use a u8 string literal
@@ -1486,23 +1570,455 @@ dotnet_diagnostic.SST2225.severity = error # A foreach loop hides an explicit el
 dotnet_diagnostic.SST2226.severity = error # A cast hides an inner explicit conversion
 dotnet_diagnostic.SST2227.severity = error # A post-assignment null fallback can be folded into the assigned expression
 dotnet_diagnostic.SST2228.severity = error # A delegate local used only as a call target can be a local function
-dotnet_diagnostic.SST2229.severity = none # LINQ terminal predicate simplification is reserved for test code; production code should avoid LINQ on hot paths
-dotnet_diagnostic.SST2230.severity = none # LINQ type-filter simplification is reserved for test code; production code should avoid LINQ on hot paths
+dotnet_diagnostic.SST2229.severity = error # see docs/rules/SST2229.md
+dotnet_diagnostic.SST2230.severity = error # see docs/rules/SST2230.md
 dotnet_diagnostic.SST2231.severity = error # A broad object pattern can use a direct null pattern
 dotnet_diagnostic.SST2232.severity = error # nameof does not need concrete generic type arguments
-dotnet_diagnostic.SST2233.severity = error # Hot-path code should avoid System.Linq.Enumerable calls
-dotnet_diagnostic.RCS1040.severity = none # covered by SST1180
+dotnet_diagnostic.SST2233.severity = none # see docs/rules/SST2233.md
+dotnet_diagnostic.SST2234.severity = error # Nullable<T> should use the T? shorthand
+dotnet_diagnostic.SST2235.severity = error # Capture-free local functions should be static
+dotnet_diagnostic.SST2236.severity = error # Tail-position using blocks can use using declarations
+dotnet_diagnostic.SST2237.severity = error # Single block-scoped namespaces can use file-scoped syntax
+dotnet_diagnostic.SST2238.severity = error # Nested property patterns can use extended property syntax
+dotnet_diagnostic.SST2239.severity = error # Forwarding lambdas can use method groups
+dotnet_diagnostic.SST2240.severity = error # Delegate null checks can use conditional invocation
+dotnet_diagnostic.SST2241.severity = error # Constructors that only store parameters can use primary-constructor storage
+dotnet_diagnostic.SST2242.severity = error # Enum switch statement mappings should name every enum value or include a catch-all
+dotnet_diagnostic.SST2243.severity = error # A verbatim string with escapes or line breaks can use a raw string literal
+dotnet_diagnostic.SST2244.severity = error # A numeric literal's suffix is lower case
+dotnet_diagnostic.SST2245.severity = error # A for loop with only a condition should be a while loop
+dotnet_diagnostic.SST2246.severity = error # A chain of conditional expressions testing one value against constants can be a switch expression
+dotnet_diagnostic.SST2247.severity = error # Consecutive locals copying one value's members in order can be a deconstruction
+dotnet_diagnostic.SST2248.severity = error # Two constant comparisons of the same value can fold into one is-pattern
+dotnet_diagnostic.SST2249.severity = error # A literal-format string.Format or literal concatenation can be an interpolated string
+dotnet_diagnostic.SST2250.severity = error # A bare local assigned once by the next statement can be an initialized declaration
+dotnet_diagnostic.SST2251.severity = error # A method call names type arguments that inference would supply
+dotnet_diagnostic.SST2252.severity = error # A switch statement is nested inside another switch statement
+dotnet_diagnostic.SST2254.severity = none # A target-typed `new()` is written where an explicit type reads more clearly; the code fix restores `new TypeName(...)`. Opt-in — the counterpart to SST2202's target-typed direction, so a team enables at most one.
+dotnet_diagnostic.SST2255.severity = error # A hand-written null-or-empty string test. Code fix uses `string.IsNullOrEmpty`.
+dotnet_diagnostic.SST2256.severity = error # An extension method called in static form. Code fix rewrites to instance form. Info.
+dotnet_diagnostic.SST2257.severity = error # A lambda block body that is a single `return`. Code fix uses an expression body. Info.
+dotnet_diagnostic.SST2258.severity = error # A redundant explicit delegate wrapper (`new EventHandler(M)`). Code fix drops it. Info.
+dotnet_diagnostic.SST2259.severity = error # A stray `;` after a type declaration. Code fix removes it. Info.
+dotnet_diagnostic.SST2260.severity = error # An `as` cast to a type the operand already has. Code fix removes it. Info.
+dotnet_diagnostic.SST2261.severity = error # `(x && !y)
+dotnet_diagnostic.SST2262.severity = error # A raw string literal whose content needs no raw syntax. Code fix demotes it. Info.
+dotnet_diagnostic.SST2263.severity = error # An infinite loop whose body re-derives its stop condition. Code fix hoists the condition into the header. Info.
+dotnet_diagnostic.SST2264.severity = error # A numeric literal cast to an enum. Code fix names the member.
+dotnet_diagnostic.SST2265.severity = none # Consecutive fluent calls on one receiver can fold into a chain. Opt-in.
+dotnet_diagnostic.SST2266.severity = none # A local read exactly once can be inlined into that use. Opt-in.
+dotnet_diagnostic.SST2267.severity = none # Infinite loops written in mixed `while(true)`/`for(;;)` styles. Configurable. Opt-in.
+dotnet_diagnostic.SST2268.severity = none # Inconsistent `()` on object creation with an initializer. Configurable. Opt-in.
+dotnet_diagnostic.SST2269.severity = none # Inconsistent parentheses around a conditional's condition. Configurable. Opt-in.
+dotnet_diagnostic.SST2270.severity = none # Inconsistent explicit-vs-implicit array-creation type. Configurable. Opt-in.
+dotnet_diagnostic.SST2271.severity = none # `var`-vs-explicit local type per the configured preference. Configurable. Opt-in.
+dotnet_diagnostic.SST2272.severity = none # `[Flags]` member values written as mixed decimals and shifts. Configurable. Opt-in.
+dotnet_diagnostic.SST2273.severity = none # A function or loop body wraps its work in a trailing `if` that could be an early-exit guard clause. Code fix inverts it. Configurable threshold. Opt-in.
+dotnet_diagnostic.SST2274.severity = error # A value assigned with `as` and then null-checked is an `is` declaration pattern in one step. Code fix rewrites it.
+dotnet_diagnostic.SST2275.severity = error # A method whose block body is a single statement can use an expression body `=> expr`. Code fix rewrites it.
+dotnet_diagnostic.SST2276.severity = none # A constructor whose block body is a single statement can use an expression body. Code fix rewrites it. Opt-in.
+dotnet_diagnostic.SST2277.severity = none # An operator whose block body is a single `return` can use an expression body. Code fix rewrites it. Opt-in.
+dotnet_diagnostic.SST2278.severity = none # A conversion operator whose block body is a single `return` can use an expression body. Code fix rewrites it. Opt-in.
+dotnet_diagnostic.SST2279.severity = error # A get-only property whose getter is a single `return` can use a whole-member expression body. Code fix rewrites it.
+dotnet_diagnostic.SST2280.severity = error # A get-only indexer whose getter is a single `return` can use a whole-member expression body. Code fix rewrites it.
+dotnet_diagnostic.SST2281.severity = error # A local function whose block body is a single statement can use an expression body. Code fix rewrites it.
+dotnet_diagnostic.SST2282.severity = error # A reference-type `ReferenceEquals` check against `null` reads as an `is null` / `is not null` pattern. Code fix rewrites it.
+dotnet_diagnostic.SST2283.severity = error # A null guard that throws right before assigning the guarded value can fold into the assignment as `?? throw`. Code fix rewrites it.
+# Design
+dotnet_diagnostic.SST2300.severity = error # A class implements IDisposable but builds only half of the disposal pattern
+dotnet_diagnostic.SST2301.severity = error # A class implementing IEquatable<T> for itself can still be derived from
+dotnet_diagnostic.SST2302.severity = error # A type overloads an operator without the rest of the set it belongs to
+dotnet_diagnostic.SST2303.severity = error # A [Flags] enum's members are not distinct bit values
+dotnet_diagnostic.SST2304.severity = error # An event's delegate does not have the standard (object sender, TEventArgs e) shape
+dotnet_diagnostic.SST2305.severity = error # A mutable collection property declares a caller-visible setter
+dotnet_diagnostic.SST2306.severity = error # A collection-returning member hands back null
+dotnet_diagnostic.SST2307.severity = error # A generic method's type parameter appears in no parameter, so no caller can infer it
+dotnet_diagnostic.SST2308.severity = error # An [Obsolete] attribute carries no message
+dotnet_diagnostic.SST2309.severity = error # An externally visible member declares an optional parameter, so callers bake in the default
+dotnet_diagnostic.SST2310.severity = error # Deprecated code is still here; remove it once its last caller is gone
+dotnet_diagnostic.SST2311.severity = error # A visible const is copied into every assembly that reads it
+dotnet_diagnostic.SST2312.severity = error # A type is declared outside any namespace
+dotnet_diagnostic.SST2313.severity = error # An enum is stored as a type the project does not allow
+dotnet_diagnostic.SST2314.severity = none # An [Obsolete] has a message but no DiagnosticId — unusable here: ObsoleteAttribute.DiagnosticId is .NET 5+, and this source is shared with net462
+dotnet_diagnostic.SST2315.severity = error # A type owns a disposable field but does not implement IDisposable
+dotnet_diagnostic.SST2316.severity = error # A type declares Dispose or DisposeAsync without implementing IDisposable
+dotnet_diagnostic.SST2317.severity = error # A disposable type owns a raw IntPtr without a SafeHandle or finalizer
+dotnet_diagnostic.SST2318.severity = error # Two members have token-identical bodies
+dotnet_diagnostic.SST2319.severity = error # An overload's optional default can never be used
+dotnet_diagnostic.SST2320.severity = error # An interface inherits two interfaces that declare the same member
+dotnet_diagnostic.SST2321.severity = error # Environment.Exit or Environment.FailFast is called from library code
+dotnet_diagnostic.SST2322.severity = error # A non-private readonly field holds a mutable collection callers can still change
+dotnet_diagnostic.SST2323.severity = error # A stateless abstract class declaring only public abstract members should be an interface
+dotnet_diagnostic.SST2324.severity = error # A member is declared more accessible than its containing type
+dotnet_diagnostic.SST2325.severity = error # An async method checks an argument after its first await
+dotnet_diagnostic.SST2326.severity = none # An interface-typed value is narrowed to a concrete implementation — this is a high-performance core library, not strictly SOLID code, and narrowing to a known runtime type is a normal fast-path technique here: foreach over IEnumerable<T> boxes List<T>'s struct enumerator (40 bytes per call, measured) where the indexed loop behind the type test allocates nothing
+dotnet_diagnostic.SST2327.severity = error # A type tests its own runtime type against a class instead of dispatching through a virtual member
+dotnet_diagnostic.SST2328.severity = error # A raw native pointer handle is exposed instead of a SafeHandle
+dotnet_diagnostic.SST2329.severity = error # A `[Flags]` enum declares no zero-valued member. Code fix adds `None = 0`.
+dotnet_diagnostic.SST2330.severity = error # A `[Flags]` member is a numeric literal equal to a combination of others (`All = 7`). Code fix writes `A
+dotnet_diagnostic.SST2331.severity = none # An enum leaves member values implicit, so their numbers depend on declaration order. Opt-in.
+dotnet_diagnostic.SST2332.severity = error # An auto-property's `private set` is only written during construction; make it get-only.
+dotnet_diagnostic.SST2333.severity = none # A generic comparison/equality contract is implemented without its non-generic counterpart. Opt-in.
+dotnet_diagnostic.SST2334.severity = none # A publicly visible type has no `[DebuggerDisplay]`. Opt-in.
+dotnet_diagnostic.SST2335.severity = none # Parts of a partial type disagree on the `static` modifier. Opt-in.
+
+# Correctness
+dotnet_diagnostic.SST2400.severity = error # Two arguments name each other's parameters and have been transposed
+dotnet_diagnostic.SST2401.severity = error # A catch targets NullReferenceException
+dotnet_diagnostic.SST2402.severity = error # An instance constructor assigns a static field of its own type
+dotnet_diagnostic.SST2403.severity = error # 'this' escapes from a constructor before the object is fully built
+dotnet_diagnostic.SST2404.severity = error # An iterator's argument guard does not run until the first MoveNext
+dotnet_diagnostic.SST2405.severity = error # A [DebuggerDisplay] string names a member the type does not have
+dotnet_diagnostic.SST2406.severity = error # A loop's stop condition reads only variables the loop never writes
+dotnet_diagnostic.SST2407.severity = error # A declared event is never raised
+dotnet_diagnostic.SST2408.severity = error # A StringBuilder is filled and never read
+dotnet_diagnostic.SST2409.severity = error # A throw constructs a general exception type (Exception/SystemException/ApplicationException)
+dotnet_diagnostic.SST2410.severity = error # A created disposable is never disposed and never leaves the method
+dotnet_diagnostic.SST2411.severity = error # A for loop declares and tests a counter it never steps
+dotnet_diagnostic.SST2412.severity = error # A for loop update moves the counter away from its stop condition
+dotnet_diagnostic.SST2413.severity = error # A for loop condition can never be true on the first pass
+dotnet_diagnostic.SST2414.severity = error # Two branches of a conditional share the same implementation
+dotnet_diagnostic.SST2415.severity = error # A non-short-circuiting & or | evaluates a right operand that does work
+dotnet_diagnostic.SST2416.severity = error # A modulus result on a signed type is compared directly to 1
+dotnet_diagnostic.SST2417.severity = error # A compound assignment operator is transposed (=+, =-, =!)
+dotnet_diagnostic.SST2418.severity = error # The result of an immutable value's method is discarded
+dotnet_diagnostic.SST2419.severity = error # A set or collection operation is performed against itself
+dotnet_diagnostic.SST2420.severity = error # An IndexOf result is tested with > 0, skipping index 0
+dotnet_diagnostic.SST2421.severity = error # A write targets a readonly field of an unconstrained type parameter
+dotnet_diagnostic.SST2422.severity = error # A property getter returns a different field than its setter writes
+dotnet_diagnostic.SST2423.severity = error # A disposable created in a using statement is returned
+dotnet_diagnostic.SST2424.severity = error # An override changes a parameter's default value
+dotnet_diagnostic.SST2425.severity = error # An override drops an optional argument on its base call
+dotnet_diagnostic.SST2426.severity = error # An override adds or removes params on a parameter
+dotnet_diagnostic.SST2427.severity = error # A derived overload widens a parameter and hides the base overload
+dotnet_diagnostic.SST2428.severity = error # A static initializer reads a static field declared later
+dotnet_diagnostic.SST2429.severity = error # A setter, init, add, or remove accessor never reads value
+dotnet_diagnostic.SST2430.severity = error # A serialization callback has the wrong signature
+dotnet_diagnostic.SST2431.severity = error # A ToString override can return null
+dotnet_diagnostic.SST2432.severity = error # GetType is called on a value that is already a System.Type
+dotnet_diagnostic.SST2433.severity = error # A caller-info parameter is not last in the list
+dotnet_diagnostic.SST2434.severity = error # An array is assigned through a covariant element type
+dotnet_diagnostic.SST2435.severity = error # A non-object base's value-equality Equals is used as a reference-equality fast path
+dotnet_diagnostic.SST2436.severity = error # An event is raised with a null sender or null args
+dotnet_diagnostic.SST2437.severity = error # A generic type inherits from itself recursively
+dotnet_diagnostic.SST2438.severity = error # A catch that discards its exception logs at Error or Critical without it
+dotnet_diagnostic.SST2439.severity = error # An exception is passed as a log template argument instead of the exception parameter
+dotnet_diagnostic.SST2440.severity = error # Log template arguments are transposed
+dotnet_diagnostic.SST2441.severity = error # A log template has an empty or non-identifier placeholder
+dotnet_diagnostic.SST2442.severity = error # A log template repeats a named placeholder
+dotnet_diagnostic.SST2443.severity = error # An ILogger is injected or created with the wrong category type
+dotnet_diagnostic.SST2444.severity = error # A regular expression pattern is invalid
+dotnet_diagnostic.SST2445.severity = error # A culture-sensitive custom date or time format is used without an invariant culture
+dotnet_diagnostic.SST2446.severity = error # A Stream.ReadAsync result is discarded through ConfigureAwait or a local
+dotnet_diagnostic.SST2448.severity = error # A combined or opaque delegate is removed with - or -=, which strips only a contiguous run
+dotnet_diagnostic.SST2449.severity = error # A lambda or anonymous-method handler is removed with -=, which never matches it
+dotnet_diagnostic.SST2450.severity = error # A Debug.Assert condition performs a side effect that a release build compiles out
+dotnet_diagnostic.SST2451.severity = error # Every constructor is private and no member ever creates an instance
+dotnet_diagnostic.SST2452.severity = error # A [Pure] method returns void, Task, or ValueTask, so it has no observable result
+dotnet_diagnostic.SST2456.severity = error # An override or new field-like event gets its own backing delegate field
+dotnet_diagnostic.SST2457.severity = error # An integer Sum wrapped in unchecked still throws on overflow
+dotnet_diagnostic.SST2458.severity = error # A bitwise operator is applied to an enum not declared [Flags]
+dotnet_diagnostic.SST2459.severity = error # [Optional] on a ref or out parameter advertises an optionality no caller can use
+dotnet_diagnostic.SST2460.severity = error # [DefaultValue] on a method or record parameter is inert
+dotnet_diagnostic.SST2462.severity = error # A new member is less accessible than the inherited member it hides
+dotnet_diagnostic.SST2463.severity = error # A field differs from an inherited accessible field only by case
+dotnet_diagnostic.SST2464.severity = error # A mutable class declares a value-equality operator ==, so it is lost as a hash key
+dotnet_diagnostic.SST2465.severity = error # A for loop body reassigns the counter or the local its condition tests
+dotnet_diagnostic.SST2467.severity = error # A params overload is shadowed by a same-arity overload with a more specific last parameter
+dotnet_diagnostic.SST2468.severity = error # A classic partial method is declared but never implemented, so its calls are removed
+dotnet_diagnostic.SST2470.severity = error # Two string literals concatenate with no space, fusing a SQL keyword into the next token
+dotnet_diagnostic.SST2472.severity = error # A type is exported for a contract it neither implements nor inherits
+dotnet_diagnostic.SST2473.severity = error # A shared export part is constructed with new, bypassing the container
+dotnet_diagnostic.SST2474.severity = error # A part-creation-policy attribute is applied to a type with no [Export]
+dotnet_diagnostic.SST2475.severity = error # An entity's primary key is typed DateTime or DateTimeOffset
+dotnet_diagnostic.SST2479.severity = error # A loop variable captured by a callback stored beyond the iteration reads its final value
+dotnet_diagnostic.SST2481.severity = error # A GetHashCode override folds the base identity hash into a value hash
+dotnet_diagnostic.SST2484.severity = error # A handle read through DangerousGetHandle is not reference-counted
+dotnet_diagnostic.SST2485.severity = error # A NotImplementedException is left in shipped code
+dotnet_diagnostic.SST2486.severity = error # An assembly is loaded by path or partial name instead of Assembly.Load
+dotnet_diagnostic.SST2487.severity = error # A [ConstructorArgument] does not name a constructor parameter
+dotnet_diagnostic.SST2488.severity = error # An exception is logged and rethrown, duplicating the record
+dotnet_diagnostic.SST2489.severity = error # A relational comparison is decided by the operand's type rather than its value
+dotnet_diagnostic.SST2490.severity = error # Adjacent try statements with identical handling should be merged
+dotnet_diagnostic.SST2491.severity = error # A non-`async` method returns an awaitable from inside `using`/`try-finally`/`lock`, so the resource is torn down before the task completes. Code fix makes it `async`.
+dotnet_diagnostic.SST2492.severity = error # A null-guard throws on a parameter the signature declares may be null.
+dotnet_diagnostic.SST2493.severity = error # `== null`/`!= null` on an unconstrained generic `T`. Code fix uses `is null`/`is not null`.
+dotnet_diagnostic.SST2494.severity = error # A `??` whose left operand is a constant null, so the right is always taken. Code fix folds it.
+dotnet_diagnostic.SST2495.severity = error # A `[Flags]` combination includes an operand whose bits another already covers. Code fix removes it.
+dotnet_diagnostic.SST2496.severity = error # An explicit `Dispose`/`Close` on a resource an enclosing `using` already disposes. Code fix removes it. Info.
+
+# Testing
+dotnet_diagnostic.SST2500.severity = error # A test method contains no assertion and no expected-exception check
+dotnet_diagnostic.SST2501.severity = error # An equality or identity assertion compares an expression with itself
+dotnet_diagnostic.SST2502.severity = error # An equality assertion passes the constant as actual and the computed value as expected
+dotnet_diagnostic.SST2503.severity = error # An equality assertion compares a value against a boolean literal
+dotnet_diagnostic.SST2504.severity = error # A test fixture declares and inherits no test method
+dotnet_diagnostic.SST2505.severity = error # A test method declares parameters but no data source
+dotnet_diagnostic.SST2506.severity = error # A test method calls Thread.Sleep
+dotnet_diagnostic.SST2507.severity = error # A test method declares its expected failure with an expected-exception attribute
+dotnet_diagnostic.SST2508.severity = error # A fluent assertion is started but never completed
+dotnet_diagnostic.SST2509.severity = error # A test method has a shape the runner cannot execute
+
+# Logging
+dotnet_diagnostic.SST2600.severity = error # Application output is written through legacy Trace instead of a structured logger
+dotnet_diagnostic.SST2601.severity = error # A logger field or property does not follow the logger naming convention
+
+# Frameworks
+dotnet_diagnostic.SST2700.severity = error # An MVC route template contains a backslash; route segments are separated by `/`, so the route is unreachable. Code fix replaces `\` with `/`.
+dotnet_diagnostic.SST2701.severity = error # A `[JSInvokable]` method is not public, so JavaScript interop cannot call it. Code fix makes it public.
+dotnet_diagnostic.SST2702.severity = error # A `[SupplyParameterFromQuery]` property has a type the framework cannot bind from the query string, which throws at runtime.
+dotnet_diagnostic.SST2703.severity = error # A routable component's route constraint (`{id:int}`) disagrees with the matching `[Parameter]` CLR type, so the route silently fails to match.
+dotnet_diagnostic.SST2704.severity = error # A public action on an `[ApiController]` declares no HTTP-verb attribute, so it answers every verb and can make routing ambiguous.
+dotnet_diagnostic.SST2705.severity = none # A bound model member is a non-nullable value type with no required marker, so a request that omits it binds the default with no error. Opt-in.
+dotnet_diagnostic.SST2706.severity = error # A Windows Forms entry point carries neither `[STAThread]` nor `[MTAThread]`; without STA, clipboard, drag-and-drop, and common dialogs misbehave. Code fix adds `[STAThread]`.
+dotnet_diagnostic.SST2707.severity = none # A fire-and-forget `Task.Run` in a controller captures the request's `HttpContext`, which is disposed when the request ends, so the background work throws `ObjectDisposedException`. Opt-in.
+dotnet_diagnostic.SST2708.severity = error # A component subscribes to an event in a lifecycle method but never unsubscribes, so the event source keeps the component alive — a per-session leak on a Server circuit.
+dotnet_diagnostic.SST2709.severity = error # `StateHasChanged` is called while the component is being disposed, which the renderer no longer supports and throws.
+dotnet_diagnostic.SST2710.severity = error # `StateHasChanged` is called directly from a timer callback, off the renderer's dispatcher; marshal it with `InvokeAsync(StateHasChanged)`.
+dotnet_diagnostic.SST2711.severity = error # A synchronous component lifecycle method is overridden as `async void`, which the framework never awaits; override the `…Async` twin returning `Task`. Code fix rewrites the signature.
+dotnet_diagnostic.SST2712.severity = error # An `[Inject]`/`[CascadingParameter]` property has no setter, so the framework's reflection-based binding leaves it null. Code fix adds a setter.
+dotnet_diagnostic.SST2713.severity = error # A `DotNetObjectReference.Create(this)` is passed inline and never stored, so nothing can dispose it and it leaks on the JavaScript side.
 
 ###################
-# PublicApiAnalyzers (RSxxxx) - public API surface tracking
+# PerformanceSharp Analyzers (PSH)
 ###################
+performancesharp.avoid_linq_on_hot_path = true
+# performancesharp.empty_string_style = pattern            # PSH1204 (pattern | length | is_null_or_empty; the last two are only offered where the string is provably not null)
+# performancesharp.excluded_properties = Items, Keys       # PSH1017 (comma-separated; properties allowed to copy on read)
+# performancesharp.include_public = false                  # PSH1411 (set true in an app to seal public types too; a break in a library)
+dotnet_diagnostic.PSH1000.severity = error # Anonymous functions without captures should be static
+dotnet_diagnostic.PSH1001.severity = error # Avoid allocating zero-length arrays (fix prefers [] on C# 12+, else Array.Empty<T>())
+dotnet_diagnostic.PSH1002.severity = error # Empty finalizers should be removed
+dotnet_diagnostic.PSH1003.severity = error # 'in' parameters should use readonly structs
+dotnet_diagnostic.PSH1004.severity = error # Constant arrays passed as arguments should be hoisted
+dotnet_diagnostic.PSH1005.severity = error # Structs should define equality members to avoid boxing comparisons
+dotnet_diagnostic.PSH1006.severity = error # ConcurrentDictionary factories should use the lambda argument
+dotnet_diagnostic.PSH1007.severity = error # Pass large readonly structs by 'in' reference (size threshold + exclusions configurable)
+dotnet_diagnostic.PSH1008.severity = error # GC.SuppressFinalize does nothing for sealed finalizer-free types
+dotnet_diagnostic.PSH1009.severity = error # Bound variable-length stackalloc with a constant guard
+dotnet_diagnostic.PSH1010.severity = error # Clear reference-typed arrays when returning them to the pool
+dotnet_diagnostic.PSH1011.severity = error # Pass state to callbacks through the state-taking overload
+dotnet_diagnostic.PSH1012.severity = error # Compare type parameter values with EqualityComparer<T>.Default
+dotnet_diagnostic.PSH1013.severity = error # Expose constant UTF-8 data as a ReadOnlySpan<byte> property
+dotnet_diagnostic.PSH1014.severity = error # Declare immutable structs as readonly
+dotnet_diagnostic.PSH1015.severity = error # Avoid casting value types through object
+dotnet_diagnostic.PSH1016.severity = error # Test enum flags with bitwise operators instead of Enum.HasFlag
+dotnet_diagnostic.PSH1017.severity = error # A property allocates a copy of a collection on every read (excludable via performancesharp.PSH1017.excluded_properties)
+dotnet_diagnostic.PSH1018.severity = error # A hand-written array is passed to a params parameter
+dotnet_diagnostic.PSH1019.severity = error # The range indexer on an array allocates a copy; slice with AsSpan/AsMemory
+dotnet_diagnostic.PSH1020.severity = error # Prefer a jagged array over a multidimensional one
+dotnet_diagnostic.PSH1021.severity = error # An explicit GC.Collect or GC.WaitForPendingFinalizers forces collection the runtime tunes itself
+dotnet_diagnostic.PSH1022.severity = error # A parameterless `new EventArgs()` allocates where the shared `EventArgs.Empty` singleton would serve. Code fix uses the singleton.
+dotnet_diagnostic.PSH1100.severity = error # Hot-path code should avoid System.Linq.Enumerable calls
+dotnet_diagnostic.PSH1101.severity = none # LINQ terminal predicate simplification is reserved for test code; production code should avoid LINQ on hot paths
+dotnet_diagnostic.PSH1102.severity = none # LINQ type-filter simplification is reserved for test code; production code should avoid LINQ on hot paths
+dotnet_diagnostic.PSH1103.severity = error # Prefer the collection's own count over enumerating
+dotnet_diagnostic.PSH1104.severity = error # Use TryGetValue instead of ContainsKey followed by an indexer read
+dotnet_diagnostic.PSH1105.severity = error # Avoid double lookups on dictionaries and sets
+dotnet_diagnostic.PSH1106.severity = error # Index collections directly instead of using LINQ element access
+dotnet_diagnostic.PSH1107.severity = error # Filter sequences before sorting them
+dotnet_diagnostic.PSH1108.severity = error # Chain secondary sorts with ThenBy
+dotnet_diagnostic.PSH1109.severity = error # Merge consecutive Where calls
+dotnet_diagnostic.PSH1110.severity = error # Use the collection's own predicate methods over LINQ
+dotnet_diagnostic.PSH1111.severity = error # Use Contains for membership tests
+dotnet_diagnostic.PSH1112.severity = error # Seed the collection through its constructor (fix honors performancesharp.prefer_collection_expressions)
+dotnet_diagnostic.PSH1113.severity = error # Sort naturally instead of ordering by the element itself
+dotnet_diagnostic.PSH1114.severity = none # Freeze static lookup collections that are never mutated. Opt-in.
+dotnet_diagnostic.PSH1115.severity = error # Insert-if-absent should probe the dictionary once
+dotnet_diagnostic.PSH1116.severity = error # Probe string-keyed collections with a span through GetAlternateLookup
+dotnet_diagnostic.PSH1117.severity = error # Ask the collection whether it is empty
+dotnet_diagnostic.PSH1118.severity = error # Take the extreme element with Min/Max/MinBy/MaxBy instead of sorting
+dotnet_diagnostic.PSH1119.severity = error # Check for elements with Any instead of counting them all
+dotnet_diagnostic.PSH1120.severity = error # Do not materialize a sequence with ToList/ToArray just to enumerate it
+dotnet_diagnostic.PSH1122.severity = error # Read a sorted set's extreme through its Min/Max property, not the LINQ extension
+dotnet_diagnostic.PSH1124.severity = error # Read a linked list's end through its First/Last property, not the LINQ extension
+dotnet_diagnostic.PSH1125.severity = error # Do not enumerate the same lazy sequence twice
+dotnet_diagnostic.PSH1126.severity = error # Ask whether an async sequence has elements instead of counting them
+dotnet_diagnostic.PSH1127.severity = error # Clear an array instead of filling it with its default
+dotnet_diagnostic.PSH1200.severity = error # Compare strings without allocating case-converted copies
+dotnet_diagnostic.PSH1201.severity = error # Use the char overload for single-character strings
+dotnet_diagnostic.PSH1202.severity = error # Append characters as char, not single-character strings
+dotnet_diagnostic.PSH1203.severity = error # Let StringBuilder do the formatting work
+dotnet_diagnostic.PSH1204.severity = error # Test for empty strings by length
+dotnet_diagnostic.PSH1205.severity = error # Remove interpolation that does no work
+dotnet_diagnostic.PSH1206.severity = error # Do not build strings by concatenation in loops
+dotnet_diagnostic.PSH1207.severity = error # Specify StringComparison for culture-sensitive string operations
+dotnet_diagnostic.PSH1208.severity = error # Encode constant strings with u8 literals
+dotnet_diagnostic.PSH1209.severity = error # Build transformed strings with string.Create
+dotnet_diagnostic.PSH1210.severity = error # Compare UTF-8 bytes without decoding them
+dotnet_diagnostic.PSH1211.severity = error # Pass values directly instead of ToString results
+dotnet_diagnostic.PSH1212.severity = error # Slice with AsSpan when the call accepts a span
+dotnet_diagnostic.PSH1213.severity = error # Probe repeated character sets through SearchValues
+dotnet_diagnostic.PSH1214.severity = error # Append the parts of a concatenation separately, not the concatenated whole
+dotnet_diagnostic.PSH1215.severity = error # Use string.Concat instead of string.Join with an empty separator
+dotnet_diagnostic.PSH1216.severity = error # Use string.Equals instead of comparing string.Compare to zero
+dotnet_diagnostic.PSH1217.severity = error # A sequence is copied to an array just to be read straight back
+dotnet_diagnostic.PSH1218.severity = error # A substring is allocated only to search it; slice with AsSpan instead
+dotnet_diagnostic.PSH1219.severity = error # Ask whether a string is blank without trimming it
+dotnet_diagnostic.PSH1220.severity = error # A length argument spells out the run that reaches the end anyway
+dotnet_diagnostic.PSH1221.severity = error # An IndexOf compared to 0 scans the whole string to answer a prefix test
+dotnet_diagnostic.PSH1222.severity = error # Concatenate slices without materializing them
+dotnet_diagnostic.PSH1223.severity = error # A reused composite format string is re-parsed on every call
+dotnet_diagnostic.PSH1224.severity = error # Convert bytes to hex in one call, not by building the string twice
+dotnet_diagnostic.PSH1225.severity = error # Decode bytes to a string in one call, without a throwaway char[]
+dotnet_diagnostic.PSH1226.severity = error # A string's `ToCharArray()` result is only iterated, allocating a throwaway `char[]`; iterate the string directly. Code fix drops the copy.
+dotnet_diagnostic.PSH1227.severity = error # A cheaper equivalent exists — `string.CompareOrdinal` over `Compare(…, Ordinal)`, `Debug.Fail` over `Debug.Assert(false, …)`. Info. Code fix rewrites the call.
+dotnet_diagnostic.PSH1300.severity = error # Use System.Threading.Lock for a dedicated lock object
+dotnet_diagnostic.PSH1301.severity = error # Do not wrap a single task in WhenAll or WaitAll
+dotnet_diagnostic.PSH1302.severity = error # TaskCompletionSource should run continuations asynchronously
+dotnet_diagnostic.PSH1303.severity = error # Do not block an async method with Thread.Sleep
+dotnet_diagnostic.PSH1304.severity = error # Use PeriodicTimer instead of pacing a loop with Task.Delay
+dotnet_diagnostic.PSH1305.severity = error # Enumerate a ConcurrentDictionary directly, not its Keys/Values snapshots
+dotnet_diagnostic.PSH1306.severity = none # Guard one-time execution with an interlocked latch. Opt-in.
+dotnet_diagnostic.PSH1307.severity = error # Access interlocked fields with Volatile
+dotnet_diagnostic.PSH1308.severity = error # Return the completed task instead of Task.FromResult
+dotnet_diagnostic.PSH1309.severity = none # Register cancellation callbacks without flowing the execution context. Opt-in.
+dotnet_diagnostic.PSH1310.severity = error # Dispose IAsyncDisposable resources with await using in async code
+dotnet_diagnostic.PSH1311.severity = error # Remove a pass-through async state machine and return the task directly
+dotnet_diagnostic.PSH1312.severity = error # Return a completed task instead of null
+dotnet_diagnostic.PSH1313.severity = error # A synchronous call where an async overload fits
+dotnet_diagnostic.PSH1314.severity = error # Read and write streams through the memory-based overloads
+dotnet_diagnostic.PSH1315.severity = error # A blocking wait on an awaitable that may not be done
+dotnet_diagnostic.PSH1316.severity = error # A ValueTask is awaited in a loop or awaited after being copied
+dotnet_diagnostic.PSH1400.severity = error # Use the static HashData method for one-shot hashing
+dotnet_diagnostic.PSH1401.severity = error # Attribute types should be sealed
+dotnet_diagnostic.PSH1402.severity = error # Use const for compile-time constants
+dotnet_diagnostic.PSH1403.severity = error # Do not initialize fields to their default value
+dotnet_diagnostic.PSH1404.severity = error # Get the assembly from typeof instead of a stack walk
+dotnet_diagnostic.PSH1405.severity = error # Use the direct Environment APIs
+dotnet_diagnostic.PSH1406.severity = error # Ask Regex for the answer directly
+dotnet_diagnostic.PSH1407.severity = error # Query the dictionary, not its Keys view
+dotnet_diagnostic.PSH1408.severity = error # Measure elapsed time with Stopwatch timestamps
+dotnet_diagnostic.PSH1409.severity = error # Use the built-in throw helpers for argument guards
+dotnet_diagnostic.PSH1410.severity = none # Mark trivial forwarders for aggressive inlining. Opt-in.
+dotnet_diagnostic.PSH1411.severity = error # Seal non-public types nothing derives from so the JIT can devirtualize
+dotnet_diagnostic.PSH1412.severity = error # Use Random.Shared instead of allocating a Random
+dotnet_diagnostic.PSH1413.severity = error # Read the Unix epoch from the framework, not a hand-built DateTime
+dotnet_diagnostic.PSH1414.severity = error # Mark members that do not touch instance state as static
+dotnet_diagnostic.PSH1415.severity = error # Hold the concrete type when the concrete type is what you have
+dotnet_diagnostic.PSH1416.severity = error # Cache the serializer options instead of building them per call
+dotnet_diagnostic.PSH1417.severity = error # Do not compute an expensive argument for an assertion
+dotnet_diagnostic.PSH1418.severity = error # An HttpClient is constructed on every call
+dotnet_diagnostic.PSH1419.severity = error # A time-zone is resolved with a platform-specific id instead of the cross-platform API
+dotnet_diagnostic.PSH1420.severity = error # A shareable client held in an instance field of an Azure Functions worker class is rebuilt on every invocation, leaking sockets and connections; share a static/singleton client or inject `IHttpClientFactory`.
+
+# ASP.NET Core - inert in this repo (no route handlers or middleware), enabled so the set stays complete
+dotnet_diagnostic.PSH1500.severity = error # A minimal API handler returns Results instead of TypedResults, boxing the result
+dotnet_diagnostic.PSH1501.severity = error # Middleware uses the legacy nested-delegate Use overload, allocating a per-request closure
+dotnet_diagnostic.PSH1502.severity = error # A route handler returns a deferred sequence the serializer enumerates on the request thread
+dotnet_diagnostic.PSH1503.severity = error # Response caching is used where server-side output caching applies
+dotnet_diagnostic.PSH1505.severity = error # Exceptions are handled in an MVC exception filter instead of an IExceptionHandler
+dotnet_diagnostic.PSH1506.severity = error # The HTTP request or response body is read or written synchronously (`ReadToEnd`, `Body.Read`, `Body.Write`), which blocks a thread on Kestrel and buffers the whole payload; use the async overload. Code fix awaits it when the method is already async.
+
+# Blazor
+dotnet_diagnostic.PSH1600.severity = error # A delegate captured per iteration inside a component render loop reallocates on every render (measured ~128 B per row per render) and churns the diff; hoist it to a cached delegate or a precomputed per-item model.
+dotnet_diagnostic.PSH1601.severity = error # A JavaScript-interop call is issued once per loop iteration; on Interactive Server each is a separate SignalR round-trip. Batch into a single call over the collection.
+dotnet_diagnostic.PSH1602.severity = error # `StateHasChanged` is called unconditionally in `OnAfterRender`/`OnAfterRenderAsync`, scheduling another render every time — a runaway loop. Guard it with `firstRender` or a state flag.
+dotnet_diagnostic.PSH1603.severity = error # A non-delegate allocation is used as a component-parameter value inside a render loop, allocating per item and forcing the child to re-render each pass. Sibling of PSH1600.
+
+###################
+# SecuritySharp Analyzers (SES)
+###################
+# Every rule is raised to error, including the three that ship at suggestion (SES1403, SES1506,
+# SES1605). Security rules only ever suggest an API they can resolve in the compilation and report
+# local shapes only - there is no interprocedural taint tracking, so the taint-flow CA rules stay on.
+# securitysharp.SES1003.iterations = 100000                # minimum accepted PBKDF2 iteration count
+# securitysharp.SES1403.maxdepth = 64                      # highest accepted System.Text.Json MaxDepth
+
+# Cryptography
+dotnet_diagnostic.SES1001.severity = error # AEAD encryption must not use a constant or reused nonce
+dotnet_diagnostic.SES1002.severity = error # Password-based key derivation must not use a constant or predictable salt
+dotnet_diagnostic.SES1003.severity = error # Password-based key derivation must use a sufficient iteration count
+dotnet_diagnostic.SES1004.severity = error # A secret must not be produced from Guid.NewGuid()
+dotnet_diagnostic.SES1005.severity = error # Compare secret values in constant time
+dotnet_diagnostic.SES1006.severity = error # A Data Protection key ring is persisted without a ProtectKeysWith call, so keys sit unencrypted at rest
+dotnet_diagnostic.SES1007.severity = error # A cryptographic primitive is implemented by hand instead of using a vetted platform algorithm
+dotnet_diagnostic.SES1008.severity = error # An XML signature is verified with the no-key CheckSignature overload, trusting the document's own KeyInfo
+dotnet_diagnostic.SES1009.severity = error # A password is stored without a slow, salted key-derivation function
+
+# Transport
+dotnet_diagnostic.SES1102.severity = error # Do not accept any server certificate
+dotnet_diagnostic.SES1104.severity = error # Certificate-chain validation must not be deliberately weakened
+dotnet_diagnostic.SES1105.severity = error # Bearer and OpenID Connect metadata must not be retrieved over plain HTTP outside development
+dotnet_diagnostic.SES1106.severity = error # Do not send HttpClient requests to a cleartext http URL
+dotnet_diagnostic.SES1107.severity = error # A SQL connection string weakens transport security via TrustServerCertificate or a disabled Encrypt
+dotnet_diagnostic.SES1108.severity = error # A custom server-certificate validation callback unconditionally returns true, so any certificate is trusted
+
+# Secrets
+dotnet_diagnostic.SES1201.severity = error # Do not hard-code secrets in source
+dotnet_diagnostic.SES1202.severity = error # Do not hard-code a credential value
+dotnet_diagnostic.SES1203.severity = error # A connection string names a user but supplies an empty or missing password
+
+# Injection
+dotnet_diagnostic.SES1301.severity = error # Do not build a process command line from non-constant string parts
+dotnet_diagnostic.SES1302.severity = error # A shell-executed process must not use a non-constant FileName
+dotnet_diagnostic.SES1303.severity = error # Regular-expression pattern must not be built from non-constant data
+dotnet_diagnostic.SES1304.severity = error # An archive entry name must not build a write path without a containment check
+dotnet_diagnostic.SES1305.severity = error # Do not build a storage path from an uploaded file name
+dotnet_diagnostic.SES1306.severity = error # Do not compile or execute non-constant C# via the scripting API
+dotnet_diagnostic.SES1307.severity = error # Path.GetTempFileName creates a predictable, world-readable temporary file
+dotnet_diagnostic.SES1308.severity = error # A file or directory is created group- or world-writable
+dotnet_diagnostic.SES1309.severity = error # An XSLT stylesheet is loaded with embedded script enabled
+dotnet_diagnostic.SES1310.severity = error # A directory bind is performed without authenticating
+
+# Serialization
+dotnet_diagnostic.SES1401.severity = error # A type resolved from non-constant data must not be instantiated or deserialized
+dotnet_diagnostic.SES1402.severity = error # Do not load an assembly from raw bytes or a non-constant location
+dotnet_diagnostic.SES1403.severity = error # JSON deserialization depth limit must stay within a safe ceiling
+dotnet_diagnostic.SES1404.severity = error # A type is instantiated by name from a non-constant Activator typeName
+dotnet_diagnostic.SES1405.severity = error # MessagePack typeless deserialization reconstructs whatever type the payload names
+dotnet_diagnostic.SES1406.severity = warning # Reflection must not reach non-public members via BindingFlags.NonPublic (opt-in; replaces S3011)
+
+# Web hardening
+dotnet_diagnostic.SES1501.severity = error # A CORS policy must not allow credentials together with any origin
+dotnet_diagnostic.SES1502.severity = error # A CORS origin predicate must not unconditionally allow every origin
+dotnet_diagnostic.SES1503.severity = error # JWT signature verification must not be disabled on TokenValidationParameters
+dotnet_diagnostic.SES1504.severity = error # A cookie with SameSite=None must be marked Secure
+dotnet_diagnostic.SES1505.severity = error # The request body size limit must not be removed
+dotnet_diagnostic.SES1506.severity = error # The developer exception page must be guarded by a development-environment check
+dotnet_diagnostic.SES1507.severity = error # AllowAnonymous and Authorize on the same declaration conflict
+dotnet_diagnostic.SES1508.severity = error # A validation method must not fail open by returning success from a catch
+dotnet_diagnostic.SES1509.severity = error # A backtracking-prone constant regex runs without a match timeout or NonBacktracking
+dotnet_diagnostic.SES1510.severity = error # A controller redirects to a non-constant URL, allowing an open redirect
+dotnet_diagnostic.SES1511.severity = error # The forwarded-headers trust boundary is cleared, letting proxies spoof the client IP
+dotnet_diagnostic.SES1512.severity = error # Sensitive framework diagnostics are enabled without a development-environment guard
+dotnet_diagnostic.SES1513.severity = error # An AuthorizeAsync result is discarded, so the guarded operation runs regardless
+dotnet_diagnostic.SES1514.severity = error # OpenID Connect protections (PKCE, state, nonce) are disabled
+dotnet_diagnostic.SES1515.severity = error # A Content-Security-Policy value disables its own protection
+
+# AI trust boundaries
+dotnet_diagnostic.SES1601.severity = error # An LLM system prompt must be a constant, trusted template
+dotnet_diagnostic.SES1602.severity = error # Do not route AI model output into a process, file, or raw SQL sink
+dotnet_diagnostic.SES1603.severity = error # An AI tool declared read-only or non-destructive must not call a state-changing API
+dotnet_diagnostic.SES1604.severity = error # Prompt-template input encoding must not be disabled
+dotnet_diagnostic.SES1605.severity = error # AI instrumentation must not enable sensitive-data capture
+dotnet_diagnostic.SES1606.severity = error # Do not fetch model weights over cleartext HTTP
+
+# Web UI trust boundaries
+dotnet_diagnostic.SES1701.severity = error # Raw HTML is rendered from a non-constant value (`MarkupString`/`AddMarkupContent`), bypassing automatic encoding — an XSS risk. Sanitizer allow-list via `securitysharp.SES1701.sanitizers`.
+dotnet_diagnostic.SES1702.severity = error # A JavaScript-interop call targets a script-evaluation primitive (`eval`, `Function`, `document.write`), turning interop into a script-injection channel.
+dotnet_diagnostic.SES1703.severity = error # `[Authorize]` on a non-routable component enforces nothing — authorization runs as a routing concern. Exempt types via `securitysharp.SES1703.exempt_types`.
+dotnet_diagnostic.SES1704.severity = error # `IHttpContextAccessor` or a cascading `HttpContext` is used in an interactively-rendered component, where it is null or frozen at circuit start.
+dotnet_diagnostic.SES1705.severity = error # `NavigationManager.NavigateTo` is called with a target that is not a verified relative URL — an open-redirect risk. Validator allow-list via `securitysharp.SES1705.validators`.
+dotnet_diagnostic.SES1706.severity = error # An uploaded file is read with an unbounded or client-chosen size limit, letting an attacker fill server memory. Threshold via `securitysharp.SES1706.max_bytes`.
+dotnet_diagnostic.SES1707.severity = error # A secret-shaped literal appears in code reachable as WebAssembly, which downloads to the browser in full — guaranteed disclosure.
+dotnet_diagnostic.SES1708.severity = error # `CircuitOptions.DetailedErrors` is enabled, shipping server exception detail to every connected client.
+dotnet_diagnostic.SES1709.severity = error # `SerializeAllClaims` serializes every claim into client-readable WebAssembly authentication state, exposing internal ids, tokens, and PII.
+dotnet_diagnostic.SES1710.severity = error # Antiforgery validation is disabled on a form (`[RequireAntiforgeryToken(required: false)]`), removing CSRF protection.
+
+
+###################
+# Microsoft.CodeAnalysis.PublicApiAnalyzers (RS)
+###################
+# Public API surface tracking
 dotnet_diagnostic.RS0016.severity = error # public symbol missing from the PublicAPI baseline
 dotnet_diagnostic.RS0017.severity = error # PublicAPI baseline entry no longer in source
 
 ###################
-# Trimming Analyzer Warnings (IL2001 - IL2123)
-# See: https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/
+# Microsoft.NET.ILLink.Analyzers (IL)
 ###################
+# Trimming
+# See: https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/
 dotnet_diagnostic.IL2001.severity = error # Type in UnreferencedCode attribute doesn't have matching RequiresUnreferencedCode
 dotnet_diagnostic.IL2002.severity = error # Method with RequiresUnreferencedCode called from code without that attribute
 dotnet_diagnostic.IL2003.severity = error # RequiresUnreferencedCode attribute is only supported on methods
@@ -1618,10 +2134,8 @@ dotnet_diagnostic.IL2117.severity = error # Methods with DynamicallyAccessedMemb
 dotnet_diagnostic.IL2122.severity = error # Reflection call to method with UnreferencedCode attribute cannot be statically analyzed
 dotnet_diagnostic.IL2123.severity = error # DynamicallyAccessedMembers on method or parameter doesn't match overridden member
 
-###################
-# AOT Analyzer Warnings (IL3xxx)
+# Native AOT
 # See: https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/warnings/
-###################
 dotnet_diagnostic.IL3050.severity = error # Using member annotated with RequiresDynamicCode
 dotnet_diagnostic.IL3051.severity = error # RequiresDynamicCode attribute is only supported on methods and constructors
 dotnet_diagnostic.IL3052.severity = error # RequiresDynamicCode attribute on type is not supported
@@ -1631,490 +2145,473 @@ dotnet_diagnostic.IL3055.severity = error # MakeGenericType on non-supported typ
 dotnet_diagnostic.IL3056.severity = error # MakeGenericMethod on non-supported method requires dynamic code
 dotnet_diagnostic.IL3057.severity = error # Reflection access to generic parameter requires dynamic code
 
+###################
+# SonarAnalyzer.CSharp (S)
+###################
+# Repository suppressions
+dotnet_diagnostic.S1075.severity = none # Hardcoded URI — canonical SourceLink hosts are the point
+dotnet_diagnostic.S2436.severity = none # Too many generic parameters — needed for the projector overload
+dotnet_diagnostic.S4036.severity = none # PATH-relative process spawn — benchmark only, trusted env
+dotnet_diagnostic.S8969.severity = none # Nullability inference is inconsistent across the repository's target frameworks
 
-###################
-# SonarAnalyzer (Sxxxx) - Blocker Bug
-###################
-dotnet_diagnostic.S1048.severity = error # Finalizers should not throw exceptions
+# Blocker bugs
+dotnet_diagnostic.S1048.severity = none # Finalizers should not throw exceptions — covered by SST1485
 dotnet_diagnostic.S2190.severity = none # Loops and recursions should not be infinite
 dotnet_diagnostic.S2275.severity = none # Composite format strings should not lead to unexpected behavior at runtime - DUPLICATE CA2241
-dotnet_diagnostic.S2857.severity = error # SQL keywords should be delimited by whitespace
-dotnet_diagnostic.S2930.severity = error # "IDisposables" should be disposed
-dotnet_diagnostic.S2931.severity = error # Classes with "IDisposable" members should implement "IDisposable"
-dotnet_diagnostic.S3464.severity = error # Type inheritance should not be recursive
-dotnet_diagnostic.S3869.severity = error # "SafeHandle.DangerousGetHandle" should not be called
-dotnet_diagnostic.S3889.severity = error # "Thread.Resume" and "Thread.Suspend" should not be used
-dotnet_diagnostic.S4159.severity = error # Classes should implement their "ExportAttribute" interfaces
+dotnet_diagnostic.S2857.severity = none # SQL keywords should be delimited by whitespace — covered by SST2470
+dotnet_diagnostic.S2930.severity = none # "IDisposables" should be disposed — covered by SST2410
+dotnet_diagnostic.S2931.severity = none # Classes with "IDisposable" members should implement "IDisposable" — covered by SST2315
+dotnet_diagnostic.S3464.severity = none # Type inheritance should not be recursive — covered by SST2437
+dotnet_diagnostic.S3869.severity = none # "SafeHandle.DangerousGetHandle" should not be called -> replaced by SST2484
+dotnet_diagnostic.S3889.severity = none # "Thread.Resume" and "Thread.Suspend" should not be used -> replaced by obsolete or compiler
+dotnet_diagnostic.S4159.severity = none # Classes should implement their "ExportAttribute" interfaces — covered by SST2472
 
-###################
-# SonarAnalyzer (Sxxxx) - Critical Bug
-###################
-dotnet_diagnostic.S2551.severity = error # Shared resources should not be used for locking
-dotnet_diagnostic.S2952.severity = error # Classes should "Dispose" of members from the classes' own "Dispose" methods
-dotnet_diagnostic.S3449.severity = error # Right operands of shift operators should be integers
-dotnet_diagnostic.S4275.severity = error # Getters and setters should access the expected fields
-dotnet_diagnostic.S4277.severity = error # "Shared" parts should not be created with "new"
-dotnet_diagnostic.S4583.severity = error # Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-dotnet_diagnostic.S4586.severity = error # Non-async "Task/Task<T>" methods should not return null
-dotnet_diagnostic.S5856.severity = error # Regular expressions should be syntactically valid
-dotnet_diagnostic.S6674.severity = error # Log message template should be syntactically correct
+# Critical bugs
+dotnet_diagnostic.S2551.severity = none # Shared resources should not be used for locking — covered by SST1902
+dotnet_diagnostic.S2952.severity = none # Classes should "Dispose" of members from the classes' own "Dispose" methods -> replaced by SST2315
+dotnet_diagnostic.S3449.severity = none # Right operands of shift operators should be integers -> replaced by SST1478
+dotnet_diagnostic.S4275.severity = none # Getters and setters should access the expected fields — covered by SST2422
+dotnet_diagnostic.S4277.severity = none # "Shared" parts should not be created with "new" — covered by SST2473
+dotnet_diagnostic.S4583.severity = none # Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke" -> replaced by obsolete (APM BeginInvoke/EndInvoke)
+dotnet_diagnostic.S4586.severity = none # Non-async "Task/Task<T>" methods should not return null — covered by PSH1312
+dotnet_diagnostic.S5856.severity = none # Regular expressions should be syntactically valid — covered by SST2444
+dotnet_diagnostic.S6674.severity = none # Log message template should be syntactically correct — covered by SST2441
 
-###################
-# SonarAnalyzer (Sxxxx) - Major Bug
-###################
-dotnet_diagnostic.S1244.severity = error # Floating point numbers should not be tested for equality
+# Major bugs
+dotnet_diagnostic.S1244.severity = none # Floating point numbers should not be tested for equality — covered by SST1473
 dotnet_diagnostic.S1656.severity = none # Variables should not be self-assigned — covered by SST1189
 dotnet_diagnostic.S1751.severity = none # Loops with at most one iteration should be refactored - covered by SST1444
-dotnet_diagnostic.S1764.severity = error # Identical expressions should not be used on both sides of operators
-dotnet_diagnostic.S1848.severity = error # Objects should not be created to be dropped immediately without being used
-dotnet_diagnostic.S1862.severity = error # Related "if/else if" statements should not have the same condition
-dotnet_diagnostic.S2114.severity = error # Collections should not be passed as arguments to their own methods
-dotnet_diagnostic.S2123.severity = error # Values should not be uselessly incremented
-dotnet_diagnostic.S2201.severity = error # Methods without side effects should not have their return values ignored
-dotnet_diagnostic.S2225.severity = error # "ToString()" method should not return null
-dotnet_diagnostic.S2251.severity = error # A "for" loop update clause should move the counter in the right direction
-dotnet_diagnostic.S2252.severity = error # For-loop conditions should be true at least once
-dotnet_diagnostic.S2445.severity = error # Blocks should be synchronized on read-only fields
-dotnet_diagnostic.S2688.severity = error # "NaN" should not be used in comparisons
-dotnet_diagnostic.S2757.severity = error # Non-existent operators like "=+" should not be used
+dotnet_diagnostic.S1764.severity = none # Identical expressions should not be used on both sides of operators — covered by SST1474
+dotnet_diagnostic.S1848.severity = none # Objects should not be created to be dropped immediately without being used -> replaced by SST1480
+dotnet_diagnostic.S1862.severity = none # Related "if/else if" statements should not have the same condition — covered by SST1475
+dotnet_diagnostic.S2114.severity = none # Collections should not be passed as arguments to their own methods — covered by SST2419
+dotnet_diagnostic.S2123.severity = none # Values should not be uselessly incremented -> replaced by SST2222
+dotnet_diagnostic.S2201.severity = none # Methods without side effects should not have their return values ignored — covered by SST2418
+dotnet_diagnostic.S2225.severity = none # "ToString()" method should not return null — covered by SST2431
+dotnet_diagnostic.S2251.severity = none # A "for" loop update clause should move the counter in the right direction — covered by SST2412
+dotnet_diagnostic.S2252.severity = none # For-loop conditions should be true at least once — covered by SST2413
+dotnet_diagnostic.S2445.severity = none # Blocks should be synchronized on read-only fields — covered by SST1904
+dotnet_diagnostic.S2688.severity = none # "NaN" should not be used in comparisons — covered by SST1473
+dotnet_diagnostic.S2757.severity = none # Non-existent operators like "=+" should not be used — covered by SST2417
 dotnet_diagnostic.S2761.severity = none # Doubled prefix operators "!!" and "~~" should not be used — covered by SST1190
-dotnet_diagnostic.S2995.severity = error # "Object.ReferenceEquals" should not be used for value types
-dotnet_diagnostic.S2996.severity = error # "ThreadStatic" fields should not be initialized
-dotnet_diagnostic.S2997.severity = error # "IDisposables" created in a "using" statement should not be returned
-dotnet_diagnostic.S3005.severity = error # "ThreadStatic" should not be used on non-static fields
-dotnet_diagnostic.S3168.severity = error # "async" methods should not return "void"
-dotnet_diagnostic.S3172.severity = error # Delegates should not be subtracted
-dotnet_diagnostic.S3244.severity = error # Anonymous delegates should not be used to unsubscribe from Events
-dotnet_diagnostic.S3249.severity = error # Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-dotnet_diagnostic.S3263.severity = error # Static fields should appear in the order they must be initialized
-dotnet_diagnostic.S3343.severity = error # Caller information parameters should come at the end of the parameter list
-dotnet_diagnostic.S3346.severity = error # Expressions used in "Debug.Assert" should not produce side effects
-dotnet_diagnostic.S3453.severity = error # Classes should not have only "private" constructors
-dotnet_diagnostic.S3466.severity = error # Optional parameters should be passed to "base" calls
-dotnet_diagnostic.S3598.severity = error # One-way "OperationContract" methods should have "void" return type
-dotnet_diagnostic.S3603.severity = error # Methods with "Pure" attribute should return a value
-dotnet_diagnostic.S3610.severity = error # Nullable type comparison should not be redundant
-dotnet_diagnostic.S3903.severity = error # Types should be defined in named namespaces
-dotnet_diagnostic.S3923.severity = error # All branches in a conditional structure should not have exactly the same implementation
-dotnet_diagnostic.S3926.severity = error # Deserialization methods should be provided for "OptionalField" members
-dotnet_diagnostic.S3927.severity = error # Serialization event handlers should be implemented correctly
-dotnet_diagnostic.S3981.severity = error # Collection sizes and array length comparisons should make sense
-dotnet_diagnostic.S3984.severity = error # Exceptions should not be created without being thrown
-dotnet_diagnostic.S4143.severity = error # Collection elements should not be replaced unconditionally
-dotnet_diagnostic.S4210.severity = error # Windows Forms entry points should be marked with STAThread
-dotnet_diagnostic.S4260.severity = error # "ConstructorArgument" parameters should exist in constructors
-dotnet_diagnostic.S4428.severity = error # "PartCreationPolicyAttribute" should be used with "ExportAttribute"
-dotnet_diagnostic.S6507.severity = error # Blocks should not be synchronized on local variables
-dotnet_diagnostic.S6677.severity = error # Message template placeholders should be unique
-dotnet_diagnostic.S6797.severity = error # Blazor query parameter type should be supported
-dotnet_diagnostic.S6798.severity = error # [JSInvokable] attribute should only be used on public methods
-dotnet_diagnostic.S6800.severity = error # Component parameter type should match the route parameter type constraint
-dotnet_diagnostic.S6930.severity = error # Backslash should be avoided in route templates
+dotnet_diagnostic.S2995.severity = none # "Object.ReferenceEquals" should not be used for value types -> replaced by CA2013
+dotnet_diagnostic.S2996.severity = none # "ThreadStatic" fields should not be initialized -> replaced by CA2019
+dotnet_diagnostic.S2997.severity = none # "IDisposables" created in a "using" statement should not be returned — covered by SST2423
+dotnet_diagnostic.S3005.severity = none # "ThreadStatic" should not be used on non-static fields -> replaced by CA2259
+dotnet_diagnostic.S3168.severity = none # "async" methods should not return "void" — covered by SST1905
+dotnet_diagnostic.S3172.severity = none # Delegates should not be subtracted — covered by SST2448
+dotnet_diagnostic.S3244.severity = none # Anonymous delegates should not be used to unsubscribe from Events — covered by SST2449
+dotnet_diagnostic.S3249.severity = none # Covered by SST1447 (canonical)
+dotnet_diagnostic.S3263.severity = none # Static fields should appear in the order they must be initialized — covered by SST2428
+dotnet_diagnostic.S3343.severity = none # Caller information parameters should come at the end of the parameter list — covered by SST2433
+dotnet_diagnostic.S3346.severity = none # Expressions used in "Debug.Assert" should not produce side effects — covered by SST2450
+dotnet_diagnostic.S3453.severity = none # Classes should not have only "private" constructors — covered by SST2451
+dotnet_diagnostic.S3466.severity = none # Optional parameters should be passed to "base" calls — covered by SST2425
+dotnet_diagnostic.S3598.severity = none # One-way "OperationContract" methods should have "void" return type -> replaced by obsolete (WCF)
+dotnet_diagnostic.S3603.severity = none # Methods with "Pure" attribute should return a value — covered by SST2452
+dotnet_diagnostic.S3610.severity = none # Nullable type comparison should not be redundant -> replaced by compiler CS0472
+dotnet_diagnostic.S3903.severity = none # Types should be defined in named namespaces — covered by SST2312
+dotnet_diagnostic.S3923.severity = none # All branches in a conditional structure should not have exactly the same implementation — covered by SST1476
+dotnet_diagnostic.S3926.severity = none # Deserialization methods should be provided for "OptionalField" members -> replaced by obsolete (legacy binary serialization)
+dotnet_diagnostic.S3927.severity = none # Serialization event handlers should be implemented correctly — covered by SST2430
+dotnet_diagnostic.S3981.severity = none # Collection sizes and array length comparisons should make sense — covered by SST1479
+dotnet_diagnostic.S3984.severity = none # Exceptions should not be created without being thrown — covered by SST1480
+dotnet_diagnostic.S4143.severity = none # Collection elements should not be replaced unconditionally — covered by SST1487
+dotnet_diagnostic.S4210.severity = none # Windows Forms entry points should be marked with STAThread -> replaced by SST2706
+dotnet_diagnostic.S4260.severity = none # "ConstructorArgument" parameters should exist in constructors -> replaced by SST2487
+dotnet_diagnostic.S4428.severity = none # "PartCreationPolicyAttribute" should be used with "ExportAttribute" — covered by SST2474
+dotnet_diagnostic.S6507.severity = none # Blocks should not be synchronized on local variables — covered by SST1903
+dotnet_diagnostic.S6677.severity = none # Message template placeholders should be unique — covered by SST2442
+dotnet_diagnostic.S6797.severity = none # Blazor query parameter type should be supported -> replaced by SST2702
+dotnet_diagnostic.S6798.severity = none # [JSInvokable] attribute should only be used on public methods -> replaced by SST2701
+dotnet_diagnostic.S6800.severity = none # Component parameter type should match the route parameter type constraint -> replaced by SST2703
+dotnet_diagnostic.S6930.severity = none # Backslash should be avoided in route templates -> replaced by SST2700
 
-###################
-# SonarAnalyzer (Sxxxx) - Minor Bug
-###################
+# Minor bugs
 dotnet_diagnostic.S1206.severity = none # "Equals(Object)" and "GetHashCode()" should be overridden in pairs - DUPLICATE CA2218
-dotnet_diagnostic.S1226.severity = none  # Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-dotnet_diagnostic.S2183.severity = error # Integral numbers should not be shifted by zero or more than their number of bits-1
-dotnet_diagnostic.S2184.severity = error # Results of integer division should not be assigned to floating point variables
-dotnet_diagnostic.S2328.severity = error # "GetHashCode" should not reference mutable fields
-dotnet_diagnostic.S2345.severity = error # Flags enumerations should explicitly initialize all their members
-dotnet_diagnostic.S2674.severity = error # The length returned from a stream read should be checked
-dotnet_diagnostic.S2934.severity = error # Property assignments should not be made for "readonly" fields not constrained to reference types
-dotnet_diagnostic.S2955.severity = error # Generic parameters not constrained to reference types should not be compared to "null"
-dotnet_diagnostic.S3363.severity = error # Date and time should not be used as a type for primary keys
-dotnet_diagnostic.S3397.severity = error # "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"
-dotnet_diagnostic.S3456.severity = error # "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly
-dotnet_diagnostic.S3887.severity = error # Mutable, non-private fields should not be "readonly"
+dotnet_diagnostic.S1226.severity = none # Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+dotnet_diagnostic.S2183.severity = none # Integral numbers should not be shifted by zero or more than their number of bits-1 — covered by SST1478
+dotnet_diagnostic.S2184.severity = none # Results of integer division should not be assigned to floating point variables — covered by SST1477
+dotnet_diagnostic.S2328.severity = none # "GetHashCode" should not reference mutable fields — covered by SST1482
+dotnet_diagnostic.S2345.severity = none # Flags enumerations should explicitly initialize all their members — covered by SST2303
+dotnet_diagnostic.S2674.severity = none # The length returned from a stream read should be checked — covered by SST2446
+dotnet_diagnostic.S2934.severity = none # Property assignments should not be made for "readonly" fields not constrained to reference types — covered by SST2421
+dotnet_diagnostic.S2955.severity = none # Generic parameters not constrained to reference types should not be compared to "null" -> replaced by compiler CS0019/CS0037
+dotnet_diagnostic.S3363.severity = none # Date and time should not be used as a type for primary keys — covered by SST2475
+dotnet_diagnostic.S3397.severity = none # "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object" — covered by SST2435
+dotnet_diagnostic.S3456.severity = none # "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly — covered by PSH1217
+dotnet_diagnostic.S3887.severity = none # Mutable, non-private fields should not be "readonly" — covered by SST2322
 
-###################
-# SonarAnalyzer (Sxxxx) - Blocker Vulnerability
-###################
-dotnet_diagnostic.S2115.severity = error # A secure password should be used when connecting to a database
-dotnet_diagnostic.S2755.severity = error # XML parsers should not be vulnerable to XXE attacks
-dotnet_diagnostic.S3884.severity = error # "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used
-dotnet_diagnostic.S6418.severity = error # Secrets should not be hard-coded
+# Blocker vulnerabilities
+dotnet_diagnostic.S2115.severity = none # A secure password should be used when connecting to a database -> replaced by SES1203
+dotnet_diagnostic.S2755.severity = none # XML parsers should not be vulnerable to XXE attacks -> replaced by CA3075
+dotnet_diagnostic.S3884.severity = none # "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used -> replaced by obsolete (COM interop security)
+dotnet_diagnostic.S6418.severity = none # Secrets should not be hard-coded — covered by SES1201
 
-###################
-# SonarAnalyzer (Sxxxx) - Critical Vulnerability
-###################
-dotnet_diagnostic.S4423.severity = error # Weak SSL/TLS protocols should not be used
-dotnet_diagnostic.S4426.severity = error # Cryptographic keys should be robust
-dotnet_diagnostic.S4433.severity = error # LDAP connections should be authenticated
-dotnet_diagnostic.S4830.severity = error # Server certificates should be verified during SSL/TLS connections
-dotnet_diagnostic.S5344.severity = error # Passwords should not be stored in plaintext or with a fast hashing algorithm
-dotnet_diagnostic.S5445.severity = error # Insecure temporary file creation methods should not be used
-dotnet_diagnostic.S5542.severity = error # Encryption algorithms should be used with secure mode and padding scheme
-dotnet_diagnostic.S5547.severity = error # Cipher algorithms should be robust
-dotnet_diagnostic.S5659.severity = error # JWT should be signed and verified with strong cipher algorithms
+# Critical vulnerabilities
+dotnet_diagnostic.S4423.severity = none # Weak SSL/TLS protocols should not be used -> replaced by CA5397/CA5398
+dotnet_diagnostic.S4426.severity = none # Cryptographic keys should be robust -> replaced by CA5385 (RSA) / CA5384 (DSA)
+dotnet_diagnostic.S4433.severity = none # LDAP connections should be authenticated -> replaced by SES1310
+dotnet_diagnostic.S4830.severity = none # Server certificates should be verified during SSL/TLS connections -> replaced by SES1102 or SES1108
+dotnet_diagnostic.S5344.severity = none # Passwords should not be stored in plaintext or with a fast hashing algorithm -> replaced by SES1009
+dotnet_diagnostic.S5445.severity = none # Insecure temporary file creation methods should not be used -> replaced by SES1307
+dotnet_diagnostic.S5542.severity = none # Encryption algorithms should be used with secure mode and padding scheme -> replaced by CA5358
+dotnet_diagnostic.S5547.severity = none # Cipher algorithms should be robust -> replaced by CA5351
+dotnet_diagnostic.S5659.severity = none # JWT should be signed and verified with strong cipher algorithms -> replaced by SES1503
 
-###################
-# SonarAnalyzer (Sxxxx) - Major Vulnerability
-###################
-dotnet_diagnostic.S2068.severity = error # Credentials should not be hard-coded
-dotnet_diagnostic.S2612.severity = error # File permissions should not be set to world-accessible values
-dotnet_diagnostic.S4211.severity = error # Members should not have conflicting transparency annotations
-dotnet_diagnostic.S4212.severity = error # Serialization constructors should be secured
-dotnet_diagnostic.S6377.severity = error # XML signatures should be validated securely
-dotnet_diagnostic.S7039.severity = error # Content Security Policies should be restrictive
+# Major vulnerabilities
+dotnet_diagnostic.S2068.severity = none # Credentials should not be hard-coded -> replaced by SES1201
+dotnet_diagnostic.S2612.severity = none # File permissions should not be set to world-accessible values -> replaced by SES1308
+dotnet_diagnostic.S4211.severity = none # Members should not have conflicting transparency annotations -> replaced by obsolete (Code Access Security)
+dotnet_diagnostic.S4212.severity = none # Serialization constructors should be secured -> replaced by obsolete (Code Access Security)
+dotnet_diagnostic.S6377.severity = none # XML signatures should be validated securely -> replaced by SES1008
+dotnet_diagnostic.S7039.severity = none # Content Security Policies should be restrictive -> replaced by SES1515
 
-###################
-# SonarAnalyzer (Sxxxx) - Blocker Code Smell
-###################
-dotnet_diagnostic.S1147.severity = error # Exit methods should not be called
+# Blocker code smells
+dotnet_diagnostic.S1147.severity = none # Exit methods should not be called — covered by SST2321
 dotnet_diagnostic.S1451.severity = none # Track lack of copyright and license headers
-dotnet_diagnostic.S2178.severity = error # Short-circuit logic should be used in boolean contexts
-dotnet_diagnostic.S2187.severity = error # Test classes should contain at least one test case
-dotnet_diagnostic.S2306.severity = error # "async" and "await" should not be used as identifiers
+dotnet_diagnostic.S2178.severity = none # Short-circuit logic should be used in boolean contexts — covered by SST2415
+dotnet_diagnostic.S2187.severity = none # Test classes should contain at least one test case — covered by SST2504
+dotnet_diagnostic.S2306.severity = none # "async" and "await" should not be used as identifiers -> replaced by compiler (contextual keyword)
 dotnet_diagnostic.S2368.severity = none # Public methods should not have multidimensional array parameters — jagged arrays are the chosen layout for hot-path lookup tables
-dotnet_diagnostic.S2387.severity = error # Child class fields should not shadow parent class fields
-dotnet_diagnostic.S2437.severity = error # Unnecessary bit operations should not be performed
-dotnet_diagnostic.S2699.severity = error # Tests should include assertions
-dotnet_diagnostic.S2953.severity = error # Methods named "Dispose" should implement "IDisposable.Dispose"
-dotnet_diagnostic.S2970.severity = error # Assertions should be complete
-dotnet_diagnostic.S3060.severity = error # "is" should not be used with "this"
-dotnet_diagnostic.S3237.severity = error # "value" contextual keyword should be used
-dotnet_diagnostic.S3427.severity = error # Method overloads with default parameter values should not overlap
-dotnet_diagnostic.S3433.severity = error # Test method signatures should be correct
-dotnet_diagnostic.S3443.severity = error # Type should not be examined on "System.Type" instances
-dotnet_diagnostic.S3875.severity = error # "operator==" should not be overloaded on reference types
-dotnet_diagnostic.S3877.severity = error # Exceptions should not be thrown from unexpected methods
-dotnet_diagnostic.S4462.severity = error # Calls to "async" methods should not be blocking
-dotnet_diagnostic.S6422.severity = error # Calls to "async" methods should not be blocking in Azure Functions
-dotnet_diagnostic.S6424.severity = error # Interfaces for durable entities should satisfy the restrictions
+dotnet_diagnostic.S2387.severity = none # Child class fields should not shadow parent class fields — covered by SST1484
+dotnet_diagnostic.S2437.severity = none # Unnecessary bit operations should not be performed — covered by SST1481
+dotnet_diagnostic.S2699.severity = none # Tests should include assertions -> replaced by SST2500
+dotnet_diagnostic.S2953.severity = none # Methods named "Dispose" should implement "IDisposable.Dispose" — covered by SST2316
+dotnet_diagnostic.S2970.severity = none # Assertions should be complete -> replaced by SST2508
+dotnet_diagnostic.S3060.severity = none # "is" should not be used with "this" -> replaced by SST2327
+dotnet_diagnostic.S3237.severity = none # "value" contextual keyword should be used — covered by SST2429
+dotnet_diagnostic.S3427.severity = none # Method overloads with default parameter values should not overlap — covered by SST2319
+dotnet_diagnostic.S3433.severity = none # Test method signatures should be correct -> replaced by SST2509
+dotnet_diagnostic.S3443.severity = none # Type should not be examined on "System.Type" instances — covered by SST2432
+dotnet_diagnostic.S3875.severity = none # "operator==" should not be overloaded on reference types -> replaced by SST2464
+dotnet_diagnostic.S3877.severity = none # Exceptions should not be thrown from unexpected methods — covered by SST1485
+dotnet_diagnostic.S4462.severity = none # Calls to "async" methods should not be blocking - covered by PSH1315
+dotnet_diagnostic.S6422.severity = none # Calls to "async" methods should not be blocking in Azure Functions — covered by PSH1315
+dotnet_diagnostic.S6424.severity = none # Interfaces for durable entities should satisfy the restrictions -> off: Durable Entity-specific; not used in this library
 
-###################
-# SonarAnalyzer (Sxxxx) - Critical Code Smell
-###################
-dotnet_diagnostic.S1006.severity = error # Method overrides should not change parameter defaults
+# Critical code smells
+dotnet_diagnostic.S1006.severity = none # Method overrides should not change parameter defaults — covered by SST2424
 dotnet_diagnostic.S1067.severity = none # Expressions should not be too complex
-dotnet_diagnostic.S1163.severity = error # Exceptions should not be thrown in finally blocks
+dotnet_diagnostic.S1163.severity = none # Exceptions should not be thrown in finally blocks -> replaced by CA2219
 dotnet_diagnostic.S1186.severity = none # Methods should not be empty — covered by SST1438
-dotnet_diagnostic.S121.severity = error # Control structures should use curly braces (kept over SA1503 — Sonar 20ms vs SA1503 50ms)
-dotnet_diagnostic.S1215.severity = none # "GC.Collect" should not be called
+dotnet_diagnostic.S121.severity = none # Control structures should use curly braces (kept over SA1503 — Sonar 20ms vs SA1503 50ms) -> replaced by SST1503
+dotnet_diagnostic.S1215.severity = none # "GC.Collect" should not be called — covered by PSH1021
 dotnet_diagnostic.S126.severity = none # "if ... else if" constructs should end with "else" clauses
 dotnet_diagnostic.S131.severity = none # "switch/Select" statements should contain a "default/Case Else" clauses
 dotnet_diagnostic.S134.severity = none # Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
 dotnet_diagnostic.S1541.severity = none # Methods and properties should not be too complex - covered by SST1442
-dotnet_diagnostic.S1699.severity = error # Constructors should only call non-overridable methods
-dotnet_diagnostic.S1821.severity = error # "switch" statements should not be nested
-dotnet_diagnostic.S1944.severity = error # Invalid casts should be avoided
-dotnet_diagnostic.S1994.severity = error # "for" loop increment clauses should modify the loops' counters
-dotnet_diagnostic.S2197.severity = error # Modulus results should not be checked for direct equality
-dotnet_diagnostic.S2198.severity = error # Unnecessary mathematical comparisons should not be made
+dotnet_diagnostic.S1699.severity = none # Constructors should only call non-overridable methods — covered by SST1483
+dotnet_diagnostic.S1821.severity = none # "switch" statements should not be nested -> replaced by SST2252
+dotnet_diagnostic.S1944.severity = none # Invalid casts should be avoided -> replaced by compiler CS0030
+dotnet_diagnostic.S1994.severity = none # "for" loop increment clauses should modify the loops' counters — covered by SST2411
+dotnet_diagnostic.S2197.severity = none # Modulus results should not be checked for direct equality — covered by SST2416
+dotnet_diagnostic.S2198.severity = none # Unnecessary mathematical comparisons should not be made -> replaced by SST2489
 dotnet_diagnostic.S2223.severity = none # Non-constant static fields should not be visible - DUPLICATE CA2211
-dotnet_diagnostic.S2290.severity = error # Field-like events should not be virtual
-dotnet_diagnostic.S2291.severity = error # Overflow checking should not be disabled for "Enumerable.Sum"
-dotnet_diagnostic.S2302.severity = error # "nameof" should be used
-dotnet_diagnostic.S2330.severity = error # Array covariance should not be used
-dotnet_diagnostic.S2339.severity = error # Public constant members should not be used
+dotnet_diagnostic.S2290.severity = none # Field-like events should not be virtual -> replaced by SST2456
+dotnet_diagnostic.S2291.severity = none # Overflow checking should not be disabled for "Enumerable.Sum" — covered by SST2457
+dotnet_diagnostic.S2302.severity = none # "nameof" should be used — covered by SST1415
+dotnet_diagnostic.S2330.severity = none # Array covariance should not be used — covered by SST2434
+dotnet_diagnostic.S2339.severity = none # Public constant members should not be used — covered by SST2311
 dotnet_diagnostic.S2346.severity = none # Flags enumerations zero-value members should be named "None" - DUPLICATE CA1008
-dotnet_diagnostic.S2360.severity = error # Optional parameters should not be used
-dotnet_diagnostic.S2365.severity = error # Properties should not make collection or array copies
+dotnet_diagnostic.S2360.severity = none # Optional parameters should not be used — conflicts with SST2433, which owns caller-info parameters requiring a default
+dotnet_diagnostic.S2365.severity = none # Properties should not make collection or array copies — covered by PSH1017
 dotnet_diagnostic.S2479.severity = none # Whitespace and control characters in string literals should be explicit — covered by SST1192
-dotnet_diagnostic.S2692.severity = error # "IndexOf" checks should not be for positive numbers
-dotnet_diagnostic.S2696.severity = error # Instance members should not write to "static" fields
-dotnet_diagnostic.S2701.severity = error # Literal boolean values should not be used in assertions
-dotnet_diagnostic.S3215.severity = error # "interface" instances should not be cast to concrete types
-dotnet_diagnostic.S3216.severity = error # "ConfigureAwait(false)" should be used
-dotnet_diagnostic.S3217.severity = error # "Explicit" conversions of "foreach" loops should not be used
-dotnet_diagnostic.S3218.severity = error # Inner class members should not shadow outer class "static" or type members
-dotnet_diagnostic.S3265.severity = error # Non-flags enums should not be used in bitwise operations
-dotnet_diagnostic.S3353.severity = error # Unchanged variables should be marked as "const"
-dotnet_diagnostic.S3447.severity = error # "[Optional]" should not be used on "ref" or "out" parameters
-dotnet_diagnostic.S3451.severity = error # "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant
-dotnet_diagnostic.S3600.severity = error # "params" should not be introduced on overrides
+dotnet_diagnostic.S2692.severity = none # "IndexOf" checks should not be for positive numbers — covered by SST2420
+dotnet_diagnostic.S2696.severity = none # Instance members should not write to "static" fields -> replaced by SST2402
+dotnet_diagnostic.S2701.severity = none # Literal boolean values should not be used in assertions — covered by SST2503
+dotnet_diagnostic.S3215.severity = none # "interface" instances should not be cast to concrete types -> deliberately unenforced, same reason as SST2326
+dotnet_diagnostic.S3216.severity = none # "ConfigureAwait(false)" should be used -> replaced by CA2007
+dotnet_diagnostic.S3217.severity = none # "Explicit" conversions of "foreach" loops should not be used — covered by SST2225
+dotnet_diagnostic.S3218.severity = none # Inner class members should not shadow outer class "static" or type members — covered by SST1484
+dotnet_diagnostic.S3265.severity = none # Non-flags enums should not be used in bitwise operations — covered by SST2458
+dotnet_diagnostic.S3353.severity = none # Unchanged variables should be marked as "const" — covered by PSH1402
+dotnet_diagnostic.S3447.severity = none # "[Optional]" should not be used on "ref" or "out" parameters — covered by SST2459
+dotnet_diagnostic.S3451.severity = none # "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant — covered by SST2460
+dotnet_diagnostic.S3600.severity = none # "params" should not be introduced on overrides — covered by SST2426
 dotnet_diagnostic.S3776.severity = none # Cognitive Complexity of methods should not be too high - covered by SST1443
-dotnet_diagnostic.S3871.severity = error # Exception types should be "public"
+dotnet_diagnostic.S3871.severity = none # Exception types should be "public" -> replaced by CA1064
 dotnet_diagnostic.S3874.severity = none # "out" and "ref" parameters — repo idiom is TryX(..., out T value)
-dotnet_diagnostic.S3904.severity = error # Assemblies should have version information
-dotnet_diagnostic.S3937.severity = error # Number patterns should be regular
-dotnet_diagnostic.S3972.severity = error # Conditionals should start on new lines
-dotnet_diagnostic.S3973.severity = error # A conditionally executed single line should be denoted by indentation
-dotnet_diagnostic.S3998.severity = error # Threads should not lock on objects with weak identity
-dotnet_diagnostic.S4000.severity = error # Pointers to unmanaged memory should not be visible
-dotnet_diagnostic.S4015.severity = error # Inherited member visibility should not be decreased
-dotnet_diagnostic.S4019.severity = error # Base class methods should not be hidden
-dotnet_diagnostic.S4025.severity = error # Child class fields should not differ from parent class fields only by capitalization
+dotnet_diagnostic.S3904.severity = none # Assemblies should have version information -> replaced by obsolete (SDK supplies assembly version)
+dotnet_diagnostic.S3937.severity = none # Number patterns should be regular — covered by SST1119
+dotnet_diagnostic.S3972.severity = none # Conditionals should start on new lines — covered by SST1146
+dotnet_diagnostic.S3973.severity = none # A conditionally executed single line should be denoted by indentation -> replaced by SST1503
+dotnet_diagnostic.S3998.severity = none # Threads should not lock on objects with weak identity -> replaced by SST1902
+dotnet_diagnostic.S4000.severity = none # Pointers to unmanaged memory should not be visible -> replaced by SST2328
+dotnet_diagnostic.S4015.severity = none # Inherited member visibility should not be decreased — covered by SST2462
+dotnet_diagnostic.S4019.severity = none # Base class methods should not be hidden — covered by SST2427
+dotnet_diagnostic.S4025.severity = none # Child class fields should not differ from parent class fields only by capitalization — covered by SST2463
 dotnet_diagnostic.S4039.severity = none # Interface methods should be callable by derived types - DUPLICATE CA1033
 dotnet_diagnostic.S4487.severity = none # Unread "private" fields should be removed
-dotnet_diagnostic.S4524.severity = error # "default" clauses should be first or last
-dotnet_diagnostic.S4635.severity = error # Start index should be used instead of calling Substring
-dotnet_diagnostic.S5034.severity = error # "ValueTask" should be consumed correctly
-dotnet_diagnostic.S6967.severity = error # ModelState.IsValid should be called in controller actions
-dotnet_diagnostic.S8367.severity = error # Identifiers should not conflict with the C# 14 "field" contextual keyword
-dotnet_diagnostic.S8368.severity = error # Identifiers should not conflict with the C# 14 "extension" contextual keyword
-dotnet_diagnostic.S8380.severity = error # Return types named "partial" should be escaped with "@"
-dotnet_diagnostic.S8381.severity = error # "scoped" should be escaped when used as an identifier or type name in parenthesized lambda parameter lists
+dotnet_diagnostic.S4524.severity = none # "default" clauses should be first or last — covered by SST1219
+dotnet_diagnostic.S4635.severity = none # Start index should be used instead of calling Substring — covered by PSH1218
+dotnet_diagnostic.S5034.severity = none # "ValueTask" should be consumed correctly — covered by PSH1316
+dotnet_diagnostic.S6967.severity = none # ModelState.IsValid should be called in controller actions -> off: ASP.NET MVC-specific; no controllers in this library
+dotnet_diagnostic.S8367.severity = none # Identifiers should not conflict with the C# 14 "field" contextual keyword - the C# 14 compiler reports this: CS9273 (error) for a local named field in an accessor, CS9258 (warning) for a rebinding read
+dotnet_diagnostic.S8368.severity = none # Identifiers should not conflict with the C# 14 "extension" contextual keyword - the C# 14 compiler reports this as CS9306, and SST1300 already flags the lowercase type name
+dotnet_diagnostic.S8380.severity = none # Return types named "partial" should be escaped with "@" - the compiler reports this as CS8981, and SST1300 already flags the lowercase type name
+dotnet_diagnostic.S8381.severity = none # "scoped" should be escaped when used as an identifier or type name in parenthesized lambda parameter lists -> replaced by compiler
 dotnet_diagnostic.S927.severity = none # Parameter names should match base declaration and other partial definitions - DUPLICATE CA1725
 
-###################
-# SonarAnalyzer (Sxxxx) - Major Code Smell
-###################
-dotnet_diagnostic.S103.severity = error # Lines should not be too long
-dotnet_diagnostic.S104.severity = error # Files should not have too many lines of code
-dotnet_diagnostic.S106.severity = error # Standard outputs should not be used directly to log anything
-dotnet_diagnostic.S1066.severity = error # Mergeable "if" statements should be combined
-dotnet_diagnostic.S107.severity = error # Methods should not have too many parameters
+# Major code smells
+dotnet_diagnostic.S103.severity = none # Lines should not be too long — covered by SST1521
+dotnet_diagnostic.S104.severity = none # Files should not have too many lines of code — covered by SST1522
+dotnet_diagnostic.S106.severity = none # Covered by SST1449 (canonical)
+dotnet_diagnostic.S1066.severity = none # Mergeable "if" statements should be combined — covered by SST2013
+dotnet_diagnostic.S107.severity = none # Methods should not have too many parameters — covered by SST1472
 dotnet_diagnostic.S108.severity = none # Nested blocks of code should not be left empty — covered by SST1439
-dotnet_diagnostic.S109.severity = error # Magic numbers should not be used
-dotnet_diagnostic.S110.severity = error # Inheritance tree of classes should not be too deep
-dotnet_diagnostic.S1110.severity = error # Redundant pairs of parentheses should be removed
-dotnet_diagnostic.S1117.severity = error # Local variables should not shadow class fields or properties
+dotnet_diagnostic.S109.severity = none # Magic numbers should not be used — covered by SST1471
+dotnet_diagnostic.S110.severity = none # Inheritance tree of classes should not be too deep — covered by SST1446
+dotnet_diagnostic.S1110.severity = none # Redundant pairs of parentheses should be removed — covered by SST1459
+dotnet_diagnostic.S1117.severity = none # Local variables should not shadow class fields or properties — covered by SST1484
 dotnet_diagnostic.S1118.severity = none # Utility classes should not have public constructors - DUPLICATE CA1052
-dotnet_diagnostic.S112.severity = error # General or reserved exceptions should never be thrown
+dotnet_diagnostic.S112.severity = none # General or reserved exceptions should never be thrown — covered by SST2409
 dotnet_diagnostic.S1121.severity = none # Assignments should not be made from within sub-expressions — covered by SST1187
-dotnet_diagnostic.S1123.severity = error # "Obsolete" attributes should include explanations
-dotnet_diagnostic.S1134.severity = error # Track uses of "FIXME" tags
-dotnet_diagnostic.S1144.severity = none # Unused private types or members should be removed - DUPLICATE IDE0051
-dotnet_diagnostic.S1151.severity = error # "switch case" clauses should not have too many lines of code
-dotnet_diagnostic.S1168.severity = error # Empty arrays and collections should be returned instead of null
-dotnet_diagnostic.S1172.severity = error # Unused method parameters should be removed
+dotnet_diagnostic.S1123.severity = none # "Obsolete" attributes should include explanations — covered by SST2308
+dotnet_diagnostic.S1134.severity = none # Track uses of "FIXME" tags -> off: TODO comment tracker; not enforced here
+dotnet_diagnostic.S1144.severity = none # Covered by SST1440 (canonical)
+dotnet_diagnostic.S1151.severity = none # "switch case" clauses should not have too many lines of code — covered by SST1524
+dotnet_diagnostic.S1168.severity = none # Empty arrays and collections should be returned instead of null — covered by SST2306
+dotnet_diagnostic.S1172.severity = none # Unused method parameters should be removed — covered by SST1461
 dotnet_diagnostic.S1200.severity = none # Classes should not be coupled to too many other classes
-dotnet_diagnostic.S122.severity = error # Statements should be on separate lines
+dotnet_diagnostic.S122.severity = none # Statements should be on separate lines — covered by SST1107
 dotnet_diagnostic.S125.severity = none # Sections of code should not be commented out — covered by SST1148
-dotnet_diagnostic.S127.severity = error # "for" loop stop conditions should be invariant
-dotnet_diagnostic.S138.severity = error # Functions should not have too many lines of code
-dotnet_diagnostic.S1479.severity = error # "switch" statements with many "case" clauses should have only one statement
-dotnet_diagnostic.S1607.severity = error # Tests should not be ignored
-dotnet_diagnostic.S1696.severity = error # NullReferenceException should not be caught
+dotnet_diagnostic.S127.severity = none # "for" loop stop conditions should be invariant — covered by SST2465
+dotnet_diagnostic.S138.severity = none # Functions should not have too many lines of code — covered by SST1523
+dotnet_diagnostic.S1479.severity = none # "switch" statements with many "case" clauses — covered by SST1423
+dotnet_diagnostic.S1607.severity = none # Tests should not be ignored -> off: ignored-test tracker; not enforced here
+dotnet_diagnostic.S1696.severity = none # NullReferenceException should not be caught — covered by SST2401
 dotnet_diagnostic.S1854.severity = none # Unused assignments should be removed - DUPLICATE IDE0059
-dotnet_diagnostic.S1871.severity = error # Two branches in a conditional structure should not have exactly the same implementation
-dotnet_diagnostic.S2139.severity = error # Exceptions should be either logged or rethrown but not both
+dotnet_diagnostic.S1871.severity = none # Two branches in a conditional structure should not have exactly the same implementation — covered by SST2414
+dotnet_diagnostic.S2139.severity = none # Exceptions should be either logged or rethrown but not both -> replaced by SST2488
 dotnet_diagnostic.S2166.severity = none # Classes named like "Exception" should extend "Exception" or a subclass - DUPLICATE CA1710
-dotnet_diagnostic.S2234.severity = error # Arguments should be passed in the same order as the method parameters
-dotnet_diagnostic.S2326.severity = error # Unused type parameters should be removed
-dotnet_diagnostic.S2327.severity = error # "try" statements with identical "catch" and/or "finally" blocks should be merged
+dotnet_diagnostic.S2234.severity = none # Arguments should be passed in the same order as the method parameters -> replaced by SST2400
+dotnet_diagnostic.S2326.severity = none # Covered by SST1452 (canonical)
+dotnet_diagnostic.S2327.severity = none # "try" statements with identical "catch" and/or "finally" blocks should be merged -> replaced by SST2490
 dotnet_diagnostic.S2357.severity = none # Fields should be private — duplicate of SST1401 (canonical); fields intentionally exposed (e.g. public test fields for reflection) already carry per-site SST1401 suppressions
-dotnet_diagnostic.S2372.severity = error # Exceptions should not be thrown from property getters
-dotnet_diagnostic.S2376.severity = error # Write-only properties should not be used
-dotnet_diagnostic.S2629.severity = error # Logging templates should be constant
-dotnet_diagnostic.S2681.severity = error # Multiline blocks should be enclosed in curly braces
+dotnet_diagnostic.S2372.severity = none # Exceptions should not be thrown from property getters — covered by SST1485
+dotnet_diagnostic.S2376.severity = none # Write-only properties should not be used — covered by SST1421
+dotnet_diagnostic.S2629.severity = none # Logging templates should be constant -> replaced by CA2254
+dotnet_diagnostic.S2681.severity = none # Multiline blocks should be enclosed in curly braces — covered by SST1503
 dotnet_diagnostic.S2743.severity = none # Static fields should not be used in generic types - DUPLICATE CA1000 — covered by SST1431
-dotnet_diagnostic.S2925.severity = error # "Thread.Sleep" should not be used in tests
+dotnet_diagnostic.S2925.severity = none # "Thread.Sleep" should not be used in tests — covered by SST2506
 dotnet_diagnostic.S2933.severity = none # Fields that are only assigned in the constructor should be "readonly" - DUPLICATE IDE0044
-dotnet_diagnostic.S2971.severity = error # LINQ expressions should be simplified
-dotnet_diagnostic.S3010.severity = error # Static fields should not be updated in constructors
-dotnet_diagnostic.S3011.severity = error # Reflection should not be used to increase accessibility of classes, methods, or fields
+dotnet_diagnostic.S2971.severity = none # LINQ expressions should be simplified — covered by PSH1101/PSH1102
+dotnet_diagnostic.S3010.severity = none # Static fields should not be updated in constructors — covered by SST2402
+dotnet_diagnostic.S3011.severity = none # Reflection should not be used to increase accessibility of classes, methods, or fields -> replaced by SES1406
 dotnet_diagnostic.S3059.severity = none # Types should not have members with visibility set higher than the type's visibility
-dotnet_diagnostic.S3063.severity = error # "StringBuilder" data should be used
-dotnet_diagnostic.S3169.severity = error # Multiple "OrderBy" calls should not be used
-dotnet_diagnostic.S3246.severity = error # Generic type parameters should be co/contravariant when possible
-dotnet_diagnostic.S3262.severity = error # "params" should be used on overrides
-dotnet_diagnostic.S3264.severity = error # Events should be invoked
+dotnet_diagnostic.S3063.severity = none # "StringBuilder" data should be used — covered by SST2408
+dotnet_diagnostic.S3169.severity = none # Multiple "OrderBy" calls should not be used — covered by PSH1108
+dotnet_diagnostic.S3246.severity = none # Generic type parameters should be co/contravariant when possible -> off: low-precision variance suggestion; not enforced
+dotnet_diagnostic.S3262.severity = none # "params" should be used on overrides — covered by SST2426
+dotnet_diagnostic.S3264.severity = none # Events should be invoked — covered by SST2407
 dotnet_diagnostic.S3358.severity = none # Ternary operators should not be nested — covered by SST1147
-dotnet_diagnostic.S3366.severity = error # "this" should not be exposed from constructors
-dotnet_diagnostic.S3415.severity = error # Assertion arguments should be passed in the correct order
-dotnet_diagnostic.S3431.severity = error # "[ExpectedException]" should not be used
+dotnet_diagnostic.S3366.severity = none # "this" should not be exposed from constructors — covered by SST2403
+dotnet_diagnostic.S3415.severity = none # Assertion arguments should be passed in the correct order — covered by SST2502
+dotnet_diagnostic.S3431.severity = none # "[ExpectedException]" should not be used — covered by SST2507
 dotnet_diagnostic.S3442.severity = none # "abstract" classes should not have "public" constructors — covered by SST1428
 dotnet_diagnostic.S3445.severity = none # Exceptions should not be explicitly rethrown — covered by SST1430
-dotnet_diagnostic.S3457.severity = error # Composite format strings should be used correctly
-dotnet_diagnostic.S3597.severity = error # "ServiceContract" and "OperationContract" attributes should be used together
-dotnet_diagnostic.S3880.severity = none # Finalizers should not be empty — covered by SST1434
-dotnet_diagnostic.S3881.severity = error # "IDisposable" should be implemented correctly
-dotnet_diagnostic.S3885.severity = error # "Assembly.Load" should be used
-dotnet_diagnostic.S3898.severity = error # Value types should implement "IEquatable<T>"
-dotnet_diagnostic.S3902.severity = error # "Assembly.GetExecutingAssembly" should not be called
-dotnet_diagnostic.S3906.severity = error # Event Handlers should have the correct signature
-dotnet_diagnostic.S3908.severity = error # Generic event handlers should be used
-dotnet_diagnostic.S3909.severity = error # Collections should implement the generic interface
+dotnet_diagnostic.S3457.severity = none # Composite format strings should be used correctly — covered by SST1454
+dotnet_diagnostic.S3597.severity = none # "ServiceContract" and "OperationContract" attributes should be used together -> replaced by obsolete (WCF)
+dotnet_diagnostic.S3880.severity = none # Finalizers should not be empty — covered by PSH1002
+dotnet_diagnostic.S3881.severity = none # "IDisposable" should be implemented correctly — covered by SST2300
+dotnet_diagnostic.S3885.severity = none # "Assembly.Load" should be used -> replaced by SST2486
+dotnet_diagnostic.S3898.severity = none # Covered by PSH1005 (canonical)
+dotnet_diagnostic.S3902.severity = none # Covered by PSH1404 (canonical)
+dotnet_diagnostic.S3906.severity = none # Event Handlers should have the correct signature — covered by SST2304
+dotnet_diagnostic.S3908.severity = none # Generic event handlers should be used -> replaced by SST2304
+dotnet_diagnostic.S3909.severity = none # Collections should implement the generic interface -> replaced by CA1010
 dotnet_diagnostic.S3925.severity = none # "ISerializable" should be implemented correctly - BinaryFormatter / ISerializable serialization is obsoleted (SYSLIB0050/0051) in modern .NET; we do not opt into legacy serialization for any exception type
 dotnet_diagnostic.S3928.severity = none # Parameter names used into ArgumentException constructors should match an existing one - DUPLICATE CA2208
 dotnet_diagnostic.S3956.severity = none # "Generic.List" instances should not be part of public APIs
-dotnet_diagnostic.S3971.severity = error # "GC.SuppressFinalize" should not be called
-dotnet_diagnostic.S3990.severity = error # Assemblies should be marked as CLS compliant
-dotnet_diagnostic.S3992.severity = error # Assemblies should explicitly specify COM visibility
-dotnet_diagnostic.S3993.severity = error # Custom attributes should be marked with "System.AttributeUsageAttribute"
+dotnet_diagnostic.S3971.severity = none # "GC.SuppressFinalize" should not be called — conflicts with PSH1008, which owns the pointless-SuppressFinalize direction and exempts unsealed types
+dotnet_diagnostic.S3990.severity = none # Assemblies should be marked as CLS compliant -> replaced by CA1014
+dotnet_diagnostic.S3992.severity = none # Assemblies should explicitly specify COM visibility -> replaced by CA1017
+dotnet_diagnostic.S3993.severity = none # Custom attributes should be marked with "System.AttributeUsageAttribute" -> replaced by CA1018
 dotnet_diagnostic.S3994.severity = none # URI Parameters should not be strings
 dotnet_diagnostic.S3995.severity = none # URI return values should not be strings
 dotnet_diagnostic.S3996.severity = none # URI properties should not be strings
-dotnet_diagnostic.S3997.severity = error # String URI overloads should call "System.Uri" overloads
-dotnet_diagnostic.S4002.severity = error # Disposable types should declare finalizers
-dotnet_diagnostic.S4004.severity = error # Collection properties should be readonly
+dotnet_diagnostic.S3997.severity = none # String URI overloads should call "System.Uri" overloads -> replaced by CA1054/CA1056/CA1057
+dotnet_diagnostic.S4002.severity = none # Disposable types should declare finalizers — covered by SST2317
+dotnet_diagnostic.S4004.severity = none # Collection properties should be readonly — covered by SST2305
 dotnet_diagnostic.S4005.severity = none # "System.Uri" arguments should be used instead of strings
-dotnet_diagnostic.S4016.severity = error # Enumeration members should not be named "Reserved"
+dotnet_diagnostic.S4016.severity = none # Enumeration members should not be named "Reserved" -> replaced by CA1700
 dotnet_diagnostic.S4017.severity = none # Method signatures should not contain nested generic types
-dotnet_diagnostic.S4035.severity = error # Classes implementing "IEquatable<T>" should be sealed
-dotnet_diagnostic.S4050.severity = error # Operators should be overloaded consistently
+dotnet_diagnostic.S4035.severity = none # Classes implementing "IEquatable<T>" should be sealed — covered by SST2301
+dotnet_diagnostic.S4050.severity = none # Operators should be overloaded consistently — covered by SST2302
 dotnet_diagnostic.S4055.severity = none # Literals should not be passed as localized parameters
-dotnet_diagnostic.S4057.severity = error # Locales should be set for data types
+dotnet_diagnostic.S4057.severity = none # Locales should be set for data types -> replaced by obsolete
 dotnet_diagnostic.S4059.severity = none # Property names should not match get methods - DUPLICATE CA1721
-dotnet_diagnostic.S4070.severity = error # Non-flags enums should not be marked with "FlagsAttribute"
-dotnet_diagnostic.S4144.severity = error # Methods should not have identical implementations
-dotnet_diagnostic.S4200.severity = error # Native methods should be wrapped
+dotnet_diagnostic.S4070.severity = none # Non-flags enums should not be marked with "FlagsAttribute" — covered by SST2303
+dotnet_diagnostic.S4144.severity = none # Methods should not have identical implementations — covered by SST2318
+dotnet_diagnostic.S4200.severity = none # Native methods should be wrapped -> replaced by CA1401
 dotnet_diagnostic.S4214.severity = none # "P/Invoke" methods should not be visible - DUPLICATE CA1401
-dotnet_diagnostic.S4220.severity = error # Events should have proper arguments
-dotnet_diagnostic.S4456.severity = error # Parameter validation in yielding methods should be wrapped
-dotnet_diagnostic.S4457.severity = none # Parameter validation in "async"/"await" methods should be wrapped
-dotnet_diagnostic.S4545.severity = error # "DebuggerDisplayAttribute" strings should reference existing members
-dotnet_diagnostic.S4581.severity = error # "new Guid()" should not be used
-dotnet_diagnostic.S6354.severity = error # Use a testable date/time provider
-dotnet_diagnostic.S6419.severity = error # Azure Functions should be stateless
-dotnet_diagnostic.S6420.severity = error # Client instances should not be recreated on each Azure Function invocation
-dotnet_diagnostic.S6421.severity = error # Azure Functions should use Structured Error Handling
-dotnet_diagnostic.S6423.severity = error # Azure Functions should log all failures
-dotnet_diagnostic.S6561.severity = error # Avoid using "DateTime.Now" for benchmarking or timing operations
-dotnet_diagnostic.S6562.severity = error # Always set the "DateTimeKind" when creating new "DateTime" instances
-dotnet_diagnostic.S6563.severity = error # Use UTC when recording DateTime instants
-dotnet_diagnostic.S6566.severity = error # Use "DateTimeOffset" instead of "DateTime"
-dotnet_diagnostic.S6575.severity = error # Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
+dotnet_diagnostic.S4220.severity = none # Events should have proper arguments — covered by SST2436
+dotnet_diagnostic.S4456.severity = none # Parameter validation in yielding methods should be wrapped — covered by SST2404
+dotnet_diagnostic.S4457.severity = none # Parameter validation in "async"/"await" methods should be wrapped — covered by SST2325
+dotnet_diagnostic.S4545.severity = none # "DebuggerDisplayAttribute" strings should reference existing members — covered by SST2405
+dotnet_diagnostic.S4581.severity = none # "new Guid()" should not be used — covered by SST2012
+dotnet_diagnostic.S6354.severity = none # Use a testable date/time provider — covered by SST2010
+dotnet_diagnostic.S6419.severity = none # Azure Functions should be stateless -> off: Azure Functions-specific; not used in this library
+dotnet_diagnostic.S6420.severity = none # Client instances should not be recreated on each Azure Function invocation — covered by PSH1418
+dotnet_diagnostic.S6421.severity = none # Azure Functions should use Structured Error Handling -> off: Azure Functions-specific; not used in this library
+dotnet_diagnostic.S6423.severity = none # Azure Functions should log all failures -> off: Azure Functions-specific; not used in this library
+dotnet_diagnostic.S6561.severity = none # Avoid using "DateTime.Now" for benchmarking or timing operations — covered by PSH1408
+dotnet_diagnostic.S6562.severity = none # Covered by SST1451 (canonical)
+dotnet_diagnostic.S6563.severity = none # Use UTC when recording DateTime instants — covered by SST2011
+dotnet_diagnostic.S6566.severity = none # Use "DateTimeOffset" instead of "DateTime" — covered by SST2016
+dotnet_diagnostic.S6575.severity = none # Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter" -> replaced by PSH1419
 dotnet_diagnostic.S6580.severity = none # Use a format provider when parsing date and time - DUPLICATE CA1305
-dotnet_diagnostic.S6673.severity = error # Log message template placeholders should be in the right order
-dotnet_diagnostic.S6802.severity = error # Using lambda expressions in loops should be avoided in Blazor markup section
-dotnet_diagnostic.S6803.severity = error # Parameters with SupplyParameterFromQuery attribute should be used only in routable components
-dotnet_diagnostic.S6931.severity = error # ASP.NET controller actions should not have a route template starting with "/"
-dotnet_diagnostic.S6932.severity = error # Use model binding instead of reading raw request data
-dotnet_diagnostic.S6934.severity = error # A Route attribute should be added to the controller when a route template is specified at the action level
-dotnet_diagnostic.S6960.severity = error # Controllers should not have mixed responsibilities
-dotnet_diagnostic.S6961.severity = error # API Controllers should derive from ControllerBase instead of Controller
-dotnet_diagnostic.S6962.severity = error # You should pool HTTP connections with HttpClientFactory
-dotnet_diagnostic.S6964.severity = error # Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.
-dotnet_diagnostic.S6965.severity = error # REST API actions should be annotated with an HTTP verb attribute
-dotnet_diagnostic.S6966.severity = error # Awaitable method should be used
-dotnet_diagnostic.S6968.severity = error # Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type
-dotnet_diagnostic.S881.severity = error # Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-dotnet_diagnostic.S907.severity = error # "goto" statement should not be used
+dotnet_diagnostic.S6673.severity = none # Log message template placeholders should be in the right order — covered by SST2440
+dotnet_diagnostic.S6802.severity = none # Using lambda expressions in loops should be avoided in Blazor markup section -> replaced by PSH1600
+dotnet_diagnostic.S6803.severity = none # Parameters with SupplyParameterFromQuery attribute should be used only in routable components -> off: Blazor-specific; no Blazor surface in this library
+dotnet_diagnostic.S6931.severity = none # ASP.NET controller actions should not have a route template starting with "/" -> off: ASP.NET MVC-specific; no controllers in this library
+dotnet_diagnostic.S6932.severity = none # Use model binding instead of reading raw request data -> off: ASP.NET MVC-specific; no controllers in this library
+dotnet_diagnostic.S6934.severity = none # A Route attribute should be added to the controller when a route template is specified at the action level -> off: ASP.NET MVC-specific; no controllers in this library
+dotnet_diagnostic.S6960.severity = none # Controllers should not have mixed responsibilities -> off: ASP.NET MVC-specific; no controllers in this library
+dotnet_diagnostic.S6961.severity = none # API Controllers should derive from ControllerBase instead of Controller -> off: ASP.NET MVC-specific; no controllers in this library
+dotnet_diagnostic.S6962.severity = none # You should pool HTTP connections with HttpClientFactory — covered by PSH1418
+dotnet_diagnostic.S6964.severity = none # Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting. -> replaced by SST2705 (opt-in)
+dotnet_diagnostic.S6965.severity = none # REST API actions should be annotated with an HTTP verb attribute -> replaced by SST2704
+dotnet_diagnostic.S6966.severity = none # Awaitable method should be used — covered by PSH1313
+dotnet_diagnostic.S6968.severity = none # Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type -> off: ASP.NET MVC-specific; no controllers in this library
+dotnet_diagnostic.S881.severity = none # Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression — covered by SST2015
+dotnet_diagnostic.S907.severity = none # "goto" statement should not be used — covered by SST2014
 
-###################
-# SonarAnalyzer (Sxxxx) - Minor Code Smell
-###################
-dotnet_diagnostic.S100.severity = error # Methods and properties should be named in PascalCase (kept over SA1300 — S100+S101 47ms vs SA1300 101ms)
-dotnet_diagnostic.S101.severity = error # Types should be named in PascalCase (kept over SA1300 — see S100)
-dotnet_diagnostic.S105.severity = error # Tabulation characters should not be used
+# Minor code smells
+dotnet_diagnostic.S100.severity = none # Methods and properties should be named in PascalCase — covered by SST1300
+dotnet_diagnostic.S101.severity = none # Types should be named in PascalCase — covered by SST1300
+dotnet_diagnostic.S105.severity = none # Tabulation characters should not be used — covered by SST1027
 dotnet_diagnostic.S1104.severity = none # Fields should not have public accessibility - DUPLICATE CA1051
-dotnet_diagnostic.S1109.severity = error # A close curly brace should be located at the beginning of a line
+dotnet_diagnostic.S1109.severity = none # A close curly brace should be located at the beginning of a line — covered by SST1500
 dotnet_diagnostic.S1116.severity = none # Empty statements should be removed - DUPLICATE SA1106
 dotnet_diagnostic.S1125.severity = none # Boolean literals should not be redundant — covered by SST1182
-dotnet_diagnostic.S1128.severity = error # Unnecessary "using" should be removed (kept over IDE0005 — Sonar 551ms vs IDE0005 2.364s)
+dotnet_diagnostic.S1128.severity = none # Covered by SST1445 (canonical)
 dotnet_diagnostic.S113.severity = none # Files should end with a newline
-dotnet_diagnostic.S1155.severity = error # "Any()" should be used to test for emptiness
+dotnet_diagnostic.S1155.severity = none # "Any()" should be used to test for emptiness — covered by PSH1119
 dotnet_diagnostic.S1185.severity = none # Overriding members should do more than simply call the same member in the base class - DUPLICATE RCS1132
-dotnet_diagnostic.S1192.severity = error # String literals should not be duplicated
-dotnet_diagnostic.S1199.severity = error # Nested code blocks should not be used
+dotnet_diagnostic.S1192.severity = none # String literals should not be duplicated — covered by SST1486
+dotnet_diagnostic.S1199.severity = none # Nested code blocks should not be used — covered by SST1138
 dotnet_diagnostic.S1210.severity = none # "Equals" and the comparison operators should be overridden when implementing "IComparable" - DUPLICATE CA1036
 dotnet_diagnostic.S1227.severity = none # break statements should not be used except for switch cases
-dotnet_diagnostic.S1264.severity = error # A "while" loop should be used instead of a "for" loop
+dotnet_diagnostic.S1264.severity = none # A "while" loop should be used instead of a "for" loop — covered by SST2245
 dotnet_diagnostic.S1301.severity = none # "switch" statements should have at least 3 "case" clauses
 dotnet_diagnostic.S1312.severity = none # Logger fields should be "private static readonly"
-dotnet_diagnostic.S1449.severity = error # Culture should be specified for "string" operations
-dotnet_diagnostic.S1450.severity = error # Private fields only used as local variables in methods should become local variables
-dotnet_diagnostic.S1481.severity = error # Unused local variables should be removed
-dotnet_diagnostic.S1643.severity = error # Strings should not be concatenated using '+' in a loop
-dotnet_diagnostic.S1659.severity = error # Multiple variables should not be declared on the same line
-dotnet_diagnostic.S1694.severity = error # An abstract class should have both abstract and concrete methods
-dotnet_diagnostic.S1698.severity = error # "==" should not be used when "Equals" is overridden
-dotnet_diagnostic.S1858.severity = error # "ToString()" calls should not be redundant
+dotnet_diagnostic.S1449.severity = none # Culture should be specified for "string" operations — covered by PSH1207
+dotnet_diagnostic.S1450.severity = none # Private fields only used as local variables in methods should become local variables — covered by SST1422
+dotnet_diagnostic.S1481.severity = none # Unused local variables should be removed — covered by SST1497
+dotnet_diagnostic.S1643.severity = none # Covered by PSH1206 (canonical)
+dotnet_diagnostic.S1659.severity = none # Multiple variables should not be declared on the same line — covered by SST1132
+dotnet_diagnostic.S1694.severity = none # An abstract class should have both abstract and concrete methods — covered by SST2323
+dotnet_diagnostic.S1698.severity = none # "==" should not be used when "Equals" is overridden — covered by SST1495
+dotnet_diagnostic.S1858.severity = none # "ToString()" calls should not be redundant — covered by PSH1211
 dotnet_diagnostic.S1905.severity = none # Redundant casts should not be used - DUPLICATE IDE0004 — covered by SST1175
-dotnet_diagnostic.S1939.severity = error # Inheritance list should not be redundant
-dotnet_diagnostic.S1940.severity = error # Boolean checks should not be inverted
+dotnet_diagnostic.S1939.severity = none # Inheritance list should not be redundant — covered by SST1490 and SST1177
+dotnet_diagnostic.S1940.severity = none # Boolean checks should not be inverted — covered by SST1172
 dotnet_diagnostic.S2094.severity = none # Classes should not be empty — covered by SST1436
 dotnet_diagnostic.S2148.severity = none # Underscores should be used to make large numbers readable — covered by SST1191
-dotnet_diagnostic.S2156.severity = error # "sealed" classes should not have "protected" members
-dotnet_diagnostic.S2219.severity = error # Runtime type checking should be simplified
+dotnet_diagnostic.S2156.severity = none # "sealed" classes should not have "protected" members — covered by SST1427
+dotnet_diagnostic.S2219.severity = none # Runtime type checking should be simplified — covered by SST2007
 dotnet_diagnostic.S2221.severity = none # "Exception" should not be caught
-dotnet_diagnostic.S2292.severity = error # Trivial properties should be auto-implemented
+dotnet_diagnostic.S2292.severity = none # Trivial properties should be auto-implemented — covered by SST1420
 dotnet_diagnostic.S2325.severity = none # Methods and properties that don't access instance data should be static - DUPLICATE CA1822
-dotnet_diagnostic.S2333.severity = error # Redundant modifiers should not be used
-dotnet_diagnostic.S2342.severity = error # Enumeration types should comply with a naming convention
+dotnet_diagnostic.S2333.severity = none # Redundant modifiers should not be used — covered by SST1419/SST1491
+dotnet_diagnostic.S2342.severity = none # Enumeration types should comply with a naming convention — covered by SST1319
 dotnet_diagnostic.S2344.severity = none # Enumeration type names should not have "Flags" or "Enum" suffixes - DUPLICATE CA1711
-dotnet_diagnostic.S2386.severity = error # Mutable fields should not be "public static"
+dotnet_diagnostic.S2386.severity = none # Mutable fields should not be "public static" — covered by SST1499
 dotnet_diagnostic.S2486.severity = none # Generic exceptions should not be ignored — covered by SST1429
-dotnet_diagnostic.S2737.severity = error # "catch" clauses should do more than rethrow
-dotnet_diagnostic.S2760.severity = error # Sequential tests should not check the same condition
-dotnet_diagnostic.S3052.severity = error # Members should not be initialized to default values
-dotnet_diagnostic.S3220.severity = error # Method calls should not resolve ambiguously to overloads with "params"
-dotnet_diagnostic.S3234.severity = error # "GC.SuppressFinalize" should not be invoked for types without destructors
-dotnet_diagnostic.S3235.severity = error # Redundant parentheses should not be used
-dotnet_diagnostic.S3236.severity = error # Caller information arguments should not be provided explicitly
+dotnet_diagnostic.S2737.severity = none # "catch" clauses should do more than rethrow — covered by SST1470
+dotnet_diagnostic.S2760.severity = none # Sequential tests should not check the same condition — covered by SST1475
+dotnet_diagnostic.S3052.severity = none # Covered by PSH1403 (canonical)
+dotnet_diagnostic.S3220.severity = none # Method calls should not resolve ambiguously to overloads with "params" — covered by SST2467
+dotnet_diagnostic.S3234.severity = none # Covered by PSH1008 (canonical)
+dotnet_diagnostic.S3235.severity = none # Redundant parentheses should not be used — covered by SST1459
+dotnet_diagnostic.S3236.severity = none # Covered by SST1448 (canonical)
 dotnet_diagnostic.S3240.severity = none # The simplest possible condition syntax should be used - duplicate of SST1198
-dotnet_diagnostic.S3241.severity = error # Methods should not return values that are never used
+dotnet_diagnostic.S3241.severity = none # Methods should not return values that are never used -> off: needs whole-program analysis; not enforced here
 dotnet_diagnostic.S3242.severity = none # Method parameters should be declared with base types
-dotnet_diagnostic.S3247.severity = error # Duplicate casts should not be made
-dotnet_diagnostic.S3251.severity = error # Implementations should be provided for "partial" methods
+dotnet_diagnostic.S3247.severity = none # Duplicate casts should not be made — covered by SST1175
+dotnet_diagnostic.S3251.severity = none # Implementations should be provided for "partial" methods — covered by SST2468
 dotnet_diagnostic.S3253.severity = none # Constructor and destructor declarations should not be redundant — covered by SST1433
-dotnet_diagnostic.S3254.severity = error # Default parameter values should not be passed as arguments
-dotnet_diagnostic.S3256.severity = error # "string.IsNullOrEmpty" should be used
-dotnet_diagnostic.S3257.severity = error # Declarations and initializations should be as concise as possible
-dotnet_diagnostic.S3260.severity = error # Non-derived "private" classes and records should be "sealed"
+dotnet_diagnostic.S3254.severity = none # Default parameter values should not be passed as arguments — covered by SST1494
+dotnet_diagnostic.S3256.severity = none # "string.IsNullOrEmpty" should be used — covered by PSH1204 (style configurable)
+dotnet_diagnostic.S3257.severity = none # Declarations and initializations should be as concise as possible -> replaced by SST2202
+dotnet_diagnostic.S3260.severity = none # Non-derived "private" classes and records should be "sealed" — covered by PSH1411
 dotnet_diagnostic.S3261.severity = none # Namespaces should not be empty — covered by SST1435
 dotnet_diagnostic.S3267.severity = none # Loops should be simplified with "LINQ" expressions
 dotnet_diagnostic.S3376.severity = none # Attribute, EventArgs, and Exception type names should end with the type being extended - DUPLICATE CA1710
-dotnet_diagnostic.S3398.severity = error # "private" methods called only by inner classes should be moved to those classes
-dotnet_diagnostic.S3400.severity = error # Methods should not return constants
-dotnet_diagnostic.S3416.severity = error # Loggers should be named for their enclosing types
-dotnet_diagnostic.S3440.severity = error # Variables should not be checked against the values they're about to be assigned
-dotnet_diagnostic.S3441.severity = error # Redundant property names should be omitted in anonymous classes
-dotnet_diagnostic.S3444.severity = error # Interfaces should not simply inherit from base interfaces with colliding members
-dotnet_diagnostic.S3450.severity = error # Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-dotnet_diagnostic.S3458.severity = error # Empty "case" clauses that fall through to the "default" should be omitted
-dotnet_diagnostic.S3459.severity = error # Unassigned members should be removed
-dotnet_diagnostic.S3532.severity = error # Empty "default" clauses should be removed
-dotnet_diagnostic.S3604.severity = error # Member initializer values should not be redundant
+dotnet_diagnostic.S3398.severity = none # "private" methods called only by inner classes should be moved to those classes — covered by SST1498
+dotnet_diagnostic.S3400.severity = none # Methods should not return constants — covered by SST1493
+dotnet_diagnostic.S3416.severity = none # Loggers should be named for their enclosing types — covered by SST2443
+dotnet_diagnostic.S3440.severity = none # Variables should not be checked against the values they're about to be assigned — covered by SST1492
+dotnet_diagnostic.S3441.severity = none # Redundant property names should be omitted in anonymous classes — covered by SST1173
+dotnet_diagnostic.S3444.severity = none # Interfaces should not simply inherit from base interfaces with colliding members — covered by SST2320
+dotnet_diagnostic.S3450.severity = none # Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]" -> replaced by obsolete (legacy DefaultParameterValue)
+dotnet_diagnostic.S3458.severity = none # Empty "case" clauses that fall through to the "default" should be omitted — covered by SST1466
+dotnet_diagnostic.S3459.severity = none # Unassigned members should be removed - the compiler reports this as CS0649; the rule only ever fires on private never-assigned fields
+dotnet_diagnostic.S3532.severity = none # Empty "default" clauses should be removed — covered by SST1179
+dotnet_diagnostic.S3604.severity = none # Member initializer values should not be redundant — covered by PSH1403
 dotnet_diagnostic.S3626.severity = none # Jump statements should not be redundant — covered by SST1174
-dotnet_diagnostic.S3717.severity = error # Track use of "NotImplementedException"
-dotnet_diagnostic.S3872.severity = error # Parameter names should not duplicate the names of their methods
-dotnet_diagnostic.S3876.severity = error # Strings or integral types should be used for indexers
-dotnet_diagnostic.S3878.severity = error # Arrays should not be created for params parameters
-dotnet_diagnostic.S3897.severity = error # Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-dotnet_diagnostic.S3962.severity = none # "static readonly" constants should be "const" instead - DUPLICATE CA1802
+dotnet_diagnostic.S3717.severity = none # Track use of "NotImplementedException" -> replaced by SST2485
+dotnet_diagnostic.S3872.severity = none # Parameter names should not duplicate the names of their methods -> replaced by SST1320
+dotnet_diagnostic.S3876.severity = none # Strings or integral types should be used for indexers -> replaced by CA1043
+dotnet_diagnostic.S3878.severity = none # Arrays should not be created for params parameters — covered by PSH1018
+dotnet_diagnostic.S3897.severity = none # Classes that provide "Equals(<T>)" should implement "IEquatable<T>" -> replaced by CA1067
+dotnet_diagnostic.S3962.severity = none # Covered by PSH1402 (canonical)
 dotnet_diagnostic.S3963.severity = none # "static" fields should be initialized inline - DUPLICATE CA1810
 dotnet_diagnostic.S3967.severity = none # Multidimensional arrays should not be used - DUPLICATE CA1814
-dotnet_diagnostic.S4018.severity = error # All type parameters should be used in the parameter list to enable type inference
-dotnet_diagnostic.S4022.severity = error # Enumerations should have "Int32" storage
+dotnet_diagnostic.S4018.severity = none # All type parameters should be used in the parameter list to enable type inference — covered by SST2307
+dotnet_diagnostic.S4022.severity = none # Enumerations should have "Int32" storage — covered by SST2313
 dotnet_diagnostic.S4023.severity = none # Interfaces should not be empty — covered by SST1437
-dotnet_diagnostic.S4026.severity = error # Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-dotnet_diagnostic.S4027.severity = error # Exceptions should provide standard constructors
+dotnet_diagnostic.S4026.severity = none # Assemblies should be marked with "NeutralResourcesLanguageAttribute" -> replaced by CA1824
+dotnet_diagnostic.S4027.severity = none # Exceptions should provide standard constructors — covered by SST1488
 dotnet_diagnostic.S4040.severity = none # Strings should be normalized to uppercase - DUPLICATE CA1308
 dotnet_diagnostic.S4041.severity = none # Type names should not match namespaces - DUPLICATE CA1724
-dotnet_diagnostic.S4047.severity = error # Generics should be used when appropriate
+dotnet_diagnostic.S4047.severity = none # Generics should be used when appropriate -> off: fuzzy prefer-generics suggestion; not enforced
 dotnet_diagnostic.S4049.severity = none # Properties should be preferred - DUPLICATE CA1024
-dotnet_diagnostic.S4052.severity = error # Types should not extend outdated base types
+dotnet_diagnostic.S4052.severity = none # Types should not extend outdated base types -> replaced by obsolete
 dotnet_diagnostic.S4056.severity = none # Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used - DUPLICATE CA1305
-dotnet_diagnostic.S4058.severity = error # Overloads with a "StringComparison" parameter should be used
+dotnet_diagnostic.S4058.severity = none # Covered by PSH1207 (canonical)
 dotnet_diagnostic.S4060.severity = none # Non-abstract attributes should be sealed - DUPLICATE CA1813
-dotnet_diagnostic.S4061.severity = error # "params" should be used instead of "varargs"
+dotnet_diagnostic.S4061.severity = none # "params" should be used instead of "varargs" -> replaced by obsolete (__arglist varargs)
 dotnet_diagnostic.S4069.severity = none # Operator overloads should have named alternatives - DUPLICATE CA2225
-dotnet_diagnostic.S4136.severity = error # Method overloads should be grouped together
-dotnet_diagnostic.S4201.severity = error # Null checks should not be combined with "is" operator checks
-dotnet_diagnostic.S4225.severity = error # Extension methods should not extend "object"
+dotnet_diagnostic.S4136.severity = none # Method overloads should be grouped together — covered by SST1218
+dotnet_diagnostic.S4201.severity = none # Null checks should not be combined with "is" operator checks — covered by SST2018
+dotnet_diagnostic.S4225.severity = none # Extension methods should not extend "object" — covered by SST1706
 dotnet_diagnostic.S4226.severity = none # Extensions should be in separate namespaces
 dotnet_diagnostic.S4261.severity = none # Methods should be named according to their synchronicities - Async suffix not used
-dotnet_diagnostic.S4663.severity = error # Comments should not be empty
+dotnet_diagnostic.S4663.severity = none # Covered by SST1120 (canonical)
 dotnet_diagnostic.S6513.severity = none # "ExcludeFromCodeCoverage" attributes should include a justification - not available on net462 and older TFMs
-dotnet_diagnostic.S6585.severity = error # Don't hardcode the format when turning dates and times to strings
-dotnet_diagnostic.S6588.severity = error # Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-dotnet_diagnostic.S6602.severity = none # "Find" method should be used instead of the "FirstOrDefault" extension - DUPLICATE CA1826
-dotnet_diagnostic.S6603.severity = error # The collection-specific "TrueForAll" method should be used instead of the "All" extension
-dotnet_diagnostic.S6605.severity = error # Collection-specific "Exists" method should be used instead of the "Any" extension
-dotnet_diagnostic.S6607.severity = error # The collection should be filtered before sorting by using "Where" before "OrderBy"
-dotnet_diagnostic.S6608.severity = none # Prefer indexing instead of "Enumerable" methods on types implementing "IList" - DUPLICATE CA1826
-dotnet_diagnostic.S6609.severity = error # "Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods
-dotnet_diagnostic.S6610.severity = error # "StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"
-dotnet_diagnostic.S6612.severity = error # The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-dotnet_diagnostic.S6613.severity = error # "First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods
-dotnet_diagnostic.S6617.severity = error # "Contains" should be used instead of "Any" for simple equality checks
-dotnet_diagnostic.S6618.severity = error # "string.Create" should be used instead of "FormattableString"
-dotnet_diagnostic.S6664.severity = error # The code block contains too many logging calls
-dotnet_diagnostic.S6667.severity = error # Logging in a catch clause should pass the caught exception as a parameter.
-dotnet_diagnostic.S6668.severity = error # Logging arguments should be passed to the correct parameter
-dotnet_diagnostic.S6669.severity = error # Logger field or property name should comply with a naming convention
-dotnet_diagnostic.S6670.severity = error # "Trace.Write" and "Trace.WriteLine" should not be used
-dotnet_diagnostic.S6672.severity = error # Generic logger injection should match enclosing type
-dotnet_diagnostic.S6675.severity = error # "Trace.WriteLineIf" should not be used with "TraceSwitch" levels
-dotnet_diagnostic.S6678.severity = error # Use PascalCase for named placeholders
-dotnet_diagnostic.S818.severity = error # Literal suffixes should be upper case
+dotnet_diagnostic.S6585.severity = none # Don't hardcode the format when turning dates and times to strings — covered by SST2445
+dotnet_diagnostic.S6588.severity = none # Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch — covered by PSH1413
+dotnet_diagnostic.S6594.severity = none # Covered by PSH1406 (canonical)
+dotnet_diagnostic.S6602.severity = none # Covered by PSH1110 (canonical)
+dotnet_diagnostic.S6603.severity = none # Covered by PSH1110 (canonical)
+dotnet_diagnostic.S6605.severity = none # Covered by PSH1110 (canonical)
+dotnet_diagnostic.S6607.severity = none # The collection should be filtered before sorting — covered by PSH1107
+dotnet_diagnostic.S6608.severity = none # Covered by PSH1106 (canonical)
+dotnet_diagnostic.S6609.severity = none # "Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods — covered by PSH1122
+dotnet_diagnostic.S6610.severity = none # Covered by PSH1201 (canonical)
+dotnet_diagnostic.S6612.severity = none # The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods — covered by PSH1006
+dotnet_diagnostic.S6613.severity = none # "First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods — covered by PSH1124
+dotnet_diagnostic.S6617.severity = none # Covered by PSH1111 (canonical)
+dotnet_diagnostic.S6618.severity = none # "string.Create" should be used instead of "FormattableString" — covered by PSH1209
+dotnet_diagnostic.S6664.severity = none # The code block contains too many logging calls -> off: fuzzy too-many-logging-calls metric; not enforced
+dotnet_diagnostic.S6667.severity = none # Logging in a catch clause should pass the caught exception as a parameter. — covered by SST2438
+dotnet_diagnostic.S6668.severity = none # Logging arguments should be passed to the correct parameter — covered by SST2439
+dotnet_diagnostic.S6669.severity = none # Logger field or property name should comply with a naming convention -> replaced by SST2601
+dotnet_diagnostic.S6670.severity = none # "Trace.Write" and "Trace.WriteLine" should not be used — covered by SST2600
+dotnet_diagnostic.S6672.severity = none # Generic logger injection should match enclosing type — covered by SST2443
+dotnet_diagnostic.S6675.severity = none # "Trace.WriteLineIf" should not be used with "TraceSwitch" levels -> off: niche TraceSwitch misuse; not enforced here
+dotnet_diagnostic.S6678.severity = none # Use PascalCase for named placeholders -> replaced by CA1727
+dotnet_diagnostic.S818.severity = none # Literal suffixes should be upper case — covered by SST2244
 
-###################
-# SonarAnalyzer (Sxxxx) - Info Code Smell
-###################
-dotnet_diagnostic.S1133.severity = error # Deprecated code should be removed
-dotnet_diagnostic.S1135.severity = error # Track uses of "TODO" tags
+# Informational code smells
+dotnet_diagnostic.S1133.severity = none # Deprecated code should be removed — covered by SST2310
+dotnet_diagnostic.S1135.severity = none # Track uses of "TODO" tags -> off: FIXME comment tracker; not enforced here
 dotnet_diagnostic.S1309.severity = none # Track uses of in-source issue suppressions
 
-###################
-# SonarAnalyzer (Sxxxx) - Uncategorized
-###################
+# Uncategorized
 dotnet_diagnostic.S9999-cpd.severity = error # Copy-paste token calculator
 dotnet_diagnostic.S9999-log.severity = error # Log generator
 dotnet_diagnostic.S9999-metadata.severity = error # File metadata generator
@@ -2125,36 +2622,30 @@ dotnet_diagnostic.S9999-testMethodDeclaration.severity = error # Test method dec
 dotnet_diagnostic.S9999-token-type.severity = error # Token type calculator
 dotnet_diagnostic.S9999-warning.severity = error # Analysis Warning generator
 
-###################
-# SonarAnalyzer (Sxxxx) - Critical Security Hotspot
-###################
+# Critical security hotspots
 dotnet_diagnostic.S2245.severity = none # Using pseudorandom number generators (PRNGs) is security-sensitive - DUPLICATE CA5394
-dotnet_diagnostic.S2257.severity = error # Using non-standard cryptographic algorithms is security-sensitive
-dotnet_diagnostic.S4502.severity = error # Disabling CSRF protections is security-sensitive
-dotnet_diagnostic.S4790.severity = error # Using weak hashing algorithms is security-sensitive
-dotnet_diagnostic.S4792.severity = error # Configuring loggers is security-sensitive
-dotnet_diagnostic.S5042.severity = error # Expanding archive files without controlling resource consumption is security-sensitive
-dotnet_diagnostic.S5332.severity = error # Using clear-text protocols is security-sensitive
-dotnet_diagnostic.S5443.severity = error # Using publicly writable directories is security-sensitive
+dotnet_diagnostic.S2257.severity = none # Using non-standard cryptographic algorithms is security-sensitive -> replaced by SES1007
+dotnet_diagnostic.S4502.severity = none # Disabling CSRF protections is security-sensitive -> replaced by in-box ASP.NET antiforgery analyzer
+dotnet_diagnostic.S4790.severity = none # Using weak hashing algorithms is security-sensitive -> replaced by CA5350/CA5351
+dotnet_diagnostic.S4792.severity = none # Configuring loggers is security-sensitive -> off: logging-configuration audit hotspot; not enforced here
+dotnet_diagnostic.S5042.severity = none # Expanding archive files without controlling resource consumption is security-sensitive -> off: unbounded decompression; needs taint analysis, out of scope
+dotnet_diagnostic.S5332.severity = none # Using clear-text protocols is security-sensitive -> replaced by SES1106
+dotnet_diagnostic.S5443.severity = none # Using publicly writable directories is security-sensitive -> replaced by SES1308
 
-###################
-# SonarAnalyzer (Sxxxx) - Major Security Hotspot
-###################
-dotnet_diagnostic.S1313.severity = error # Using hardcoded IP addresses is security-sensitive
-dotnet_diagnostic.S2077.severity = error # Formatting SQL queries is security-sensitive
-dotnet_diagnostic.S5693.severity = error # Allowing requests with excessive content length is security-sensitive
-dotnet_diagnostic.S5753.severity = error # Disabling ASP.NET "Request Validation" feature is security-sensitive
-dotnet_diagnostic.S5766.severity = error # Creating Serializable objects without data validation checks is security-sensitive
-dotnet_diagnostic.S6444.severity = error # Not specifying a timeout for regular expressions is security-sensitive
-dotnet_diagnostic.S6640.severity = error # Using unsafe code blocks is security-sensitive
+# Major security hotspots
+dotnet_diagnostic.S1313.severity = none # Using hardcoded IP addresses is security-sensitive -> off: hardcoded-IP heuristic; too noisy to enforce
+dotnet_diagnostic.S2077.severity = none # Formatting SQL queries is security-sensitive -> replaced by CA2100
+dotnet_diagnostic.S5693.severity = none # Allowing requests with excessive content length is security-sensitive -> replaced by SES1505
+dotnet_diagnostic.S5753.severity = none # Disabling ASP.NET "Request Validation" feature is security-sensitive -> replaced by obsolete (legacy ASP.NET request validation)
+dotnet_diagnostic.S5766.severity = none # Creating Serializable objects without data validation checks is security-sensitive -> off: legacy BinaryFormatter deserialization; obsolete path, not used here
+dotnet_diagnostic.S6444.severity = none # Not specifying a timeout for regular expressions is security-sensitive -> replaced by SES1509
+dotnet_diagnostic.S6640.severity = none # Using unsafe code blocks is security-sensitive -> off: unsafe-code audit; not enforced here
 
-###################
-# SonarAnalyzer (Sxxxx) - Minor Security Hotspot
-###################
-dotnet_diagnostic.S2092.severity = error # Creating cookies without the "secure" flag is security-sensitive
-dotnet_diagnostic.S3330.severity = error # Creating cookies without the "HttpOnly" flag is security-sensitive
-dotnet_diagnostic.S4507.severity = error # Delivering code in production with debug features activated is security-sensitive
-dotnet_diagnostic.S5122.severity = error # Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+# Minor security hotspots
+dotnet_diagnostic.S2092.severity = none # Creating cookies without the "secure" flag is security-sensitive -> replaced by CA5382
+dotnet_diagnostic.S3330.severity = none # Creating cookies without the "HttpOnly" flag is security-sensitive -> replaced by CA5383
+dotnet_diagnostic.S4507.severity = none # Delivering code in production with debug features activated is security-sensitive -> off: debug features in production; partly covered by SES1506, rest not enforced
+dotnet_diagnostic.S5122.severity = none # Having a permissive Cross-Origin Resource Sharing policy is security-sensitive -> replaced by SES1501
 
 #############################################
 # JetBrains ReSharper / Rider Inspections
@@ -2304,6 +2795,35 @@ resharper_identifier_typo_highlighting = none # typo checks are out of scope
 resharper_markup_text_typo_highlighting = none # typo checks are out of scope
 
 #############################################
+# Deliberate type-driven registration APIs
+#############################################
+# These public factory/registration APIs intentionally require callers to select types
+# explicitly. SST2307 documents this as a legitimate exception to its inference rule.
+[src/Extensions.Hosting.Avalonia/Extensions/AvaloniaBuilderExtensions.cs]
+dotnet_diagnostic.SST2307.severity = none
+
+[src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/HostBuilderEntityFrameworkCoreExtensions.cs]
+dotnet_diagnostic.SST2307.severity = none
+
+[src/Extensions.Hosting.Identity.EntityFrameworkCore/HostBuilderEntityFrameworkCoreExtensions.cs]
+dotnet_diagnostic.SST2307.severity = none
+
+[src/Extensions.Hosting.Maui/HostBuilderMauiExtensions.cs]
+dotnet_diagnostic.SST2307.severity = none
+
+[src/Extensions.Hosting.Maui/MauiBuilderExtensions.cs]
+dotnet_diagnostic.SST2307.severity = none
+
+[src/Extensions.Hosting.WinForms/HostBuilderWinFormsExtensions.cs]
+dotnet_diagnostic.SST2307.severity = none
+
+[src/Extensions.Hosting.WinUI/HostBuilderWinUIExtensions.cs]
+dotnet_diagnostic.SST2307.severity = none
+
+[src/Extensions.Hosting.Wpf/WpfBuilderExtensions.cs]
+dotnet_diagnostic.SST2307.severity = none
+
+#############################################
 # Other Settings
 #############################################
 vsspell_dictionary_languages = en-US
@@ -2339,18 +2859,9 @@ end_of_line = lf
 [*.{cmd, bat}]
 end_of_line = crlf
 
-
 #############################################
 # Test projects (TUnit)
 #############################################
 # TUnit instantiates test classes per test, so they must remain instance classes and
 # cannot be marked static — even when a partial declaration happens to hold only static
 # members (the instance [Test] methods live in sibling partial files).
-[**/tests/**/*.cs]
-stylesharp.avoid_linq_on_hot_path = false
-dotnet_diagnostic.SST2229.severity = error # In tests, simplify LINQ Where plus terminal calls instead of banning LINQ
-dotnet_diagnostic.SST2230.severity = error # In tests, simplify LINQ type filters instead of banning LINQ
-dotnet_diagnostic.SST2233.severity = none # Tests can use LINQ for clarity
-dotnet_diagnostic.SST1432.severity = none
-dotnet_diagnostic.RCS1072.severity = none # covered by SST1435
-dotnet_diagnostic.RCS1106.severity = none # covered by SST1434

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Avalonia" Version="12.1.0" />
     <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="CP.Nuke.BuildTools" Version="3.0.2" />
     <PackageVersion Include="log4net" Version="3.3.2" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.8.2" />
@@ -22,37 +23,39 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
-    <PackageVersion Include="ReactiveUI.Primitives.Core" Version="6.0.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.Core" Version="7.1.0" />
     <!--Reactive UI with ReactiveUI.Primitives support-->
-    <PackageVersion Include="ReactiveUI.Primitives" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.0-beta.1" />
-    <PackageVersion Include="ReactiveUI.Core" Version="24.0.0-beta.3" />
+    <PackageVersion Include="ReactiveUI.Primitives" Version="7.1.0" />
+    <PackageVersion Include="ReactiveUI" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.0" />
+    <PackageVersion Include="ReactiveUI.Core" Version="24.0.0" />
     <PackageVersion Include="ReactiveUI.Disposables" Version="7.1.0" />
-    <PackageVersion Include="ReactiveUI.Drawing" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.Maui" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.WinForms" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.WinUI" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.WPF" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.Reactive" Version="24.0.0-beta.3" />
+    <PackageVersion Include="ReactiveUI.Drawing" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.Maui" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.WinForms" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.WinUI" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.WPF" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.Reactive" Version="24.0.0" />
     <!--Reactive UI with System.Reactive support-->
-    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="6.0.0" />
-    <PackageVersion Include="ReactiveUI.Avalonia.Reactive" Version="12.1.0-beta.1" />
-    <PackageVersion Include="ReactiveUI.Drawing.Reactive" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.Maui.Reactive" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.WinForms.Reactive" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.WinUI.Reactive" Version="24.0.0-beta.3" />
-    <PackageVersion Include="ReactiveUI.WPF.Reactive" Version="24.0.0-beta.3" />
+    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="7.1.0" />
+    <PackageVersion Include="ReactiveUI.Avalonia.Reactive" Version="12.1.0" />
+    <PackageVersion Include="ReactiveUI.Drawing.Reactive" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.Maui.Reactive" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.WinForms.Reactive" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.WinUI.Reactive" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI.WPF.Reactive" Version="24.0.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Splat" Version="20.2.0" />
     <PackageVersion Include="Splat.Microsoft.Extensions.DependencyInjection" Version="20.2.0" />
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
-    <PackageVersion Include="StyleSharp.Analyzers" Version="3.28.1" />
+    <PackageVersion Include="StyleSharp.Analyzers" Version="3.39.0" />
+    <PackageVersion Include="PerformanceSharp.Analyzers" Version="3.39.0" />
+    <PackageVersion Include="SecuritySharp.Analyzers" Version="3.39.0" />
     <PackageVersion Include="Tmds.DBus.Protocol" Version="0.94.2" />
     <PackageVersion Include="TUnit" Version="1.61.38" />
     <PackageVersion Include="Verify.TUnit" Version="31.27.0" />

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 The public namespaces use `ReactiveMarbles.Extensions.Hosting.*`.
 
+Use this guide as both a tutorial and the package API reference. Public APIs are
+grouped by feature, every overload is listed explicitly, and the
+[V3.1.26 to V4.0.0 migration guide](#migrate-from-v3126-to-v400) calls out source,
+binary, dependency, target-framework, and behavior changes.
+
 ## Package Matrix
 
 | Package | Main namespace | Purpose |
@@ -31,6 +36,20 @@ The public namespaces use `ReactiveMarbles.Extensions.Hosting.*`.
 | `CP.Extensions.Hosting.ReactiveUI.Maui.Reactive` | `ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI` | Reactive package variant of the MAUI ReactiveUI/Splat integration. |
 | `CP.Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer` | `ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore` | SQL Server DbContext and ASP.NET Core Identity registration helpers. |
 | `CP.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite` | `ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite` | SQLite DbContext and ASP.NET Core Identity registration helpers. |
+| `CP.Extensions.Logging.Log4Net` | `ReactiveMarbles.Extensions.Logging` | Microsoft.Extensions.Logging provider backed by log4net, including scopes, configuration overrides, and custom event/level adapters. |
+
+Install only the feature packages that the application uses. The platform packages
+already reference `CP.Extensions.Hosting.MainUIThread`; reference that shared package
+directly only when building a new UI adapter.
+
+```powershell
+dotnet add package CP.Extensions.Hosting.Wpf --version 4.0.0
+dotnet add package CP.Extensions.Hosting.ReactiveUI.Wpf --version 4.0.0
+dotnet add package CP.Extensions.Hosting.SingleInstance --version 4.0.0
+```
+
+Replace the platform names in this example for WinForms, WinUI, Avalonia, or MAUI.
+Use matching versions for all `CP.Extensions.Hosting.*` packages in an application.
 
 ## Normal And Reactive Packages
 
@@ -85,10 +104,16 @@ The libraries target .NET Framework where the platform supports it, current .NET
 | ReactiveUI WPF/WinForms | .NET Framework TFMs plus `net8.0-windows10.0.19041`, `net9.0-windows10.0.19041`, `net10.0-windows10.0.19041`, `net11.0-windows10.0.19041` |
 | WinUI and ReactiveUI WinUI | `net8.0-windows10.0.19041`, `net9.0-windows10.0.19041`, `net10.0-windows10.0.19041`, `net11.0-windows10.0.19041` |
 | Avalonia and ReactiveUI Avalonia | `net8.0`, `net9.0`, `net10.0`, `net11.0` |
-| MAUI and ReactiveUI MAUI | `net10.0`, `net11.0`, Android, iOS, Mac Catalyst, macOS, tvOS, and Windows where supported |
+| MAUI host | `net9.0`, `net10.0`, `net11.0`; platform workloads start at `net10.0-*` and include Android, iOS, Mac Catalyst, macOS, and tvOS where supported |
+| ReactiveUI MAUI | `net10.0`, `net11.0`; matching platform workload TFMs start at `net10.0-*` |
 | Identity EF Core helpers | `net8.0`, `net9.0`, `net10.0`, `net11.0` |
+| Log4Net | `net462`, `net472`, `net48`, `net481`, `net8.0`, `net9.0`, `net10.0`, `net11.0` |
 
-The repository uses Central Package Management in `Directory.Packages.props`. Notable centrally managed versions include `StyleSharp.Analyzers` `3.16.0`, `ReactiveUI.Primitives` `6.0.0`, `ReactiveUI` `24.0.0-beta.3`, and `ReactiveUI.Avalonia` `12.1.0-beta.1`.
+The repository uses Central Package Management in `Directory.Packages.props`. Notable
+centrally managed versions include `StyleSharp.Analyzers` `3.39.0`,
+`ReactiveUI.Primitives` `7.1.0`, `ReactiveUI` `24.0.0`,
+`ReactiveUI.Avalonia` `12.1.0`, and `Splat` `20.2.0`. `net11.0` support uses preview
+SDK and workload packages until those dependencies become stable.
 
 ## Host Builder Styles
 
@@ -116,7 +141,65 @@ using var host = builder.Build();
 await host.RunAsync().ConfigureAwait(false);
 ```
 
-The extension methods are fluent. Platform packages usually register a context, a UI thread adapter, and an `IHostedService` that starts the UI loop with the host.
+The extension methods are fluent. Platform packages register a context, a UI-thread
+adapter, and an `IHostedService` that starts the UI loop with the host. These framework
+hosted-service types are public for composition and testing, but applications normally
+let `Configure*` register them rather than registering them a second time.
+
+### Configuration Order
+
+1. Add application services and, when needed, call
+   `ConfigureSplatForMicrosoftDependencyResolver()`.
+2. Call the platform `Configure*` method.
+3. Call the matching `Use*Lifetime` method where one exists.
+4. Build the host once.
+5. Call `MapSplatLocator` on the built host when Splat needs the final service provider.
+6. Run and dispose the host.
+
+`UseWpfLifetime` and `UseAvaloniaLifetime` throw `NotSupportedException` when invoked
+before their matching `Configure*` method. WinUI installs its hosted lifetime from
+`ConfigureWinUI<TApp,TAppWindow>()`; there is no `UseWinUILifetime` method.
+
+### Shared Platform Lifecycle
+
+Every platform context inherits `IUiContext.IsRunning` and
+`IUiContext.IsLifetimeLinked`. `IsRunning` becomes `true` when platform startup is
+complete. When lifetime linking is enabled, UI exit requests
+`IHostApplicationLifetime.StopApplication()`. Host shutdown dispatches the matching UI
+exit operation when the context is still running.
+
+Register platform services to perform UI-thread initialization after the platform
+application has been created:
+
+| Platform | UI-thread initialization contract |
+| --- | --- |
+| WPF | `IWpfService.Initialize(System.Windows.Application)` |
+| WinForms | `IWinFormsService.Initialize()` |
+| WinUI | `IWinUIService.Initialize(Microsoft.UI.Xaml.Application)` |
+| Avalonia | `IAvaloniaService.Initialize(Avalonia.Application)` |
+| MAUI | `IMauiService.Initialize(Microsoft.Maui.Controls.Application)` |
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+
+public sealed class ThemeInitializer : IWpfService
+{
+    public void Initialize(System.Windows.Application application)
+    {
+        application.Resources["AccentBrush"] =
+            new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Colors.CornflowerBlue);
+    }
+}
+
+builder.Services.AddSingleton<IWpfService, ThemeInitializer>();
+```
+
+Keep `Initialize` work short and non-blocking because it runs on the UI thread.
+Platform thread types in `*.Internals` are public for compatibility and advanced
+adapter/testing scenarios. Treat them as framework-owned: prefer `Configure*` and do
+not replace or double-register the context, thread, or hosted service in normal apps.
 
 ## Shared UI Thread Infrastructure
 
@@ -132,8 +215,13 @@ Namespace: `ReactiveMarbles.Extensions.Hosting.UiThread`
 | `IUiContext.IsRunning` | Tracks whether the UI application has started and is still running. |
 | `BaseUiContext` | Simple base implementation of `IUiContext`. |
 | `BaseUiThread<TContext>` | Base class for UI-thread adapters where `TContext : class, IUiContext`. |
+| `BaseUiThread<TContext>(IServiceProvider)` | Creates an adapter that owns a dedicated UI thread. |
+| `BaseUiThread<TContext>(IServiceProvider, bool useDedicatedUiThread)` | Allows an adapter to run on a dedicated thread or synchronously on the caller. |
+| `BaseUiThread<TContext>.UiContext` | Protected platform context resolved from DI. |
+| `BaseUiThread<TContext>.ServiceProvider` | Protected service provider used for platform application, shell, and service resolution. |
 | `BaseUiThread<TContext>.Start()` | Signals or starts the UI loop. |
 | `BaseUiThread<TContext>.Dispose()` | Releases startup synchronization resources. |
+| `BaseUiThread<TContext>.Dispose(bool)` | Virtual protected disposal hook for derived adapters. |
 | `BaseUiThread<TContext>.PreUiThreadStart()` | Override point that runs before the UI loop starts. |
 | `BaseUiThread<TContext>.UiThreadStart()` | Override point that runs the platform message loop. |
 | `BaseUiThread<TContext>.HandleApplicationExit()` | Marks the UI context stopped and requests host shutdown when lifetime is linked. |
@@ -173,6 +261,12 @@ public sealed class CustomUiThread(IServiceProvider services)
 }
 ```
 
+On Windows, dedicated UI threads are created as STA threads. With
+`useDedicatedUiThread: false`, `Start()` executes the UI loop synchronously and can
+block the caller until that loop exits. `HandleApplicationExit()` requests host
+shutdown only when lifetime linking is enabled and the host is not already stopping or
+stopped.
+
 ## WPF Hosting
 
 Package: `CP.Extensions.Hosting.Wpf`
@@ -183,16 +277,23 @@ Namespace: `ReactiveMarbles.Extensions.Hosting.Wpf`
 
 | API | Description |
 | --- | --- |
-| `ConfigureWpf(Action<IWpfBuilder>? configureDelegate = null)` | Registers WPF hosting services and optional application/window types. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
-| `UseWpfLifetime(ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)` | Links host shutdown to the WPF application lifetime. Call after `ConfigureWpf`. |
+| `ConfigureWpf()` / `ConfigureWpf(Action<IWpfBuilder>? configureDelegate)` | Registers WPF context, UI thread, hosted service, and optional application/window types. Both overloads are available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `UseWpfLifetime()` / `UseWpfLifetime(ShutdownMode shutdownMode)` | Links host shutdown to WPF. The no-argument overload uses `OnLastWindowClose`. Call after `ConfigureWpf`; otherwise it throws `NotSupportedException`. |
 | `IWpfBuilder.UseApplication<TApplication>()` | Registers a WPF `Application` type. |
 | `IWpfBuilder.UseCurrentApplication<TApplication>(TApplication currentApplication)` | Registers an existing WPF `Application` instance. |
-| `IWpfBuilder.UseWindow<TWindow>()` | Registers a WPF `Window` type. If the window implements `IWpfShell`, it is also registered as the shell. |
+| `IWpfBuilder.UseWindow<TWindow>() where TWindow : Window` | Registers a singleton WPF window. If it implements `IWpfShell`, it is also registered as the shell. |
 | `IWpfBuilder.ConfigureContext(Action<IWpfContext> configureAction)` | Customizes the WPF context before it is used. |
+| `IWpfBuilder.ApplicationType` / `Application` | Configured application type and optional current application instance. |
+| `IWpfBuilder.WindowTypes` | Ordered list of singleton window types to register and show. |
+| `IWpfBuilder.ConfigureContextAction` | Context callback recorded by the fluent builder. |
 | `IWpfContext.ShutdownMode` | WPF shutdown behavior. |
 | `IWpfContext.WpfApplication` | Current WPF application instance. |
 | `IWpfContext.Dispatcher` | WPF dispatcher for UI-thread work. |
-| `IWpfShell` | Marker interface for a shell window. |
+| `IWpfService.Initialize(Application)` | Initializes a registered service on the hosted WPF UI thread. |
+| `IWpfShell : IInputElement` | Shell contract. A registered shell normally also derives from `Window`. |
+| `WpfThread(IServiceProvider)` | Public platform adapter constructed automatically by `ConfigureWpf`. |
+| `WpfHostedService(ILogger<WpfHostedService>, WpfThread, IWpfContext)` | Hosted lifetime service constructed automatically by DI. |
+| `WpfHostedService.StartAsync` / `StopAsync` | Starts the registered `WpfThread`; on host shutdown, dispatcher-invokes `Application.Shutdown()` when WPF is running. |
 
 ### Example
 
@@ -238,6 +339,11 @@ public sealed partial class MainWindow : Window, IWpfShell
 }
 ```
 
+Register zero, one, or multiple shell windows. One shell is passed to
+`Application.Run`; multiple shells are shown at startup. When using an existing
+application whose dispatcher belongs to another thread, remove `StartupUri` and
+provide a shell window or an existing `MainWindow`.
+
 ## WinForms Hosting
 
 Package: `CP.Extensions.Hosting.WinForms`
@@ -248,13 +354,18 @@ Namespace: `ReactiveMarbles.Extensions.Hosting.WinForms`
 
 | API | Description |
 | --- | --- |
-| `ConfigureWinForms(Action<IWinFormsContext>? configureAction = null)` | Registers WinForms hosting services. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
-| `ConfigureWinForms<TView>(Action<IWinFormsContext>? configureAction = null)` | Registers a `Form` as a singleton. If it implements `IWinFormsShell`, it is also registered as the shell. |
-| `ConfigureWinFormsShell<TShell>()` | Registers a shell form where `TShell : Form, IWinFormsShell`. |
+| `ConfigureWinForms()` / `ConfigureWinForms(Action<IWinFormsContext>? configureAction)` | Registers WinForms context, UI thread, and hosted service. Available on both host builder styles. |
+| `ConfigureWinForms<TView>()` / `ConfigureWinForms<TView>(Action<IWinFormsContext>? configureAction) where TView : Form` | Registers a form as a singleton. If it implements `IWinFormsShell`, it is also mapped as the shell. |
+| `ConfigureWinFormsShell<TShell>() where TShell : Form, IWinFormsShell` | Registers a singleton shell form. |
 | `UseWinFormsLifetime()` | Links host shutdown to the WinForms message loop. |
 | `IWinFormsContext.EnableVisualStyles` | Enables or disables WinForms visual styles before the UI starts. |
 | `IWinFormsContext.Dispatcher` | Optional dispatcher used for marshaling work. |
-| `IWinFormsShell` | Marker interface for the main form. |
+| `IWinFormsService.Initialize()` | Initializes a registered service on the WinForms UI thread before the message loop runs. |
+| `IWinFormsShell : IComponent` | Main-form contract; normal shell implementations derive from `Form`. |
+| `WinFormsThread(IServiceProvider)` | Public platform adapter constructed automatically by `ConfigureWinForms`. |
+| `MultiShellContext(params Form[] forms)` | `ApplicationContext` used internally to keep a multiple-form message loop alive until every shell closes. |
+| `WinFormsHostedService(ILogger<WinFormsHostedService>, WinFormsThread, IWinFormsContext)` | Hosted lifetime service constructed automatically by DI. |
+| `WinFormsHostedService.StartAsync` / `StopAsync` | Starts the UI thread. Shutdown snapshots all open forms, closes and disposes each, logs individual cleanup failures, and exits the UI thread. |
 
 ### Example
 
@@ -291,6 +402,11 @@ public sealed class MainForm : Form, IWinFormsShell
 }
 ```
 
+Registering no shell starts an empty WinForms message loop. One shell is passed to
+`Application.Run`; multiple shells use a shared `ApplicationContext` and exit after the
+last form closes. The classic builder extensions retain nullable `IHostBuilder?` return
+types for compatibility; modern builder overloads return `IHostApplicationBuilder`.
+
 ## WinUI Hosting
 
 Package: `CP.Extensions.Hosting.WinUI`
@@ -301,12 +417,15 @@ Namespace: `ReactiveMarbles.Extensions.Hosting.WinUI`
 
 | API | Description |
 | --- | --- |
-| `ConfigureWinUI<TApp, TAppWindow>()` | Registers the WinUI `Application` and main `Window` types, the WinUI context, and the hosted service. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `ConfigureWinUI<TApp,TAppWindow>() where TApp : Application where TAppWindow : Window` | Registers the WinUI application, main window, context, UI thread, and hosted service. Available on both builder styles. |
 | `IWinUIContext.AppWindow` | Current WinUI window instance. |
 | `IWinUIContext.AppWindowType` | Window type to create. Set by `ConfigureWinUI<TApp, TAppWindow>()`. |
 | `IWinUIContext.Dispatcher` | `DispatcherQueue` for UI-thread work. |
 | `IWinUIContext.WinUIApplication` | Current WinUI application instance. |
-| `IWinUIService` | Marker interface for WinUI services. |
+| `IWinUIService.Initialize(Application)` | Initializes a registered service on the hosted WinUI thread before the main window is activated. |
+| `WinUIThread(IServiceProvider)` | Public platform adapter constructed automatically by `ConfigureWinUI`. |
+| `WinUIHostedService(ILogger<WinUIHostedService>, WinUIThread, IWinUIContext)` | Hosted lifetime service constructed automatically by DI. |
+| `WinUIHostedService.StartAsync` / `StopAsync` | Starts the WinUI loop and dispatcher-enqueues `Application.Exit()` during host shutdown. |
 
 ### Example
 
@@ -336,6 +455,12 @@ public sealed partial class MainWindow : Window
 }
 ```
 
+`ConfigureWinUI` provides the lifetime integration; do not look for a separate
+`UseWinUILifetime`. If the application is running, `StopAsync` throws
+`InvalidOperationException` when no dispatcher is available or `TryEnqueue` rejects the
+exit callback. It waits for the queued exit callback and honors cancellation both
+before and while waiting. A pre-cancelled `StartAsync` does not start the UI thread.
+
 ## Avalonia Hosting
 
 Package: `CP.Extensions.Hosting.Avalonia`
@@ -346,18 +471,25 @@ Namespace: `ReactiveMarbles.Extensions.Hosting.Avalonia`
 
 | API | Description |
 | --- | --- |
-| `ConfigureAvalonia(Action<IAvaloniaBuilder>? configureDelegate = null)` | Registers Avalonia hosting services and optional application/window types. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
-| `UseAvaloniaLifetime(ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)` | Links host shutdown to the Avalonia desktop lifetime. |
+| `ConfigureAvalonia()` / `ConfigureAvalonia(Action<IAvaloniaBuilder>? configureDelegate)` | Registers Avalonia context, application builder, hosted service, and optional application/window types. Available on both builder styles. |
+| `UseAvaloniaLifetime()` / `UseAvaloniaLifetime(ShutdownMode shutdownMode)` | Links host shutdown to the desktop lifetime. The no-argument overload uses `OnLastWindowClose`. Call after `ConfigureAvalonia`; otherwise it throws `NotSupportedException`. |
 | `IAvaloniaBuilder.UseApplication<TApplication>()` | Registers an Avalonia `Application` type. |
 | `IAvaloniaBuilder.UseCurrentApplication<TApplication>(TApplication currentApplication)` | Registers an existing Avalonia application instance. |
 | `IAvaloniaBuilder.UseWindow<TWindow>()` | Registers an Avalonia `Window` type. If it implements `IAvaloniaShell`, it is also registered as the shell. |
 | `IAvaloniaBuilder.ConfigureContext(Action<IAvaloniaContext> configureAction)` | Customizes the Avalonia context. |
 | `IAvaloniaBuilder.ConfigureAppBuilder(Action<AppBuilder> configureAction)` | Customizes Avalonia `AppBuilder` before startup. |
+| `IAvaloniaBuilder.ApplicationType` / `Application` | Configured application type and optional current application instance. |
+| `IAvaloniaBuilder.WindowTypes` | Ordered list of singleton window types to register. |
+| `IAvaloniaBuilder.ConfigureContextAction` / `ConfigureAppBuilderAction` | Callbacks recorded by the fluent builder. |
 | `IAvaloniaContext.ShutdownMode` | Avalonia shutdown behavior. |
 | `IAvaloniaContext.AvaloniaApplication` | Current Avalonia application. |
 | `IAvaloniaContext.ApplicationLifetime` | Avalonia desktop lifetime. |
 | `IAvaloniaContext.Dispatcher` | Avalonia dispatcher. |
-| `IAvaloniaShell` | Marker interface for the main window. |
+| `IAvaloniaService.Initialize(Application)` | Initializes a registered service on the Avalonia UI thread during desktop startup. |
+| `IAvaloniaShell : IInputElement` | Shell contract; normal implementations derive from `Window`. |
+| `AvaloniaThread(IServiceProvider, AppBuilder)` | Public platform adapter constructed automatically by `ConfigureAvalonia`. |
+| `AvaloniaHostedService(ILogger<AvaloniaHostedService>, AvaloniaThread, IAvaloniaContext)` | Hosted lifetime service constructed automatically by DI. |
+| `AvaloniaHostedService.StartAsync` / `StopAsync` | Runs classic desktop lifetime and dispatcher-invokes lifetime shutdown. |
 
 ### Example
 
@@ -394,6 +526,11 @@ public sealed class MainWindow : Window, IAvaloniaShell
 }
 ```
 
+On Windows, call `RunAsync` from an STA entry thread; `AvaloniaHostedService.StartAsync`
+throws `InvalidOperationException` when the entry thread is not STA. One registered
+shell becomes `MainWindow`; multiple shells are shown in registration order. Zero
+shells is valid when the application creates its own windows.
+
 ## MAUI Hosting
 
 Package: `CP.Extensions.Hosting.Maui`
@@ -404,17 +541,24 @@ Namespace: `ReactiveMarbles.Extensions.Hosting.Maui`
 
 | API | Description |
 | --- | --- |
-| `ConfigureMaui(Action<IMauiBuilder>? configureDelegate = null)` | Registers MAUI hosting services, builds a `MauiApp`, and registers application/page types. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `ConfigureMaui()` / `ConfigureMaui(Action<IMauiBuilder>? configureDelegate)` | Creates/configures `MauiAppBuilder` and registers MAUI context, startup, and hosted services. It does not eagerly build a `MauiApp`. Available on both builder styles. |
 | `UseMauiLifetime()` | Links host shutdown to the MAUI lifetime. |
 | `ConfigureMauiShell<TShell>()` | Registers a singleton shell page where `TShell : Page, IMauiShell`. |
 | `IMauiBuilder.AddSingletonPage<TPage>()` | Registers a MAUI `Page` as a singleton. If it implements `IMauiShell`, it is also registered as the shell. |
-| `IMauiBuilder.UseMauiApp<TApplication>(Action<MauiAppBuilder>? configureMauiApp = null)` | Registers a MAUI `Application` type and configures the underlying `MauiAppBuilder`. |
-| `IMauiBuilder.UseMauiApp<TApplication>(TApplication currentApplication, Action<MauiAppBuilder>? configureMauiApp = null)` | Registers an existing MAUI application instance. |
+| `IMauiBuilder.UseMauiApp<TApplication>()` / `(Action<MauiAppBuilder>? configureMauiApp)` | Registers a MAUI application type and optionally configures the underlying builder. |
+| `IMauiBuilder.UseMauiApp<TApplication>(TApplication currentApplication)` / `(TApplication currentApplication, Action<MauiAppBuilder>? configureMauiApp)` | Registers an existing MAUI application and optionally configures the underlying builder. |
 | `IMauiBuilder.ConfigureContext(Action<IMauiContext> configureAction)` | Customizes the MAUI context. |
+| `IMauiBuilder.ApplicationType` / `Application` | Configured application type and optional existing application instance. |
+| `IMauiBuilder.PageTypes` | Ordered list of singleton pages to register. |
+| `IMauiBuilder.ConfigureContextAction` | Context callback recorded by the fluent builder. |
 | `IMauiBuilder.MauiAppBuilder` | Underlying MAUI builder for fonts, handlers, services, and app configuration. |
 | `IMauiContext.MauiApplication` | Current MAUI application. |
 | `IMauiContext.Dispatcher` | MAUI dispatcher. |
-| `IMauiShell` | Marker interface for the main shell page. |
+| `IMauiService.Initialize(Application)` | Initializes a registered service on the MAUI UI thread after application creation. |
+| `IMauiShell : IView` | Shell contract; normal implementations derive from `Page` or `Shell`. |
+| `MauiThread(IServiceProvider)` | Public platform adapter constructed automatically by `ConfigureMaui`. |
+| `MauiHostedService(ILogger<MauiHostedService>, MauiThread, IMauiContext)` | Hosted lifetime service constructed automatically by DI. |
+| `MauiHostedService.StartAsync` / `StopAsync` | Starts MAUI through the configured dispatcher and dispatches `Application.Quit()` during host shutdown. |
 
 ### Example
 
@@ -451,6 +595,12 @@ public sealed class AppShell : Shell, IMauiShell
 }
 ```
 
+MAUI application construction is deferred to UI startup. Configure `IMauiBuilder`
+before `Build` and do not expect an eagerly built `MauiApp` immediately after
+`ConfigureMaui`. A pre-cancelled start is skipped. For a running app, shutdown throws
+`InvalidOperationException` when the dispatcher is absent or rejects the quit
+callback, and honors cancellation before and while awaiting that callback.
+
 ## ReactiveUI And Splat Integration
 
 Packages:
@@ -472,7 +622,7 @@ Reactive namespace: `ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI`
 | --- | --- |
 | `ConfigureSplatForMicrosoftDependencyResolver()` on `IHostBuilder` | Registers Splat to use Microsoft.Extensions.DependencyInjection and initializes ReactiveUI for the target platform. |
 | `ConfigureSplatForMicrosoftDependencyResolver()` on `IHostApplicationBuilder` | Same behavior for the modern builder API. |
-| `MapSplatLocator(Action<IServiceProvider?> containerFactory)` on `IHost` | Maps Splat to the built host service provider and invokes a custom service-provider callback. |
+| `MapSplatLocator(Action<IServiceProvider?> containerFactory)` on `IHost` | Maps Splat to the built host service provider, invokes the callback, and returns the same host (or `null` for a null receiver). Call after `Build`. |
 
 Each platform package initializes the matching ReactiveUI builder extension:
 
@@ -483,6 +633,12 @@ Each platform package initializes the matching ReactiveUI builder extension:
 | WinUI | `WithWinUI()` |
 | Avalonia | `WithAvalonia()` |
 | MAUI | `WithMaui()` |
+
+For hosted WPF, `ConfigureSplatForMicrosoftDependencyResolver()` also registers an
+internal `IWpfService` that binds `RxSchedulers.MainThreadScheduler` to the dispatcher
+owned by the hosted application. Do not add a `SchedulerRegistrar`, and do not use
+removed `RxApp` scheduler workarounds. The same public configuration call selects the
+appropriate ReactiveUI platform initialization for the other four UI frameworks.
 
 ### WPF Example
 
@@ -509,6 +665,24 @@ host.MapSplatLocator(serviceProvider =>
     // Register additional Splat services that need the built provider.
 });
 
+await host.RunAsync().ConfigureAwait(false);
+```
+
+The modern Avalonia form is identical at the call site:
+
+```csharp
+using ReactiveMarbles.Extensions.Hosting.Avalonia;
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.ConfigureSplatForMicrosoftDependencyResolver();
+builder.ConfigureAvalonia(avalonia => avalonia
+    .UseApplication<App>()
+    .UseWindow<MainWindow>());
+builder.UseAvaloniaLifetime();
+
+using var host = builder.Build();
+host.MapSplatLocator(_ => { });
 await host.RunAsync().ConfigureAwait(false);
 ```
 
@@ -575,7 +749,10 @@ Namespace: `ReactiveMarbles.Extensions.Hosting.AppServices`
 | `IMutexBuilder.MutexId` | Unique named mutex identifier. |
 | `IMutexBuilder.IsGlobal` | Uses the `Global\` mutex namespace when `true`; otherwise uses `Local\`. |
 | `IMutexBuilder.WhenNotFirstInstance` | Callback invoked with `IHostEnvironment` and `ILogger` when another instance already owns the mutex. |
-| `ResourceMutex.Create(ILogger? logger, string? mutexId, string? resourceName = null, bool global = false)` | Creates and locks a named mutex directly. |
+| `ResourceMutex.Create(ILogger? logger, string? mutexId)` | Creates and locks a local named mutex whose resource name is the mutex id. |
+| `ResourceMutex.Create(ILogger? logger, string? mutexId, string? resourceName)` | Creates and locks a local mutex with a diagnostic resource name. |
+| `ResourceMutex.Create(ILogger? logger, string? mutexId, bool global)` | Creates and locks a local or global mutex. |
+| `ResourceMutex.Create(ILogger? logger, string? mutexId, string? resourceName, bool global)` | Full explicit factory overload. |
 | `ResourceMutex.IsLocked` | Indicates whether the mutex was acquired. |
 | `ResourceMutex.Lock()` | Attempts to acquire the mutex. |
 | `ResourceMutex.Dispose()` | Releases the mutex on the owning thread. |
@@ -627,6 +804,13 @@ if (!mutex.IsLocked)
 // Run the protected work.
 ```
 
+The factory attempts acquisition immediately, waits up to two seconds, and `Lock()` can
+be called again when the instance does not own the mutex. A null logger uses internal
+no-op logging. A null,
+empty, or whitespace `mutexId` throws `ArgumentException`. Global mutexes require the
+process permissions needed for the `Global\` namespace. Dispose on the thread that
+owns the mutex; disposal coordinates release with that owner thread.
+
 ## Plug-ins
 
 Packages:
@@ -642,7 +826,7 @@ Reactive namespace: `ReactiveMarbles.Extensions.Hosting.Reactive.Plugins`
 
 | API | Description |
 | --- | --- |
-| `ConfigurePlugins(Action<IPluginBuilder?> configurePlugin)` | Configures plug-in scanning and loading. Available on `IHostBuilder` and `IHostApplicationBuilder`. |
+| `ConfigurePlugins(Action<IPluginBuilder?> configurePlugin)` | Configures plug-in scanning and loading. Available on both builder styles; the callback itself may be null at runtime and receives the persisted builder instance. |
 | `IPlugin.ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)` | Called for each discovered plug-in so it can register services. |
 | `IPluginBuilder.PluginDirectories` | Root directories scanned for plug-in assemblies. |
 | `IPluginBuilder.FrameworkDirectories` | Root directories scanned for framework assemblies. |
@@ -657,12 +841,13 @@ Reactive namespace: `ReactiveMarbles.Extensions.Hosting.Reactive.Plugins`
 | `ExcludeFrameworks(params string[] frameworkGlobs)` | Adds framework exclude globs. |
 | `IncludePlugins(params string[] pluginGlobs)` | Adds plug-in include globs. |
 | `ExcludePlugins(params string[] pluginGlobs)` | Adds plug-in exclude globs. |
-| `RequirePlugins(bool failIfNone = true)` | Sets `FailIfNoPlugins`. |
-| `PluginScanner.ByNamingConvention(Assembly pluginAssembly)` | Finds a conventional `{AssemblyName}.Plugin` type. |
-| `PluginScanner.ScanForPluginInstances(Assembly pluginAssembly)` | Finds public concrete classes implementing `IPlugin`. |
-| `PluginOrderAttribute` | Orders discovered plug-ins. Lower values run earlier. Constructors accept no value, an `int`, or an enum/object value. |
-| `PluginBase<T>`, `PluginBase<T1,T2>`, `PluginBase<T1,T2,T3>` | Base plug-ins that register one, two, or three hosted services. |
-| `HostedServiceBase<T>` | Base hosted service with logging, cleanup, and lifetime callback hooks. |
+| `RequirePlugins()` / `RequirePlugins(bool failIfNone)` | Requires at least one discovered plug-in or explicitly sets `FailIfNoPlugins`. |
+| `PluginScanner.ByNamingConvention(Assembly pluginAssembly)` | Instantiates the public `{AssemblyName}.Plugin` type when it implements `IPlugin`. |
+| `PluginScanner.ScanForPluginInstances(Assembly pluginAssembly)` | Instantiates exported, public, concrete classes implementing `IPlugin`. |
+| `PluginOrderAttribute()` / `(int order)` / `(object enumValue)` | Orders discovered plug-ins. Lower values run earlier; discovery order is preserved within an equal-order bucket. |
+| `PluginOrderAttribute.Order` / `EnumValue` | Integer order and, when the object constructor was used, its original enum/object value. |
+| `PluginBase<T>`, `PluginBase<T1,T2>`, `PluginBase<T1,T2,T3>` | Base plug-ins that register one, two, or three types; every generic parameter must implement `IHostedService`. |
+| `HostedServiceBase<T>(ILogger<T>, IHostApplicationLifetime)` | Base hosted service with logging, cleanup, and lifetime callback hooks. |
 
 `HostedServiceBase<T>` exposes:
 
@@ -674,6 +859,32 @@ Reactive namespace: `ReactiveMarbles.Extensions.Hosting.Reactive.Plugins`
 | `OnStarted()` | Override to start work after the application starts. |
 | `OnStopping()` | Override to stop work and dispose resources. Call the base implementation unless you intentionally replace cleanup behavior. |
 | `OnStopped()` | Override to run final stopped logic. |
+| `StartAsync(CancellationToken)` | Registers callbacks for `ApplicationStarted`, `ApplicationStopping`, and `ApplicationStopped`. |
+| `StopAsync(CancellationToken)` | Completes immediately; shutdown work is driven by lifetime callbacks. |
+| `Dispose()` | Disposes the cleanup collection and suppresses finalization. |
+
+`OnStarted()` is invoked once asynchronously after `ApplicationStarted`. Its exception
+is logged and is not retried or propagated through the lifetime callback. Implement
+bounded retry and cancellation explicitly when the service requires them. The normal
+package uses `ReactiveUI.Primitives.Disposables.CompositeDisposable`; the `.Reactive`
+package exposes the same hosting lifecycle and API shape in its reactive namespace.
+
+The following public loader compatibility APIs live in the `.Plugins.Internals`
+namespace. Prefer the higher-level builder and scanner APIs unless implementing a
+custom loader:
+
+| API | Description |
+| --- | --- |
+| `AssemblyDependencyResolver(string pluginPath)` | Creates a resolver rooted beside the supplied plug-in assembly path. |
+| `ResolveAssemblyToPath(AssemblyName)` | Returns an existing managed assembly path or `null`. |
+| `ResolveUnmanagedDllToPath(string)` | Returns an existing native DLL path or `null`; blank names throw `ArgumentException`. |
+| `AssemblyLoadContext(string name)` | Creates the package's cross-target load-context abstraction. |
+| `AssemblyLoadContext.Default` / `Assemblies` / `Name` | Default context, currently loaded application-domain assemblies, and context name. |
+| `AssemblyLoadContext.LoadFromAssemblyPath(string)` | Static managed assembly load by full path. |
+| `AssemblyLoadContext.LoadFromAssemblyName(AssemblyName)` | Instance managed assembly load by identity. |
+| `AssemblyLoadContext.Load(AssemblyName)` / `LoadUnmanagedDll(string)` | Protected virtual resolution hooks for derived contexts. |
+| `AssemblyLoadContext.LoadUnmanagedDllFromPath(string)` | Protected static native-load hook. |
+| `TryGetAssembly(AssemblyName, out Assembly?)` | Searches loaded assemblies by simple name. |
 
 ### Host Scanning Example
 
@@ -773,14 +984,19 @@ Reactive namespace: `ReactiveMarbles.Extensions.Hosting.Reactive.PluginService`
 | API | Description |
 | --- | --- |
 | `ServiceHost.Logger` | Gets the `ILogger` created by the service host after startup. |
-| `ServiceHost.Create(Type type, string[] args, Func<IHostBuilder?, IHostBuilder?>? hostBuilder = default, Action<IHost>? configureHost = default, string nameSpace = "ReactiveMarbles.Plugin", string? targetRuntime = null)` | Creates, configures, and runs a classic `IHostBuilder` service host. |
-| `ServiceHost.CreateApplication(Type type, string[] args, Func<IHostApplicationBuilder?, IHostApplicationBuilder?>? hostBuilder = default, Action<IHost>? configureHost = default, string nameSpace = "ReactiveMarbles.Plugin", string? targetRuntime = null)` | Creates, configures, and runs a modern `IHostApplicationBuilder` service host. |
+| `ServiceHost.Create(Type type, string[] args)` | Creates and runs a classic service host with the default plug-in namespace/runtime rules. |
+| `ServiceHost.Create(Type type, string[] args, Func<IHostBuilder?,IHostBuilder?>? hostBuilder, Action<IHost>? configureHost, string nameSpace, string? targetRuntime)` | Full classic factory. The six-argument overload has no optional arguments. |
+| `ServiceHost.CreateApplication(Type type, string[] args)` | Creates and runs a modern application-builder service host with defaults. |
+| `ServiceHost.CreateApplication(Type type, string[] args, Func<IHostApplicationBuilder?,IHostApplicationBuilder?>? hostBuilder, Action<IHost>? configureHost, string nameSpace, string? targetRuntime)` | Full modern factory. The six-argument overload has no optional arguments. |
 | `UseServiceBaseLifetime()` on `IHostBuilder` | Registers `ServiceBaseLifetime` as `IHostLifetime`. |
 | `UseServiceBaseLifetime()` on `IHostApplicationBuilder` | Registers `ServiceBaseLifetime` as `IHostLifetime`. |
 | `UseConsoleLifetime()` on `IHostApplicationBuilder` | Registers `ConsoleLifetime` as `IHostLifetime`. |
-| `RunAsServiceAsync(CancellationToken cancellationToken = default)` on `IHostBuilder` | Builds and runs with `ServiceBaseLifetime`. |
-| `RunAsServiceAsync(CancellationToken cancellationToken = default)` on `HostApplicationBuilder` | Builds and runs with `ServiceBaseLifetime`. |
-| `ServiceBaseLifetime` | `IHostLifetime` implementation backed by `System.ServiceProcess.ServiceBase`. |
+| `RunAsServiceAsync()` / `RunAsServiceAsync(CancellationToken)` on `IHostBuilder` | Builds and runs with `ServiceBaseLifetime`. |
+| `RunAsServiceAsync()` / `RunAsServiceAsync(CancellationToken)` on `HostApplicationBuilder` | Configures service lifetime, builds, and runs the modern builder. |
+| `ServiceBaseLifetime(IHostApplicationLifetime)` | `IHostLifetime` backed by `System.ServiceProcess.ServiceBase`. |
+| `ServiceBaseLifetime.WaitForStartAsync(CancellationToken)` | Starts the Windows service dispatcher on a background task and completes when the service reports start. |
+| `ServiceBaseLifetime.StopAsync(CancellationToken)` | Stops the service when the lifetime is active. |
+| `DefaultLogger.Logger` | Exposes the logger used by `ServiceHost` after DI construction. |
 
 `ServiceHost` configures:
 
@@ -810,9 +1026,14 @@ await ServiceHost.Create(
         ServiceHost.Logger?.LogInformation("Host configured.");
     },
     nameSpace: "Contoso.Plugin",
+    nameSpace: "Contoso.Plugin",
     targetRuntime: "win-x64")
     .ConfigureAwait(false);
 ```
+
+The full factory overload deliberately requires all six arguments. Use the
+two-argument overload when every default is acceptable; do not rely on the V3
+three-to-five-argument optional-parameter call forms.
 
 ### Modern Builder Entry Point
 
@@ -863,35 +1084,52 @@ SQLite package: `CP.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite`
 
 SQLite namespace: `ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite`
 
+Across both providers, `TContext : DbContext`; Identity user and role type parameters
+are constrained to `class`. The helpers register the requested DbContext provider,
+Identity stores, and the selected service lifetime.
+
 ### SQL Server API
 
 | API | Description |
 | --- | --- |
 | `IConfiguration.HasConnectionString(string connectionStringName)` | Returns `true` when the named connection string exists and is not empty. |
 | `IConfiguration.GetRequiredConnectionString(string connectionStringName)` | Gets the named connection string or throws a descriptive `InvalidOperationException`. |
-| `IHostApplicationBuilder.AddSqlServerDbContext<TContext>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQL Server `DbContext`. |
-| `IHostApplicationBuilder.AddSqlServerWithIdentity<TContext,TUser,TRole>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQL Server EF Core plus ASP.NET Core Identity with roles. |
-| `IHostApplicationBuilder.AddSqlServerWithIdentity<TContext,TUser>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQL Server EF Core plus ASP.NET Core Identity without a custom role type. |
-| `IHostBuilder.UseWebHostServices(...)` | Adds minimal ASP.NET Core web-host services. Three overloads support service-only, web-host customization, and web-host plus app-pipeline customization. |
-| `IServiceCollection.UseEntityFrameworkCoreSqlServer<TContext,TUser,TRole>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQL Server EF Core plus Identity with roles in a web-host service callback. |
-| `IServiceCollection.UseEntityFrameworkCoreSqlServer<TContext,TUser>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQL Server EF Core plus Identity without a custom role type. |
-| `IServiceCollection.AddSqlServerDbContext<TContext>(IConfiguration configuration, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQL Server `DbContext` from configuration. |
-| `IServiceCollection.AddSqlServerDbContextWithConnectionString<TContext>(string connectionString, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQL Server `DbContext` from a direct connection string. |
+| `IHostApplicationBuilder.AddSqlServerDbContext<TContext>(string connectionStringName)` / `(string connectionStringName, ServiceLifetime serviceLifetime)` | Registers a SQL Server `DbContext`; the short overload uses `Scoped`. |
+| `IHostApplicationBuilder.AddSqlServerWithIdentity<TContext,TUser,TRole>(string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers SQL Server EF Core plus Identity with roles; the short overload uses `Scoped`. |
+| `IHostApplicationBuilder.AddSqlServerWithIdentity<TContext,TUser>(string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers SQL Server EF Core plus Identity without a custom role type. |
+| `IServiceCollection.UseEntityFrameworkCoreSqlServer<TContext,TUser,TRole>(WebHostBuilderContext context, string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers SQL Server EF Core plus Identity with roles in a web-host callback. |
+| `IServiceCollection.UseEntityFrameworkCoreSqlServer<TContext,TUser>(WebHostBuilderContext context, string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers SQL Server EF Core plus Identity without a custom role type. |
+| `IServiceCollection.AddSqlServerDbContext<TContext>(IConfiguration configuration, string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers a SQL Server `DbContext` from configuration. |
+| `IServiceCollection.AddSqlServerDbContextWithConnectionString<TContext>(string connectionString)` / `(..., ServiceLifetime serviceLifetime)` | Registers a SQL Server `DbContext` from a direct connection string. |
 
 ### SQLite API
 
 | API | Description |
 | --- | --- |
-| `IHostApplicationBuilder.AddSqliteDbContext<TContext>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQLite `DbContext`. |
-| `IHostApplicationBuilder.AddSqliteWithIdentity<TContext,TUser,TRole>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQLite EF Core plus ASP.NET Core Identity with roles. |
-| `IHostApplicationBuilder.AddSqliteWithIdentity<TContext,TUser>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQLite EF Core plus ASP.NET Core Identity without a custom role type. |
-| `IHostBuilder.UseWebHostServices(...)` | Adds minimal ASP.NET Core web-host services. Three overloads match the SQL Server package. |
-| `IServiceCollection.UseEntityFrameworkCoreSqlite<TContext,TUser,TRole>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQLite EF Core plus Identity with roles in a web-host service callback. |
-| `IServiceCollection.UseEntityFrameworkCoreSqlite<TContext,TUser>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers SQLite EF Core plus Identity without a custom role type. |
-| `IServiceCollection.AddSqliteDbContext<TContext>(IConfiguration configuration, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQLite `DbContext` from configuration. |
-| `IServiceCollection.AddSqliteDbContextWithConnectionString<TContext>(string connectionString, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)` | Registers a SQLite `DbContext` from a direct connection string. |
-| `CreateInMemoryConnectionString(string? databaseName = null)` | Creates a SQLite in-memory connection string. |
+| `IHostApplicationBuilder.AddSqliteDbContext<TContext>(string connectionStringName)` / `(string connectionStringName, ServiceLifetime serviceLifetime)` | Registers a SQLite `DbContext`; the short overload uses `Scoped`. |
+| `IHostApplicationBuilder.AddSqliteWithIdentity<TContext,TUser,TRole>(string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers SQLite EF Core plus Identity with roles. |
+| `IHostApplicationBuilder.AddSqliteWithIdentity<TContext,TUser>(string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers SQLite EF Core plus Identity without a custom role type. |
+| `IServiceCollection.UseEntityFrameworkCoreSqlite<TContext,TUser,TRole>(WebHostBuilderContext context, string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers SQLite EF Core plus Identity with roles in a web-host callback. |
+| `IServiceCollection.UseEntityFrameworkCoreSqlite<TContext,TUser>(WebHostBuilderContext context, string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers SQLite EF Core plus Identity without a custom role type. |
+| `IServiceCollection.AddSqliteDbContext<TContext>(IConfiguration configuration, string connectionStringName)` / `(..., ServiceLifetime serviceLifetime)` | Registers a SQLite `DbContext` from configuration. |
+| `IServiceCollection.AddSqliteDbContextWithConnectionString<TContext>(string connectionString)` / `(..., ServiceLifetime serviceLifetime)` | Registers a SQLite `DbContext` from a direct connection string. |
+| `CreateInMemoryConnectionString()` / `CreateInMemoryConnectionString(string? databaseName)` | Creates a named or unnamed SQLite in-memory connection string. |
 | `CreateFileConnectionString(string filePath)` | Creates a SQLite file connection string. |
+
+Both provider packages expose six `IHostBuilder.UseWebHostServices` overloads:
+
+| Overload shape | Behavior |
+| --- | --- |
+| `UseWebHostServices(Action<WebHostBuilderContext,IServiceCollection> configureServices)` | Configures web-host services with default scope validation. |
+| `UseWebHostServices(Action<...> configureServices, bool validateScopes)` | Also controls service-provider scope validation. |
+| `UseWebHostServices(Func<IWebHostBuilder,IWebHostBuilder> configureWebHost, Action<...> configureServices)` | Customizes the web host and services. |
+| Previous overload plus `bool validateScopes` | Adds explicit scope validation. |
+| Previous overload plus `Func<IApplicationBuilder,IApplicationBuilder> configureApp` | Also customizes the terminal application pipeline. |
+| Previous overload plus `bool validateScopes` | Full web-host, services, pipeline, and validation overload. |
+
+When no `configureApp` delegate is supplied, the helper installs a terminal no-op
+pipeline. Use the explicit `ServiceLifetime` overload when a context lifetime other
+than the default `Scoped` registration is intentional.
 
 ### Modern Builder Example
 
@@ -948,6 +1186,88 @@ var connectionString =
 services.AddSqliteDbContextWithConnectionString<AppDbContext>(connectionString);
 ```
 
+## Log4Net Logging
+
+Package: `CP.Extensions.Logging.Log4Net`
+
+Main namespace: `ReactiveMarbles.Extensions.Logging`
+
+Entity namespace: `ReactiveMarbles.Extensions.Logging.Log4Net.Entities`
+
+Extension namespace: `ReactiveMarbles.Extensions.Logging.Log4Net.Extensions`
+
+### API
+
+| API | Description |
+| --- | --- |
+| `ILoggerFactory.AddLog4Net()` | Adds a provider using `log4net.config` without file watching. |
+| `ILoggerFactory.AddLog4Net(string configFile)` | Adds a provider using the named configuration file. |
+| `ILoggerFactory.AddLog4Net(string configFile, bool watch)` | Adds a provider and optionally reloads when the XML file changes. |
+| `ILoggerFactory.AddLog4Net(Log4NetProviderOptions options)` | Adds a directly constructed provider with advanced options. |
+| `ILoggingBuilder.AddLog4Net()` / `(string)` / `(string,bool)` / `(Log4NetProviderOptions)` | DI registration equivalents for Generic Host logging configuration. |
+| `Log4NetProvider()` / `(string configFile)` / `(Log4NetProviderOptions options)` | Creates the concrete `ILoggerProvider`. |
+| `Log4NetProvider.CreateLogger()` / `CreateLogger(string categoryName)` | Creates a default-category or named logger. |
+| `ILoggerProvider.CreateLogger(Type nameType)` | Creates a type-named logger; throws `ArgumentOutOfRangeException` for a provider other than `Log4NetProvider`. |
+| `Log4NetProvider.ExternalScopeProvider` / `SetScopeProvider(...)` | Gets or replaces the Microsoft logging scope provider. |
+| `Log4NetProvider.Dispose()` | Disposes cached loggers/provider resources. |
+| `Log4NetLogger.Name` / `BeginScope` / `IsEnabled` / `Log` | Concrete Microsoft `ILogger` implementation used by the provider. |
+| `ILog.Critical(object, Exception)` / `Trace(object, Exception)` | Adds explicit log4net Critical and Trace calls. |
+| `ILog4NetLoggingEventFactory.CreateLoggingEvent<TState>(...)` | Customizes conversion from Microsoft log state to a log4net `LoggingEvent`. |
+| `ILog4NetLogLevelTranslator.TranslateLogLevel(...)` | Customizes Microsoft-to-log4net level mapping. |
+| `Log4NetLoggingEventFactory` / `Log4NetLogLevelTranslator` | Default implementations of the two customization interfaces. |
+| `MessageCandidate<TState>` | Immutable input record containing `LogLevel`, `EventId`, state, exception, and formatter for event creation. |
+| `NodeInfo` | XML override descriptor with `XPath`, `NodeContent`, and a mutable get-only `Attributes` dictionary. |
+
+`Log4NetProviderOptions` supports:
+
+| Option | Meaning |
+| --- | --- |
+| `Name` | Optional provider/configuration name. |
+| `Log4NetConfigFileName` | XML configuration path; defaults to `log4net.config`. |
+| `LoggerRepository` | Explicit log4net repository name. |
+| `OverrideCriticalLevelWith` | Maps Microsoft `Critical` to a configured log4net level name. |
+| `PropertyOverrides` | Mutable get-only list of `NodeInfo` XML overrides. |
+| `Watch` | Reloads the configuration file after changes. |
+| `ExternalConfigurationSetup` | Leaves repository configuration to application code and skips provider configuration. |
+| `UseWebOrAppConfig` | Reads log4net configuration from `web.config` or `app.config`. |
+| `ConfigurationAssembly` | Assembly used to establish repository identity when no repository name is supplied. |
+| `LoggingEventFactory` | Optional `ILog4NetLoggingEventFactory` replacement. |
+| `LogLevelTranslator` | Optional `ILog4NetLogLevelTranslator` replacement. |
+
+### Generic Host Example
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Logging;
+using ReactiveMarbles.Extensions.Logging.Log4Net.Entities;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var log4NetOptions = new Log4NetProviderOptions("log4net.config", watch: true)
+{
+    Name = "Desktop",
+    OverrideCriticalLevelWith = "FATAL",
+};
+
+var appenderOverride = new NodeInfo
+{
+    XPath = "/log4net/appender[@name='RollingFile']/file",
+};
+appenderOverride.Attributes["value"] = "logs/application.log";
+log4NetOptions.PropertyOverrides.Add(appenderOverride);
+
+builder.Logging.AddLog4Net(log4NetOptions);
+
+using var host = builder.Build();
+await host.RunAsync().ConfigureAwait(false);
+```
+
+If log4net is configured before the Generic Host starts, set
+`ExternalConfigurationSetup = true` so the provider preserves that repository.
+`PropertyOverrides` and `NodeInfo.Attributes` are get-only mutable collections: use
+`Add` or index assignment instead of replacing the collection.
+
 ## Recommended Composition
 
 The packages are designed to compose as small host extensions. A desktop app can combine single-instance enforcement, ReactiveUI/Splat, platform lifetime, and plug-in loading in one host.
@@ -973,6 +1293,240 @@ var host = new HostBuilder()
 
 await host.RunAsync().ConfigureAwait(false);
 ```
+
+## Migrate From V3.1.26 To V4.0.0
+
+V4 is a major-version migration. Upgrade all `CP.Extensions.Hosting.*` references
+together and rebuild every consuming assembly, including plug-ins. Source calls that
+still look the same may bind to different explicit overloads, so copying V3 binaries
+into a V4 process is unsupported.
+
+### Migration Checklist
+
+1. Move the application to a supported target framework and install the .NET workloads
+   required by its UI platform.
+2. Upgrade all Extensions.Hosting packages to `4.0.0`.
+3. Choose either the normal or `.Reactive` package family for plug-ins,
+   PluginService, and ReactiveUI bridges.
+4. Update reactive namespaces when choosing `.Reactive`.
+5. Replace V3 `System.Reactive` disposable contracts used through
+   `HostedServiceBase<T>`.
+6. Rebuild custom shell implementations against the new platform-typed interfaces.
+7. Update `ResourceMutex` and `ServiceHost` calls to explicit V4 overloads.
+8. Remove application `SchedulerRegistrar`/`RxApp` workarounds.
+9. Exercise native startup, dispatcher shutdown, cancellation, plug-in discovery, and
+   service/console mode.
+
+### Package And Namespace Selection
+
+V4 default packages use the normal ReactiveUI.Primitives family. V4 adds explicit
+`.Reactive` packages for applications that use the reactive bridge family:
+
+| V3.1.26 package | V4 default | V4 `.Reactive` alternative |
+| --- | --- | --- |
+| `CP.Extensions.Hosting.Plugins` | Same package | `CP.Extensions.Hosting.Plugins.Reactive` |
+| `CP.Extensions.Hosting.PluginService` | Same package | `CP.Extensions.Hosting.PluginService.Reactive` |
+| `CP.Extensions.Hosting.ReactiveUI.Wpf` | Same package | `CP.Extensions.Hosting.ReactiveUI.Wpf.Reactive` |
+| `CP.Extensions.Hosting.ReactiveUI.WinForms` | Same package | `CP.Extensions.Hosting.ReactiveUI.WinForms.Reactive` |
+| `CP.Extensions.Hosting.ReactiveUI.WinUI` | Same package | `CP.Extensions.Hosting.ReactiveUI.WinUI.Reactive` |
+| `CP.Extensions.Hosting.ReactiveUI.Avalonia` | Same package | `CP.Extensions.Hosting.ReactiveUI.Avalonia.Reactive` |
+| `CP.Extensions.Hosting.ReactiveUI.Maui` | Same package | `CP.Extensions.Hosting.ReactiveUI.Maui.Reactive` |
+
+```xml
+<!-- V3.1.26 or the V4 default/Primitives path -->
+<PackageReference Include="CP.Extensions.Hosting.Plugins" Version="4.0.0" />
+
+<!-- V4 explicit reactive bridge path -->
+<PackageReference Include="CP.Extensions.Hosting.Plugins.Reactive" Version="4.0.0" />
+```
+
+```csharp
+// V4 default packages
+using ReactiveMarbles.Extensions.Hosting.Plugins;
+using ReactiveMarbles.Extensions.Hosting.PluginService;
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+
+// V4 .Reactive packages
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+using ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+using ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+```
+
+Do not mix a normal package and its `.Reactive` sibling in the same project.
+
+### HostedServiceBase Disposable And Startup Changes
+
+`HostedServiceBase<T>` no longer implements `System.Reactive.ICancelable`. It implements
+`ReactiveUI.Primitives.Disposables.IsDisposed`, remains `IDisposable`, and exposes a
+Primitives `CompositeDisposable` through `CleanUp`.
+
+```csharp
+// V3
+System.Reactive.ICancelable service = hostedService;
+if (!service.IsDisposed)
+{
+    service.Dispose();
+}
+
+// V4
+ReactiveUI.Primitives.Disposables.IsDisposed service = hostedService;
+if (!service.IsDisposed)
+{
+    ((IDisposable)hostedService).Dispose();
+}
+```
+
+`OnStarted()` is now invoked once asynchronously after `ApplicationStarted`.
+Exceptions are logged and are neither retried nor propagated through the lifetime
+callback. Replace any reliance on the previous Rx `Retry()` path with an explicit,
+bounded retry policy that honors application cancellation.
+
+### Platform-Typed Shell Contracts
+
+The shell interfaces are no longer unconstrained markers:
+
+| V4 shell | Required base interface |
+| --- | --- |
+| `IWpfShell` | `System.Windows.IInputElement` |
+| `IAvaloniaShell` | `Avalonia.Input.IInputElement` |
+| `IWinFormsShell` | `System.ComponentModel.IComponent` |
+| `IMauiShell` | `Microsoft.Maui.IView` |
+
+Normal `Window`, `Form`, `Page`, and `Shell` implementations already satisfy these
+requirements. Custom marker-only implementations must now implement the platform
+interface or, preferably, compose the shell contract into a real platform view.
+
+### Explicit Overload Changes
+
+V3 exposed optional arguments for `ResourceMutex.Create`; V4 exposes four methods:
+
+```csharp
+// V3
+using var mutex = ResourceMutex.Create(
+    logger,
+    "Contoso.Desktop",
+    resourceName: "Desktop application",
+    global: true);
+
+// V4: select one explicit overload
+using var mutex = ResourceMutex.Create(
+    logger,
+    "Contoso.Desktop",
+    "Desktop application",
+    global: true);
+```
+
+V3 allowed partial `ServiceHost.Create` and `CreateApplication` calls through optional
+arguments. V4 supports either two arguments or all six:
+
+```csharp
+// V3.1.26
+await ServiceHost.Create(
+    typeof(Program),
+    args,
+    hostBuilder: ConfigureHostBuilder);
+
+// V4 default path
+await ServiceHost.Create(typeof(Program), args);
+
+// V4 configured path
+await ServiceHost.Create(
+    typeof(Program),
+    args,
+    ConfigureHostBuilder,
+    configureHost: null,
+    nameSpace: "Contoso.Plugin",
+    targetRuntime: null);
+```
+
+`RunAsServiceAsync(CancellationToken cancellationToken = default)` was likewise split
+into parameterless and `CancellationToken` overloads. Normal parameterless call syntax
+is unchanged.
+
+V4 implementation source uses C# extension blocks and explicit no-argument/full
+overload pairs throughout the hosting APIs. Consumer syntax remains
+`builder.ConfigureWpf(...)`, `builder.ConfigurePlugins(...)`, and so on, but
+reflection-based code must not assume V3 optional-parameter metadata.
+
+### Scheduler And UI Lifecycle Changes
+
+- WPF `ConfigureSplatForMicrosoftDependencyResolver()` now installs hosted dispatcher
+  scheduling through an internal `IWpfService`. Remove `SchedulerRegistrar` and old
+  `RxApp` scheduler setup; use `RxSchedulers`.
+- MAUI application construction is deferred to UI startup. Do not resolve an eagerly
+  built `MauiApp` immediately after `ConfigureMaui`.
+- MAUI and WinUI shutdown now fails fast instead of waiting indefinitely when the
+  dispatcher is absent or rejects the callback. Handle `InvalidOperationException`,
+  and expect `OperationCanceledException` when shutdown is cancelled.
+- WinForms shutdown snapshots open forms before closing and disposing them. One form's
+  cleanup failure is logged and does not prevent the remaining forms from being
+  processed.
+- WPF and Avalonia lifetime methods must follow their `Configure*` methods and throw
+  `NotSupportedException` when that order is violated.
+
+### Plug-in API Changes
+
+Plug-ins with the same `PluginOrderAttribute.Order` retain discovery order within that
+order bucket. The attribute lookup is cached per plug-in type.
+`PluginOrderAttribute(object enumValue)` now preserves the supplied value through
+`EnumValue` as well as exposing its converted integer `Order`.
+
+Types under `ReactiveMarbles.Extensions.Hosting.Plugins.Internals` are public for
+historical compatibility but remain implementation APIs. V4 changes include:
+
+- `AssemblyDependencyResolver` is sealed and
+  `ResolveUnmanagedDllToPath` returns `string?`.
+- `AssemblyLoadContext.Assemblies`, `LoadFromAssemblyPath`, and
+  `LoadUnmanagedDllFromPath` are static.
+- `PluginLoadContext` is sealed and its former public `ResolveAssemblyPath` is
+  internal.
+
+Migrate callers to `ConfigurePlugins`, `IPluginBuilder`, and `PluginScanner` instead of
+binding to those loader implementation types.
+
+### Log4Net Changes
+
+`CP.Extensions.Logging.Log4Net` no longer targets `netstandard2.0`. Move consumers to
+.NET Framework 4.6.2 or later, or .NET 8 or later.
+
+```csharp
+// V3
+ILogger logger = provider.CreateLogger<MyCategory>();
+
+// V4
+ILogger logger = provider.CreateLogger(typeof(MyCategory));
+```
+
+`Log4NetProviderOptions.PropertyOverrides` and `NodeInfo.Attributes` are get-only
+mutable collections:
+
+```csharp
+// V3 assignment
+options.PropertyOverrides = new List<NodeInfo> { node };
+node.Attributes = new Dictionary<string, string> { ["value"] = "app.log" };
+
+// V4 mutation
+options.PropertyOverrides.Add(node);
+node.Attributes["value"] = "app.log";
+```
+
+When `ExternalConfigurationSetup` is `true`, V4 preserves the externally configured
+repository and skips provider configuration.
+
+### Target Framework And Dependency Changes
+
+- Most packages add `net48` and `net11.0`/`net11.0-windows`; net11 support is preview.
+- The base MAUI host retains `net9.0`, but V4 MAUI platform workload assets begin at
+  `net10.0-*`. ReactiveUI MAUI V4 begins at net10.
+- Log4Net removes `netstandard2.0`.
+- ReactiveUI moves from 23.2.27 to 24.0.0, Splat from 19.3.1 to 20.2.0, Avalonia from
+  12.0.2 to 12.1.0, and the default packages use ReactiveUI.Primitives 7.1.
+- EF helper call sites remain conceptually compatible. Short overloads use
+  `ServiceLifetime.Scoped`; use the new explicit-lifetime overloads when a different
+  lifetime is required.
+
+Consumers do not need to enable C# preview merely because V4 implementation assemblies
+use preview language features; they need only a supported SDK and target framework.
 
 ## Build And Test
 

--- a/Skill.md
+++ b/Skill.md
@@ -1,0 +1,221 @@
+---
+name: extensions-hosting
+description: Configure, compose, troubleshoot, and migrate CP.Extensions.Hosting packages for Generic Host applications. Use for WPF, WinForms, WinUI, Avalonia, MAUI, ReactiveUI/Splat, single-instance enforcement, plug-ins, Windows service hosting, normal versus .Reactive package selection, and V3.1.26-to-V4.0.0 upgrades.
+---
+
+# Extensions.Hosting
+
+Use this skill when a project references a `CP.Extensions.Hosting.*` package or needs a
+Microsoft Generic Host around a desktop UI, plug-in system, or Windows service.
+
+Read the package-root `README.md` before changing code. It contains the complete API
+tables, platform recipes, exceptions, and migration guide. Treat the installed package
+version and the project's target framework as authoritative.
+
+## Select packages
+
+Choose one platform host when the application owns a UI:
+
+| Application | Host package | Optional ReactiveUI/Splat bridge |
+| --- | --- | --- |
+| WPF | `CP.Extensions.Hosting.Wpf` | `CP.Extensions.Hosting.ReactiveUI.Wpf` |
+| WinForms | `CP.Extensions.Hosting.WinForms` | `CP.Extensions.Hosting.ReactiveUI.WinForms` |
+| WinUI | `CP.Extensions.Hosting.WinUI` | `CP.Extensions.Hosting.ReactiveUI.WinUI` |
+| Avalonia | `CP.Extensions.Hosting.Avalonia` | `CP.Extensions.Hosting.ReactiveUI.Avalonia` |
+| MAUI | `CP.Extensions.Hosting.Maui` | `CP.Extensions.Hosting.ReactiveUI.Maui` |
+
+Add supporting packages only for features that are used:
+
+- `CP.Extensions.Hosting.SingleInstance` for mutex-backed single-instance enforcement.
+- `CP.Extensions.Hosting.Plugins` for plug-in discovery and hosted-service plug-ins.
+- `CP.Extensions.Hosting.PluginService` for console or Windows service plug-in hosts.
+- `CP.Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer` or `.Sqlite` for
+  database and Identity registration.
+
+Do not reference `CP.Extensions.Hosting.MainUIThread` directly unless implementing a
+new platform adapter.
+
+## Choose the normal or `.Reactive` family
+
+Use normal packages with the normal ReactiveUI and ReactiveUI.Primitives family.
+Select the `.Reactive` variant for plug-in, PluginService, or ReactiveUI bridge
+features when that project and its plug-ins use the
+`ReactiveUI.Primitives.*.Reactive` or `ReactiveUI.*.Reactive` dependency family. A UI
+bridge is not required for `Plugins.Reactive` or `PluginService.Reactive`.
+
+| Normal | `.Reactive` |
+| --- | --- |
+| `CP.Extensions.Hosting.Plugins` | `CP.Extensions.Hosting.Plugins.Reactive` |
+| `CP.Extensions.Hosting.PluginService` | `CP.Extensions.Hosting.PluginService.Reactive` |
+| `CP.Extensions.Hosting.ReactiveUI.<Platform>` | `CP.Extensions.Hosting.ReactiveUI.<Platform>.Reactive` |
+| `ReactiveMarbles.Extensions.Hosting.Plugins` | `ReactiveMarbles.Extensions.Hosting.Reactive.Plugins` |
+| `ReactiveMarbles.Extensions.Hosting.PluginService` | `ReactiveMarbles.Extensions.Hosting.Reactive.PluginService` |
+| `ReactiveMarbles.Extensions.Hosting.ReactiveUI` | `ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI` |
+
+Platform hosts (`CP.Extensions.Hosting.Wpf`, `.WinForms`, `.WinUI`, `.Avalonia`,
+`.Maui`), `CP.Extensions.Hosting.SingleInstance`,
+`CP.Extensions.Hosting.MainUIThread`, Identity helpers, and Log4Net have no
+`.Reactive` siblings. Keep those normal packages even when using a `.Reactive` bridge
+or plug-in package. For example, `CP.Extensions.Hosting.ReactiveUI.Wpf.Reactive` still
+uses `CP.Extensions.Hosting.Wpf`.
+
+Never mix normal and `.Reactive` variants of the same feature in one project.
+Do not add direct Rx.NET references merely to use these hosting APIs.
+
+## Compose the host
+
+Apply configuration before the matching lifetime method, then build once:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.AppServices;
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.ConfigureSingleInstance("Contoso.Desktop");
+builder.ConfigureSplatForMicrosoftDependencyResolver();
+builder.ConfigureWpf(wpf => wpf
+    .UseApplication<App>()
+    .UseWindow<MainWindow>());
+builder.UseWpfLifetime();
+
+using var host = builder.Build();
+host.MapSplatLocator(_ => { });
+await host.RunAsync().ConfigureAwait(false);
+```
+
+Ordering rules:
+
+1. Register application services and optional Splat integration.
+2. Configure single-instance enforcement before platform-hosted services when used.
+3. Call `ConfigureWpf`, `ConfigureWinForms`, `ConfigureWinUI`, `ConfigureAvalonia`, or
+   `ConfigureMaui`.
+4. Call the matching `Use*Lifetime` method where the platform exposes one.
+5. Build the host.
+6. Call `MapSplatLocator` only on the built host.
+7. Run and dispose the host.
+
+`UseWpfLifetime` and `UseAvaloniaLifetime` throw when called before their matching
+`Configure*` method. WinUI installs its hosted lifetime in `ConfigureWinUI`; it has no
+`UseWinUILifetime` method.
+
+## Initialize services on the UI thread
+
+Register platform initialization services with DI. The host invokes them on the
+platform UI thread:
+
+```csharp
+public sealed class ThemeInitializer : IWpfService
+{
+    public void Initialize(System.Windows.Application application)
+    {
+        application.Resources["AccentBrush"] =
+            new System.Windows.Media.SolidColorBrush(
+                System.Windows.Media.Colors.CornflowerBlue);
+    }
+}
+
+builder.Services.AddSingleton<IWpfService, ThemeInitializer>();
+```
+
+Equivalent contracts are `IWinFormsService`, `IWinUIService`, `IAvaloniaService`, and
+`IMauiService`.
+
+## ReactiveUI schedulers
+
+Call the platform `ConfigureSplatForMicrosoftDependencyResolver()` extension. For WPF,
+V4 automatically binds `RxSchedulers.MainThreadScheduler` to the dispatcher owned by
+the hosted application through an internal `IWpfService`.
+
+Do not add or register `SchedulerRegistrar`. Do not use removed `RxApp` scheduler
+workarounds.
+
+## Plug-ins
+
+Configure scan roots and explicit include patterns:
+
+```csharp
+builder.ConfigurePlugins(plugins =>
+{
+    plugins?.AddScanDirectories(AppContext.BaseDirectory);
+    plugins?.IncludePlugins("plugins/**/*.Plugin.dll");
+    plugins?.ExcludePlugins("plugins/**/*.Disabled.dll");
+    plugins?.RequirePlugins();
+});
+```
+
+Implement `IPlugin.ConfigureHost` to register services. Use `PluginOrderAttribute` for
+deterministic order and `HostedServiceBase<T>` only when its application-lifetime
+callbacks fit the service. `OnStarted()` runs once; implement bounded retry and
+cancellation explicitly when needed.
+
+## Single-instance applications
+
+Use `ConfigureSingleInstance` for hosted applications:
+
+```csharp
+builder.ConfigureSingleInstance(mutex =>
+{
+    mutex.MutexId = "Contoso.Desktop";
+    mutex.IsGlobal = false;
+    mutex.WhenNotFirstInstance = (_, logger) =>
+        logger.LogWarning("Another instance is already running.");
+});
+```
+
+Use one of the four explicit `ResourceMutex.Create` overloads for direct locking. A
+blank mutex id is invalid. Dispose the mutex on its owning thread.
+
+## Diagnose lifecycle failures
+
+- Missing UI: verify the application/window/page type is registered and the shell
+  implements the platform shell interface.
+- Host never exits: enable the platform lifetime after platform configuration.
+- WPF/Avalonia lifetime throws during setup: reverse the `Use*Lifetime` and
+  `Configure*` calls.
+- MAUI/WinUI shutdown throws: the running application must expose a usable dispatcher;
+  rejected dispatch is an `InvalidOperationException`, and cancellation is honored.
+- Avalonia fails on Windows startup: enter the hosted UI from an STA thread.
+- Splat cannot resolve host services: call `MapSplatLocator` after `Build`.
+- No plug-ins load: verify scan roots, glob patterns, runtime subdirectory, and
+  `ValidatePlugin`.
+
+## Migrate V3.1.26 to V4.0.0
+
+1. Upgrade every `CP.Extensions.Hosting.*` reference together.
+2. Rebuild all consumers; V4 changes binary signatures even where source calls remain.
+3. Choose the normal or `.Reactive` family and update namespaces as a unit.
+4. Replace `System.Reactive.ICancelable` assumptions on `HostedServiceBase<T>` with
+   `ReactiveUI.Primitives.Disposables.IsDisposed` and `IDisposable`.
+5. Replace optional `ResourceMutex.Create` assumptions with an explicit overload.
+6. Replace partial `ServiceHost.Create`/`CreateApplication` calls with either the
+   two-argument overload or all six arguments.
+7. Make custom WPF, Avalonia, WinForms, and MAUI shells implement their new platform
+   base interface.
+8. Remove `SchedulerRegistrar`; use hosted WPF scheduler wiring.
+9. Retarget MAUI platform-workload applications, and all `ReactiveUI.Maui`
+   consumers, to net10 or later. The base `CP.Extensions.Hosting.Maui` host still
+   supports net9; its platform workload assets begin at net10. Move Log4Net
+   `netstandard2.0` consumers to a supported target.
+10. Run a warning-as-error build and exercise startup and shutdown on the native UI.
+
+## Validate
+
+For a consumer project, restore, build, and test the application for every target
+platform/runtime, then manually exercise native startup and shutdown.
+
+For a repository checkout:
+
+```powershell
+cd src
+dotnet workload restore
+dotnet restore Extensions.Hosting.slnx
+dotnet build Extensions.Hosting.slnx -c Release -warnaserror
+dotnet test --solution Extensions.Hosting.slnx -c Release
+```
+
+For consumer projects, validate both the target platform and deployment runtime.
+MAUI, WinUI, WPF, WinForms, and Windows service behavior cannot be fully established
+by a platform-neutral unit test alone.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,6 +31,15 @@
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'Extensions.Hosting.PluginService.Reactive.Platform.Tests'
+                         Or '$(MSBuildProjectName)' == 'Extensions.Hosting.ReactiveUI.Maui.Reactive.Platform.Tests'
+                         Or '$(MSBuildProjectName)' == 'Extensions.Hosting.ReactiveUI.WinForms.Reactive.Tests'
+                         Or '$(MSBuildProjectName)' == 'Extensions.Hosting.ReactiveUI.WinUI.Reactive.Platform.Tests'">
+    <BaseIntermediateOutputPath>obj\Reactive\</BaseIntermediateOutputPath>
+    <BaseOutputPath>bin\Reactive\</BaseOutputPath>
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\bin\**;$(MSBuildProjectDirectory)\obj\**</DefaultItemExcludes>
+  </PropertyGroup>
+
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
     <Features>$(Features);runtime-async=on</Features>
   </PropertyGroup>
@@ -80,9 +89,21 @@
     <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'Extensions.Hosting.MainUIThread'
+                     Or '$(MSBuildProjectName)' == 'Extensions.Hosting.SingleInstance'
+                     Or '$(MSBuildProjectName)' == 'Extensions.Hosting.Plugins'
+                     Or '$(MSBuildProjectName)' == 'Extensions.Hosting.Plugins.Reactive'
+                     Or '$(MSBuildProjectName)' == 'Extensions.Hosting.PluginService'
+                     Or '$(MSBuildProjectName)' == 'Extensions.Hosting.PluginService.Reactive'">
+    <None Include="$(MSBuildThisFileDirectory)..\Skill.md" Pack="true" PackagePath="Skill.md" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\Skill.md" Pack="true" PackagePath=".agents\skills\extensions-hosting\SKILL.md" Visible="false" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="MinVer" PrivateAssets="all" />
     <PackageReference Include="StyleSharp.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="PerformanceSharp.Analyzers" PrivateAssets="all"/>
+    <PackageReference Include="SecuritySharp.Analyzers" PrivateAssets="all"/>
     <PackageReference Include="Roslynator.Analyzers" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Extensions.Hosting.Avalonia/AvaloniaHostedService.cs
+++ b/src/Extensions.Hosting.Avalonia/AvaloniaHostedService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -28,7 +28,7 @@ public class AvaloniaHostedService(ILogger<AvaloniaHostedService> logger, Avalon
 {
     /// <summary>Logs when the Avalonia application is stopping.</summary>
     private static readonly Action<ILogger, Exception?> LogStoppingAvalonia =
-        LoggerMessage.Define(LogLevel.Debug, new EventId(1, nameof(LogStoppingAvalonia)), "Stopping Avalonia due to application exit.");
+        LoggerMessage.Define(LogLevel.Debug, new(1, nameof(LogStoppingAvalonia)), "Stopping Avalonia due to application exit.");
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)

--- a/src/Extensions.Hosting.Avalonia/Extensions/AvaloniaBuilderExtensions.cs
+++ b/src/Extensions.Hosting.Avalonia/Extensions/AvaloniaBuilderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -28,10 +28,7 @@ public static class AvaloniaBuilderExtensions
         public IAvaloniaBuilder UseWindow<TWindow>()
             where TWindow : Window
         {
-            if (avaloniaBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(avaloniaBuilder));
-            }
+            _ = avaloniaBuilder ?? throw new ArgumentNullException(nameof(avaloniaBuilder));
 
             avaloniaBuilder.WindowTypes.Add(typeof(TWindow));
             return avaloniaBuilder;
@@ -45,10 +42,7 @@ public static class AvaloniaBuilderExtensions
         public IAvaloniaBuilder UseApplication<TApplication>()
             where TApplication : Application
         {
-            if (avaloniaBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(avaloniaBuilder));
-            }
+            _ = avaloniaBuilder ?? throw new ArgumentNullException(nameof(avaloniaBuilder));
 
             avaloniaBuilder.ApplicationType = typeof(TApplication);
             return avaloniaBuilder;
@@ -65,10 +59,7 @@ public static class AvaloniaBuilderExtensions
         public IAvaloniaBuilder UseCurrentApplication<TApplication>(TApplication currentApplication)
             where TApplication : Application
         {
-            if (avaloniaBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(avaloniaBuilder));
-            }
+            _ = avaloniaBuilder ?? throw new ArgumentNullException(nameof(avaloniaBuilder));
 
             avaloniaBuilder.ApplicationType = typeof(TApplication);
             avaloniaBuilder.Application = currentApplication;
@@ -83,10 +74,7 @@ public static class AvaloniaBuilderExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="avaloniaBuilder"/> is null.</exception>
         public IAvaloniaBuilder ConfigureContext(Action<IAvaloniaContext> configureAction)
         {
-            if (avaloniaBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(avaloniaBuilder));
-            }
+            _ = avaloniaBuilder ?? throw new ArgumentNullException(nameof(avaloniaBuilder));
 
             avaloniaBuilder.ConfigureContextAction = configureAction;
             return avaloniaBuilder;
@@ -98,10 +86,7 @@ public static class AvaloniaBuilderExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="avaloniaBuilder"/> is null.</exception>
         public IAvaloniaBuilder ConfigureAppBuilder(Action<AppBuilder> configureAction)
         {
-            if (avaloniaBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(avaloniaBuilder));
-            }
+            _ = avaloniaBuilder ?? throw new ArgumentNullException(nameof(avaloniaBuilder));
 
             avaloniaBuilder.ConfigureAppBuilderAction = configureAction;
             return avaloniaBuilder;

--- a/src/Extensions.Hosting.Avalonia/Extensions/HostApplicationBuilderAvaloniaExtensions.cs
+++ b/src/Extensions.Hosting.Avalonia/Extensions/HostApplicationBuilderAvaloniaExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -22,15 +22,16 @@ public static class HostApplicationBuilderAvaloniaExtensions
         /// <remarks>This method integrates Avalonia's lifetime management into the host application, ensuring
         /// that the application shuts down according to the selected mode. Use this extension when building Avalonia
         /// applications with generic host support.</remarks>
-        /// <param name="shutdownMode">Specifies the shutdown behavior for the application. The default is <see
-        /// langword="ShutdownMode.OnLastWindowClose"/>.</param>
         /// <returns>The updated <see cref="IHostApplicationBuilder"/> instance, allowing for further configuration.</returns>
-        public IHostApplicationBuilder UseAvaloniaLifetime(ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
+        public IHostApplicationBuilder UseAvaloniaLifetime() =>
+            hostApplicationBuilder.UseAvaloniaLifetime(ShutdownMode.OnLastWindowClose);
+
+        /// <summary>Configures Avalonia lifetime management with the specified shutdown mode.</summary>
+        /// <param name="shutdownMode">Specifies the shutdown behavior for the application.</param>
+        /// <returns>The updated <see cref="IHostApplicationBuilder"/> instance, allowing for further configuration.</returns>
+        public IHostApplicationBuilder UseAvaloniaLifetime(ShutdownMode shutdownMode)
         {
-            if (hostApplicationBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostApplicationBuilder));
-            }
+            _ = hostApplicationBuilder ?? throw new ArgumentNullException(nameof(hostApplicationBuilder));
 
             return InternalBuilderAvaloniaUtility.UseAvaloniaLifetime(hostApplicationBuilder, shutdownMode);
         }
@@ -38,12 +39,14 @@ public static class HostApplicationBuilderAvaloniaExtensions
         /// <summary>Configures the Avalonia application builder for integration with the host application builder, optionally allowing further customization.</summary>
         /// <remarks>Use this method to enable Avalonia support in your application's host builder. The optional
         /// delegate allows you to modify Avalonia-specific settings before the application is built.</remarks>
-        /// <param name="configureDelegate">An optional delegate that provides additional customization for the Avalonia builder. If null, default
-        /// configuration is applied.</param>
         /// <returns>An instance of IHostApplicationBuilder that is configured to support Avalonia.</returns>
-        public IHostApplicationBuilder ConfigureAvalonia(Action<IAvaloniaBuilder>? configureDelegate = null)
-        {
-            return InternalBuilderAvaloniaUtility.ConfigureAvalonia(hostApplicationBuilder, configureDelegate);
-        }
+        public IHostApplicationBuilder ConfigureAvalonia() =>
+            hostApplicationBuilder.ConfigureAvalonia(null);
+
+        /// <summary>Configures Avalonia and applies the supplied customization.</summary>
+        /// <param name="configureDelegate">A delegate that provides additional customization for the Avalonia builder.</param>
+        /// <returns>An instance of IHostApplicationBuilder that is configured to support Avalonia.</returns>
+        public IHostApplicationBuilder ConfigureAvalonia(Action<IAvaloniaBuilder>? configureDelegate) =>
+            InternalBuilderAvaloniaUtility.ConfigureAvalonia(hostApplicationBuilder, configureDelegate);
     }
 }

--- a/src/Extensions.Hosting.Avalonia/Extensions/HostBuilderAvaloniaExtensions.cs
+++ b/src/Extensions.Hosting.Avalonia/Extensions/HostBuilderAvaloniaExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -21,15 +21,16 @@ public static class HostBuilderAvaloniaExtensions
         /// <remarks>This method integrates Avalonia's lifetime management with the host builder, ensuring that
         /// the application shuts down according to the selected shutdown mode. Use this extension when hosting Avalonia
         /// applications to control shutdown behavior.</remarks>
-        /// <param name="shutdownMode">Specifies the shutdown mode for the Avalonia application. The default is <see
-        /// cref="ShutdownMode.OnLastWindowClose"/>, which shuts down the application when the last window is closed.</param>
         /// <returns>The updated <see cref="IHostBuilder"/> instance, allowing for further configuration.</returns>
-        public IHostBuilder UseAvaloniaLifetime(ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
+        public IHostBuilder UseAvaloniaLifetime() =>
+            hostBuilder.UseAvaloniaLifetime(ShutdownMode.OnLastWindowClose);
+
+        /// <summary>Configures the host builder to use Avalonia lifetime management with a shutdown mode.</summary>
+        /// <param name="shutdownMode">Specifies the shutdown mode for the Avalonia application.</param>
+        /// <returns>The updated <see cref="IHostBuilder"/> instance, allowing for further configuration.</returns>
+        public IHostBuilder UseAvaloniaLifetime(ShutdownMode shutdownMode)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             return InternalBuilderAvaloniaUtility.UseAvaloniaLifetime(hostBuilder, shutdownMode);
         }
@@ -37,15 +38,16 @@ public static class HostBuilderAvaloniaExtensions
         /// <summary>Configures the Avalonia framework for the specified host builder, enabling integration and customization of Avalonia application settings before startup.</summary>
         /// <remarks>Use this method to set up Avalonia-specific configurations and options prior to application
         /// startup. This enables customization of the Avalonia environment within a generic host.</remarks>
-        /// <param name="configureDelegate">An optional delegate that allows further customization of the Avalonia builder. If provided, it is invoked to
-        /// configure Avalonia-specific options.</param>
         /// <returns>An instance of IHostBuilder that has been configured for Avalonia support.</returns>
-        public IHostBuilder ConfigureAvalonia(Action<IAvaloniaBuilder>? configureDelegate = null)
+        public IHostBuilder ConfigureAvalonia() =>
+            hostBuilder.ConfigureAvalonia(null);
+
+        /// <summary>Configures Avalonia and applies the supplied customization.</summary>
+        /// <param name="configureDelegate">A delegate that allows further customization of the Avalonia builder.</param>
+        /// <returns>An instance of IHostBuilder that has been configured for Avalonia support.</returns>
+        public IHostBuilder ConfigureAvalonia(Action<IAvaloniaBuilder>? configureDelegate)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             return InternalBuilderAvaloniaUtility.ConfigureAvalonia(hostBuilder, configureDelegate);
         }

--- a/src/Extensions.Hosting.Avalonia/Extensions/InternalBuilderAvaloniaUtility.cs
+++ b/src/Extensions.Hosting.Avalonia/Extensions/InternalBuilderAvaloniaUtility.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -31,17 +31,6 @@ internal static class InternalBuilderAvaloniaUtility
     internal static IHostBuilder UseAvaloniaLifetime(IHostBuilder hostBuilder, ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose) =>
         hostBuilder.ConfigureServices((hostBuilderContext, serviceCollection) => InnerUseAvaloniaLifetime(hostBuilder.Properties, shutdownMode));
 
-    /// <summary>Configures the Avalonia application by adding Avalonia services to the host builder and applying an optional configuration delegate.</summary>
-    /// <remarks>This method integrates Avalonia into the application's dependency injection system, enabling
-    /// Avalonia UI functionality within a generic host environment. Use the configuration delegate to customize
-    /// Avalonia-specific options as needed.</remarks>
-    /// <param name="hostBuilder">The host builder used to configure application services and properties. Cannot be null.</param>
-    /// <param name="configureDelegate">An optional delegate that allows further customization of the Avalonia builder during configuration. If
-    /// provided, it will be invoked to modify Avalonia-specific settings.</param>
-    /// <returns>An instance of IHostBuilder that has been configured to support Avalonia features and services.</returns>
-    internal static IHostBuilder ConfigureAvalonia(IHostBuilder hostBuilder, Action<IAvaloniaBuilder>? configureDelegate = null) =>
-        hostBuilder.ConfigureServices((hostBuilderContext, serviceCollection) => InnerConfigureAvalonia(hostBuilder.Properties, serviceCollection, configureDelegate));
-
     /// <summary>Configures Avalonia lifetime management for the application host, enabling proper shutdown behavior according to the specified shutdown mode.</summary>
     /// <remarks>This method integrates Avalonia's lifetime management into the application's host, ensuring
     /// that the application shuts down correctly based on the defined shutdown mode.</remarks>
@@ -55,6 +44,17 @@ internal static class InternalBuilderAvaloniaUtility
 
         return hostApplicationBuilder;
     }
+
+    /// <summary>Configures the Avalonia application by adding Avalonia services to the host builder and applying an optional configuration delegate.</summary>
+    /// <remarks>This method integrates Avalonia into the application's dependency injection system, enabling
+    /// Avalonia UI functionality within a generic host environment. Use the configuration delegate to customize
+    /// Avalonia-specific options as needed.</remarks>
+    /// <param name="hostBuilder">The host builder used to configure application services and properties. Cannot be null.</param>
+    /// <param name="configureDelegate">An optional delegate that allows further customization of the Avalonia builder during configuration. If
+    /// provided, it will be invoked to modify Avalonia-specific settings.</param>
+    /// <returns>An instance of IHostBuilder that has been configured to support Avalonia features and services.</returns>
+    internal static IHostBuilder ConfigureAvalonia(IHostBuilder hostBuilder, Action<IAvaloniaBuilder>? configureDelegate = null) =>
+        hostBuilder.ConfigureServices((hostBuilderContext, serviceCollection) => InnerConfigureAvalonia(hostBuilder.Properties, serviceCollection, configureDelegate));
 
     /// <summary>Configures the Avalonia application within the specified host application builder, optionally allowing further customization through a delegate.</summary>
     /// <remarks>This method sets up Avalonia integration for the host application builder and applies any

--- a/src/Extensions.Hosting.Avalonia/IAvaloniaBuilder.cs
+++ b/src/Extensions.Hosting.Avalonia/IAvaloniaBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -8,7 +8,7 @@ using Avalonia;
 
 namespace ReactiveMarbles.Extensions.Hosting.Avalonia;
 
-/// <summary>Provides a contract for configuring an Avalonia application, including application type, existing application instance, window types, and context and builder configuration actions.</summary>
+/// <summary>Provides a contract for configuring an Avalonia application, its windows, context, and application builder.</summary>
 /// <remarks>Implementations of this interface allow developers to set up the Avalonia application environment by
 /// specifying the application type, supplying an existing application instance, defining window types, and providing
 /// actions to configure both the Avalonia context and the AppBuilder. This enables flexible customization of the

--- a/src/Extensions.Hosting.Avalonia/IAvaloniaContext.cs
+++ b/src/Extensions.Hosting.Avalonia/IAvaloniaContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Avalonia;

--- a/src/Extensions.Hosting.Avalonia/IAvaloniaService.cs
+++ b/src/Extensions.Hosting.Avalonia/IAvaloniaService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Avalonia;

--- a/src/Extensions.Hosting.Avalonia/IAvaloniaShell.cs
+++ b/src/Extensions.Hosting.Avalonia/IAvaloniaShell.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Avalonia.Input;

--- a/src/Extensions.Hosting.Avalonia/Internals/AvaloniaBuilder.cs
+++ b/src/Extensions.Hosting.Avalonia/Internals/AvaloniaBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.Avalonia/Internals/AvaloniaContext.cs
+++ b/src/Extensions.Hosting.Avalonia/Internals/AvaloniaContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Avalonia;

--- a/src/Extensions.Hosting.Avalonia/Internals/AvaloniaThread.cs
+++ b/src/Extensions.Hosting.Avalonia/Internals/AvaloniaThread.cs
@@ -1,9 +1,9 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,33 +43,40 @@ public class AvaloniaThread(IServiceProvider serviceProvider, AppBuilder appBuil
                     avaloniaService.Initialize(UiContext.AvaloniaApplication);
                 }
 
-                var shellWindows = ServiceProvider.GetServices<IAvaloniaShell>().Cast<Window>().ToList();
+                var shellWindows = new List<Window>();
+                foreach (var shell in ServiceProvider.GetServices<IAvaloniaShell>())
+                {
+                    if (shell is Window window)
+                    {
+                        shellWindows.Add(window);
+                    }
+                }
 
                 switch (shellWindows.Count)
                 {
                     case 1:
-                    {
-                        lifetime.MainWindow = shellWindows[0];
-                        shellWindows[0].Show();
-                        break;
-                    }
-
-                    case 0:
-                    {
-                        break;
-                    }
-
-                    default:
-                    {
-                        lifetime.MainWindow = shellWindows[0];
-
-                        for (var i = 0; i < shellWindows.Count; i++)
                         {
-                            shellWindows[i]?.Show();
+                            lifetime.MainWindow = shellWindows[0];
+                            shellWindows[0].Show();
+                            break;
                         }
 
-                        break;
-                    }
+                    case 0:
+                        {
+                            break;
+                        }
+
+                    default:
+                        {
+                            lifetime.MainWindow = shellWindows[0];
+
+                            for (var i = 0; i < shellWindows.Count; i++)
+                            {
+                                shellWindows[i]?.Show();
+                            }
+
+                            break;
+                        }
                 }
 
                 UiContext.IsRunning = true;

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/HostBuilderEntityFrameworkCoreExtensions.cs
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/HostBuilderEntityFrameworkCoreExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.AspNetCore.Builder;
@@ -28,14 +28,24 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// from configuration.</remarks>
         /// <typeparam name="TContext">The type of the Entity Framework Core DbContext to use for data access.</typeparam>
         /// <param name="connectionStringName">The name of the connection string in the configuration. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
+        public IHostApplicationBuilder AddSqliteDbContext<TContext>(string connectionStringName)
+            where TContext : DbContext =>
+            builder.AddSqliteDbContext<TContext>(connectionStringName, ServiceLifetime.Scoped);
+
+        /// <summary>Configures Entity Framework Core with SQLite and an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IHostApplicationBuilder AddSqliteDbContext<TContext>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IHostApplicationBuilder AddSqliteDbContext<TContext>(
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -53,16 +63,30 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <typeparam name="TUser">The type representing application users for ASP.NET Core Identity.</typeparam>
         /// <typeparam name="TRole">The type representing application roles for ASP.NET Core Identity.</typeparam>
         /// <param name="connectionStringName">The name of the connection string in the configuration. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
+        public IHostApplicationBuilder AddSqliteWithIdentity<TContext, TUser, TRole>(string connectionStringName)
+            where TContext : DbContext
+            where TUser : class
+            where TRole : class =>
+            builder.AddSqliteWithIdentity<TContext, TUser, TRole>(connectionStringName, ServiceLifetime.Scoped);
+
+        /// <summary>Configures SQLite and Identity with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <typeparam name="TUser">The Identity user type.</typeparam>
+        /// <typeparam name="TRole">The Identity role type.</typeparam>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IHostApplicationBuilder AddSqliteWithIdentity<TContext, TUser, TRole>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IHostApplicationBuilder AddSqliteWithIdentity<TContext, TUser, TRole>(
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
             where TUser : class
             where TRole : class
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -83,15 +107,27 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <typeparam name="TContext">The type of the Entity Framework Core DbContext to use for data access.</typeparam>
         /// <typeparam name="TUser">The type representing application users for ASP.NET Core Identity.</typeparam>
         /// <param name="connectionStringName">The name of the connection string in the configuration. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
+        public IHostApplicationBuilder AddSqliteWithIdentity<TContext, TUser>(string connectionStringName)
+            where TContext : DbContext
+            where TUser : class =>
+            builder.AddSqliteWithIdentity<TContext, TUser>(connectionStringName, ServiceLifetime.Scoped);
+
+        /// <summary>Configures SQLite and user-only Identity with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <typeparam name="TUser">The Identity user type.</typeparam>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IHostApplicationBuilder AddSqliteWithIdentity<TContext, TUser>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IHostApplicationBuilder AddSqliteWithIdentity<TContext, TUser>(
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
             where TUser : class
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -116,16 +152,26 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// into generic host scenarios or for testing purposes.</remarks>
         /// <param name="configureServices">A delegate that configures the application's service collection. Invoked with the web host builder context and
         /// the service collection.</param>
-        /// <param name="validateScopes">true to enable scope validation for the service provider; otherwise, false. The default is false.</param>
         /// <returns>The same instance of the host builder for chaining further configuration.</returns>
-        public IHostBuilder UseWebHostServices(Action<WebHostBuilderContext, IServiceCollection> configureServices, bool validateScopes = false)
-        {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices) =>
+            hostBuilder.UseWebHostServices(configureServices, false);
 
+        /// <summary>Configures web host services and explicitly controls scope validation.</summary>
+        /// <param name="configureServices">The web host service configuration delegate.</param>
+        /// <param name="validateScopes">true to validate service scopes; otherwise, false.</param>
+        /// <returns>The same instance of the host builder for chaining further configuration.</returns>
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            bool validateScopes)
+        {
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
+
+            // Register a no-op pipeline so the web host creates an application service provider.
             return hostBuilder.ConfigureWebHostDefaults(webBuilder =>
-                          webBuilder.UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
-                             .Configure(app => app.Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
-                             .ConfigureServices((context, services) => configureServices(context, services)));
+                webBuilder.UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
+                    .Configure(static app => app.Run(static async (_) => await Task.CompletedTask))
+                    .ConfigureServices((context, services) => configureServices(context, services)));
         }
 
         /// <summary>Configures the host builder to use ASP.NET Core web host services with custom service and web host configuration.</summary>
@@ -136,18 +182,29 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// collection.</param>
         /// <param name="configureWebHost">A delegate that further configures the web host builder. Receives and returns an instance of <see
         /// cref="IWebHostBuilder"/>.</param>
-        /// <param name="validateScopes">A value indicating whether to validate service scopes when building the service provider. Set to <see
-        /// langword="true"/> to enable scope validation; otherwise, <see langword="false"/>. The default is <see
-        /// langword="false"/>.</param>
         /// <returns>The same <see cref="IHostBuilder"/> instance for chaining further configuration.</returns>
-        public IHostBuilder UseWebHostServices(Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, bool validateScopes = false)
-        {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            Func<IWebHostBuilder, IWebHostBuilder> configureWebHost) =>
+            hostBuilder.UseWebHostServices(configureServices, configureWebHost, false);
 
+        /// <summary>Configures web host services and the web host with explicit scope validation.</summary>
+        /// <param name="configureServices">The web host service configuration delegate.</param>
+        /// <param name="configureWebHost">The web host configuration delegate.</param>
+        /// <param name="validateScopes">true to validate service scopes; otherwise, false.</param>
+        /// <returns>The same <see cref="IHostBuilder"/> instance for chaining further configuration.</returns>
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            Func<IWebHostBuilder, IWebHostBuilder> configureWebHost,
+            bool validateScopes)
+        {
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
+
+            // Register a no-op pipeline so the web host creates an application service provider.
             return hostBuilder.ConfigureWebHostDefaults(webBuilder =>
                 configureWebHost(webBuilder)
                     .UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
-                    .Configure(app => app.Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
+                    .Configure(static app => app.Run(static async (_) => await Task.CompletedTask))
                     .ConfigureServices((context, services) => configureServices(context, services)));
         }
 
@@ -162,16 +219,32 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// configured builder.</param>
         /// <param name="configureApp">A delegate that configures the application's request pipeline. Receives the application builder and returns the
         /// configured builder.</param>
-        /// <param name="validateScopes">true to validate service scopes when building the service provider; otherwise, false. The default is false.</param>
         /// <returns>The same instance of the host builder for chaining further configuration.</returns>
-        public IHostBuilder UseWebHostServices(Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, Func<IApplicationBuilder, IApplicationBuilder> configureApp, bool validateScopes = false)
-        {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            Func<IWebHostBuilder, IWebHostBuilder> configureWebHost,
+            Func<IApplicationBuilder, IApplicationBuilder> configureApp) =>
+            hostBuilder.UseWebHostServices(configureServices, configureWebHost, configureApp, false);
 
+        /// <summary>Configures web services, web host, and application with explicit scope validation.</summary>
+        /// <param name="configureServices">The web host service configuration delegate.</param>
+        /// <param name="configureWebHost">The web host configuration delegate.</param>
+        /// <param name="configureApp">The application pipeline configuration delegate.</param>
+        /// <param name="validateScopes">true to validate service scopes; otherwise, false.</param>
+        /// <returns>The same instance of the host builder for chaining further configuration.</returns>
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            Func<IWebHostBuilder, IWebHostBuilder> configureWebHost,
+            Func<IApplicationBuilder, IApplicationBuilder> configureApp,
+            bool validateScopes)
+        {
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
+
+            // Register a no-op pipeline so the web host creates an application service provider.
             return hostBuilder.ConfigureWebHostDefaults(webBuilder =>
                 configureWebHost(webBuilder)
                     .UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
-                    .Configure(app => configureApp(app).Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
+                    .Configure(app => configureApp(app).Run(static async (_) => await Task.CompletedTask))
                     .ConfigureServices((context, services) => configureServices(context, services)));
         }
     }
@@ -191,17 +264,38 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <param name="context">The web host builder context containing configuration and environment information. Cannot be null.</param>
         /// <param name="connectionStringName">The name of the connection string in the configuration to use for the SQLite database. Cannot be null or
         /// whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. The default is Scoped.</param>
+        /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
+        public IServiceCollection UseEntityFrameworkCoreSqlite<TContext, TUser, TRole>(
+            WebHostBuilderContext context,
+            string connectionStringName)
+            where TContext : DbContext
+            where TUser : class
+            where TRole : class =>
+            services.UseEntityFrameworkCoreSqlite<TContext, TUser, TRole>(
+                context,
+                connectionStringName,
+                ServiceLifetime.Scoped);
+
+        /// <summary>Configures SQLite and Identity with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <typeparam name="TUser">The Identity user type.</typeparam>
+        /// <typeparam name="TRole">The Identity role type.</typeparam>
+        /// <param name="context">The web host builder context.</param>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IServiceCollection UseEntityFrameworkCoreSqlite<TContext, TUser, TRole>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IServiceCollection UseEntityFrameworkCoreSqlite<TContext, TUser, TRole>(
+            WebHostBuilderContext context,
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
             where TUser : class
             where TRole : class
         {
-            ArgumentNullException.ThrowIfNull(services);
-            ArgumentNullException.ThrowIfNull(context);
+            _ = services ?? throw new ArgumentNullException(nameof(services));
+            _ = context ?? throw new ArgumentNullException(nameof(context));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -225,16 +319,35 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <param name="context">The WebHostBuilderContext containing application configuration and environment information.</param>
         /// <param name="connectionStringName">The name of the connection string in the configuration to use for the SQLite database. Cannot be null or
         /// whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. The default is Scoped.</param>
+        /// <returns>The IServiceCollection instance configured for SQLite and Identity.</returns>
+        public IServiceCollection UseEntityFrameworkCoreSqlite<TContext, TUser>(
+            WebHostBuilderContext context,
+            string connectionStringName)
+            where TContext : DbContext
+            where TUser : class =>
+            services.UseEntityFrameworkCoreSqlite<TContext, TUser>(
+                context,
+                connectionStringName,
+                ServiceLifetime.Scoped);
+
+        /// <summary>Configures SQLite and user-only Identity with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <typeparam name="TUser">The Identity user type.</typeparam>
+        /// <param name="context">The web host builder context.</param>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The IServiceCollection instance with Entity Framework Core and Identity services configured for SQLite.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IServiceCollection UseEntityFrameworkCoreSqlite<TContext, TUser>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IServiceCollection UseEntityFrameworkCoreSqlite<TContext, TUser>(
+            WebHostBuilderContext context,
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
             where TUser : class
         {
-            ArgumentNullException.ThrowIfNull(services);
-            ArgumentNullException.ThrowIfNull(context);
+            _ = services ?? throw new ArgumentNullException(nameof(services));
+            _ = context ?? throw new ArgumentNullException(nameof(context));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -255,15 +368,32 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <typeparam name="TContext">The type of the Entity Framework Core DbContext to use for data access.</typeparam>
         /// <param name="configuration">The configuration instance containing the connection string. Cannot be null.</param>
         /// <param name="connectionStringName">The name of the connection string in the configuration. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
+        public IServiceCollection AddSqliteDbContext<TContext>(
+            IConfiguration configuration,
+            string connectionStringName)
+            where TContext : DbContext =>
+            services.AddSqliteDbContext<TContext>(
+                configuration,
+                connectionStringName,
+                ServiceLifetime.Scoped);
+
+        /// <summary>Configures a SQLite DbContext with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <param name="configuration">The application configuration.</param>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IServiceCollection AddSqliteDbContext<TContext>(IConfiguration configuration, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IServiceCollection AddSqliteDbContext<TContext>(
+            IConfiguration configuration,
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
         {
-            ArgumentNullException.ThrowIfNull(services);
-            ArgumentNullException.ThrowIfNull(configuration);
+            _ = services ?? throw new ArgumentNullException(nameof(services));
+            _ = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -280,13 +410,25 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// other sources such as environment variables or secret managers.</remarks>
         /// <typeparam name="TContext">The type of the Entity Framework Core DbContext to use for data access.</typeparam>
         /// <param name="connectionString">The SQLite connection string. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
+        public IServiceCollection AddSqliteDbContextWithConnectionString<TContext>(string connectionString)
+            where TContext : DbContext =>
+            services.AddSqliteDbContextWithConnectionString<TContext>(
+                connectionString,
+                ServiceLifetime.Scoped);
+
+        /// <summary>Configures a SQLite DbContext from a connection string with an explicit lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <param name="connectionString">The SQLite connection string.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionString is null or consists only of white-space characters.</exception>
-        public IServiceCollection AddSqliteDbContextWithConnectionString<TContext>(string connectionString, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IServiceCollection AddSqliteDbContextWithConnectionString<TContext>(
+            string connectionString,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
         {
-            ArgumentNullException.ThrowIfNull(services);
+            _ = services ?? throw new ArgumentNullException(nameof(services));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
@@ -301,14 +443,17 @@ public static class HostBuilderEntityFrameworkCoreExtensions
     /// <remarks>In-memory SQLite databases are useful for testing scenarios where you need a fast,
     /// isolated database that doesn't persist to disk. Note that in-memory databases only persist
     /// as long as the connection remains open.</remarks>
-    /// <param name="databaseName">Optional name for the in-memory database. If not provided, a shared in-memory database is used.</param>
     /// <returns>A SQLite connection string for an in-memory database.</returns>
-    public static string CreateInMemoryConnectionString(string? databaseName = null)
-    {
-        return string.IsNullOrWhiteSpace(databaseName)
+    public static string CreateInMemoryConnectionString() =>
+        CreateInMemoryConnectionString(null);
+
+    /// <summary>Creates a SQLite connection string for a named in-memory database.</summary>
+    /// <param name="databaseName">The in-memory database name, or null to use an isolated in-memory database.</param>
+    /// <returns>A SQLite connection string for an in-memory database.</returns>
+    public static string CreateInMemoryConnectionString(string? databaseName) =>
+        string.IsNullOrWhiteSpace(databaseName)
             ? "DataSource=:memory:"
             : $"DataSource={databaseName};Mode=Memory;Cache=Shared";
-    }
 
     /// <summary>Creates a SQLite connection string for a file-based database.</summary>
     /// <remarks>Use this helper to create properly formatted SQLite connection strings for

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore/HostBuilderEntityFrameworkCoreExtensions.cs
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore/HostBuilderEntityFrameworkCoreExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.AspNetCore.Builder;
@@ -27,7 +27,7 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <returns>True if the connection string exists and is not empty; otherwise, false.</returns>
         public bool HasConnectionString(string connectionStringName)
         {
-            ArgumentNullException.ThrowIfNull(configuration);
+            _ = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
             if (string.IsNullOrWhiteSpace(connectionStringName))
             {
@@ -44,14 +44,16 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <exception cref="InvalidOperationException">Thrown if the connection string is not found or is empty.</exception>
         public string GetRequiredConnectionString(string connectionStringName)
         {
-            ArgumentNullException.ThrowIfNull(configuration);
+            _ = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
             var connectionString = configuration.GetConnectionString(connectionStringName);
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new InvalidOperationException($"Connection string '{connectionStringName}' not found in configuration. Ensure it is defined in appsettings.json or environment variables under 'ConnectionStrings:{connectionStringName}'.");
+                throw new InvalidOperationException(
+                    $"Connection string '{connectionStringName}' not found in configuration. Ensure it is defined "
+                    + $"in appsettings.json or environment variables under 'ConnectionStrings:{connectionStringName}'.");
             }
 
             return connectionString;
@@ -68,14 +70,24 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// from configuration.</remarks>
         /// <typeparam name="TContext">The type of the Entity Framework Core DbContext to use for data access.</typeparam>
         /// <param name="connectionStringName">The name of the connection string in the configuration. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
+        public IHostApplicationBuilder AddSqlServerDbContext<TContext>(string connectionStringName)
+            where TContext : DbContext =>
+            builder.AddSqlServerDbContext<TContext>(connectionStringName, ServiceLifetime.Scoped);
+
+        /// <summary>Configures Entity Framework Core with SQL Server and an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IHostApplicationBuilder AddSqlServerDbContext<TContext>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IHostApplicationBuilder AddSqlServerDbContext<TContext>(
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -93,16 +105,30 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <typeparam name="TUser">The type representing application users for ASP.NET Core Identity.</typeparam>
         /// <typeparam name="TRole">The type representing application roles for ASP.NET Core Identity.</typeparam>
         /// <param name="connectionStringName">The name of the connection string in the configuration. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
+        public IHostApplicationBuilder AddSqlServerWithIdentity<TContext, TUser, TRole>(string connectionStringName)
+            where TContext : DbContext
+            where TUser : class
+            where TRole : class =>
+            builder.AddSqlServerWithIdentity<TContext, TUser, TRole>(connectionStringName, ServiceLifetime.Scoped);
+
+        /// <summary>Configures SQL Server and Identity with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <typeparam name="TUser">The Identity user type.</typeparam>
+        /// <typeparam name="TRole">The Identity role type.</typeparam>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IHostApplicationBuilder AddSqlServerWithIdentity<TContext, TUser, TRole>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IHostApplicationBuilder AddSqlServerWithIdentity<TContext, TUser, TRole>(
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
             where TUser : class
             where TRole : class
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -123,15 +149,27 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <typeparam name="TContext">The type of the Entity Framework Core DbContext to use for data access.</typeparam>
         /// <typeparam name="TUser">The type representing application users for ASP.NET Core Identity.</typeparam>
         /// <param name="connectionStringName">The name of the connection string in the configuration. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
+        public IHostApplicationBuilder AddSqlServerWithIdentity<TContext, TUser>(string connectionStringName)
+            where TContext : DbContext
+            where TUser : class =>
+            builder.AddSqlServerWithIdentity<TContext, TUser>(connectionStringName, ServiceLifetime.Scoped);
+
+        /// <summary>Configures SQL Server and user-only Identity with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <typeparam name="TUser">The Identity user type.</typeparam>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IHostApplicationBuilder instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IHostApplicationBuilder AddSqlServerWithIdentity<TContext, TUser>(string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IHostApplicationBuilder AddSqlServerWithIdentity<TContext, TUser>(
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
             where TUser : class
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -156,15 +194,25 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// registrations within a generic host setup.</remarks>
         /// <param name="configureServices">A delegate that configures services for the web host. Receives the web host builder context and the service
         /// collection to configure.</param>
-        /// <param name="validateScopes">true to validate service scopes when building the service provider; otherwise, false. The default is false.</param>
         /// <returns>The same instance of the host builder for chaining further configuration.</returns>
-        public IHostBuilder UseWebHostServices(Action<WebHostBuilderContext, IServiceCollection> configureServices, bool validateScopes = false)
-        {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices) =>
+            hostBuilder.UseWebHostServices(configureServices, false);
 
+        /// <summary>Configures web host services and explicitly controls scope validation.</summary>
+        /// <param name="configureServices">The web host service configuration delegate.</param>
+        /// <param name="validateScopes">true to validate service scopes; otherwise, false.</param>
+        /// <returns>The same instance of the host builder for chaining further configuration.</returns>
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            bool validateScopes)
+        {
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
+
+            // Register a no-op pipeline so the web host creates an application service provider.
             return hostBuilder.ConfigureWebHostDefaults(webBuilder =>
                 webBuilder.UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
-                    .Configure(app => app.Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
+                    .Configure(static app => app.Run(static async (_) => await Task.CompletedTask))
                     .ConfigureServices((context, services) => configureServices(context, services)));
         }
 
@@ -176,16 +224,29 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// collection.</param>
         /// <param name="configureWebHost">A delegate that configures the web host builder. Receives the current web host builder and returns the
         /// configured instance.</param>
-        /// <param name="validateScopes">true to enable scope validation for the default service provider; otherwise, false. The default is false.</param>
         /// <returns>The same IHostBuilder instance for chaining further configuration.</returns>
-        public IHostBuilder UseWebHostServices(Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, bool validateScopes = false)
-        {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            Func<IWebHostBuilder, IWebHostBuilder> configureWebHost) =>
+            hostBuilder.UseWebHostServices(configureServices, configureWebHost, false);
 
+        /// <summary>Configures web host services and the web host with explicit scope validation.</summary>
+        /// <param name="configureServices">The web host service configuration delegate.</param>
+        /// <param name="configureWebHost">The web host configuration delegate.</param>
+        /// <param name="validateScopes">true to validate service scopes; otherwise, false.</param>
+        /// <returns>The same IHostBuilder instance for chaining further configuration.</returns>
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            Func<IWebHostBuilder, IWebHostBuilder> configureWebHost,
+            bool validateScopes)
+        {
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
+
+            // Register a no-op pipeline so the web host creates an application service provider.
             return hostBuilder.ConfigureWebHostDefaults(webBuilder =>
                 configureWebHost(webBuilder)
                     .UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
-                    .Configure(app => app.Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
+                    .Configure(static app => app.Run(static async (_) => await Task.CompletedTask))
                     .ConfigureServices((context, services) => configureServices(context, services)));
         }
 
@@ -199,16 +260,32 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// configured builder.</param>
         /// <param name="configureApp">A delegate that configures the application builder. Receives the application builder and returns the configured
         /// builder.</param>
-        /// <param name="validateScopes">true to validate service scopes when building the service provider; otherwise, false. The default is false.</param>
         /// <returns>The same IHostBuilder instance for chaining further configuration.</returns>
-        public IHostBuilder UseWebHostServices(Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, Func<IApplicationBuilder, IApplicationBuilder> configureApp, bool validateScopes = false)
-        {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            Func<IWebHostBuilder, IWebHostBuilder> configureWebHost,
+            Func<IApplicationBuilder, IApplicationBuilder> configureApp) =>
+            hostBuilder.UseWebHostServices(configureServices, configureWebHost, configureApp, false);
 
+        /// <summary>Configures web services, web host, and application with explicit scope validation.</summary>
+        /// <param name="configureServices">The web host service configuration delegate.</param>
+        /// <param name="configureWebHost">The web host configuration delegate.</param>
+        /// <param name="configureApp">The application pipeline configuration delegate.</param>
+        /// <param name="validateScopes">true to validate service scopes; otherwise, false.</param>
+        /// <returns>The same IHostBuilder instance for chaining further configuration.</returns>
+        public IHostBuilder UseWebHostServices(
+            Action<WebHostBuilderContext, IServiceCollection> configureServices,
+            Func<IWebHostBuilder, IWebHostBuilder> configureWebHost,
+            Func<IApplicationBuilder, IApplicationBuilder> configureApp,
+            bool validateScopes)
+        {
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
+
+            // Register a no-op pipeline so the web host creates an application service provider.
             return hostBuilder.ConfigureWebHostDefaults(webBuilder =>
                 configureWebHost(webBuilder)
                     .UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
-                    .Configure(app => configureApp(app).Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
+                    .Configure(app => configureApp(app).Run(static async (_) => await Task.CompletedTask))
                     .ConfigureServices((context, services) => configureServices(context, services)));
         }
     }
@@ -217,7 +294,7 @@ public static class HostBuilderEntityFrameworkCoreExtensions
     /// <param name="services">The receiver instance.</param>
     extension(IServiceCollection services)
     {
-        /// <summary>Configures Entity Framework Core with SQL Server and ASP.NET Core Identity using the specified context, user, and role types, and registers the required services in the dependency injection container.</summary>
+        /// <summary>Configures SQL Server and ASP.NET Core Identity with the specified context, user, and role types.</summary>
         /// <remarks>This method sets up Entity Framework Core to use SQL Server as the database provider and
         /// configures ASP.NET Core Identity with the specified user and role types. It is typically called during
         /// application startup to register data access and identity services. The method also adds the Entity Framework
@@ -228,17 +305,38 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <param name="context">The web host builder context containing configuration and environment information. Cannot be null.</param>
         /// <param name="connectionStringName">The name of the connection string in the application's configuration to use for the SQL Server database. Cannot
         /// be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
+        public IServiceCollection UseEntityFrameworkCoreSqlServer<TContext, TUser, TRole>(
+            WebHostBuilderContext context,
+            string connectionStringName)
+            where TContext : DbContext
+            where TUser : class
+            where TRole : class =>
+            services.UseEntityFrameworkCoreSqlServer<TContext, TUser, TRole>(
+                context,
+                connectionStringName,
+                ServiceLifetime.Scoped);
+
+        /// <summary>Configures SQL Server and Identity with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <typeparam name="TUser">The Identity user type.</typeparam>
+        /// <typeparam name="TRole">The Identity role type.</typeparam>
+        /// <param name="context">The web host builder context.</param>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IServiceCollection UseEntityFrameworkCoreSqlServer<TContext, TUser, TRole>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IServiceCollection UseEntityFrameworkCoreSqlServer<TContext, TUser, TRole>(
+            WebHostBuilderContext context,
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
             where TUser : class
             where TRole : class
         {
-            ArgumentNullException.ThrowIfNull(services);
-            ArgumentNullException.ThrowIfNull(context);
+            _ = services ?? throw new ArgumentNullException(nameof(services));
+            _ = context ?? throw new ArgumentNullException(nameof(context));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -253,7 +351,7 @@ public static class HostBuilderEntityFrameworkCoreExtensions
             return services;
         }
 
-        /// <summary>Configures Entity Framework Core to use SQL Server with the specified DbContext and identity user types, and registers the necessary services for identity and data access.</summary>
+        /// <summary>Configures SQL Server with the specified DbContext and Identity user type.</summary>
         /// <remarks>This method adds the DbContext, ASP.NET Core Identity, and Entity Framework stores to the
         /// service collection, enabling authentication and data access using SQL Server. The connection string must be
         /// defined in the application's configuration under the provided name.</remarks>
@@ -262,16 +360,35 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <param name="context">The web host builder context containing configuration information. Cannot be null.</param>
         /// <param name="connectionStringName">The name of the connection string in the configuration to use for the SQL Server database. Cannot be null or
         /// whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. The default is Scoped.</param>
+        /// <returns>The IServiceCollection instance configured for SQL Server and Identity.</returns>
+        public IServiceCollection UseEntityFrameworkCoreSqlServer<TContext, TUser>(
+            WebHostBuilderContext context,
+            string connectionStringName)
+            where TContext : DbContext
+            where TUser : class =>
+            services.UseEntityFrameworkCoreSqlServer<TContext, TUser>(
+                context,
+                connectionStringName,
+                ServiceLifetime.Scoped);
+
+        /// <summary>Configures SQL Server and user-only Identity with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <typeparam name="TUser">The Identity user type.</typeparam>
+        /// <param name="context">The web host builder context.</param>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The IServiceCollection instance with Entity Framework Core and identity services configured for SQL Server.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IServiceCollection UseEntityFrameworkCoreSqlServer<TContext, TUser>(WebHostBuilderContext context, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IServiceCollection UseEntityFrameworkCoreSqlServer<TContext, TUser>(
+            WebHostBuilderContext context,
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
             where TUser : class
         {
-            ArgumentNullException.ThrowIfNull(services);
-            ArgumentNullException.ThrowIfNull(context);
+            _ = services ?? throw new ArgumentNullException(nameof(services));
+            _ = context ?? throw new ArgumentNullException(nameof(context));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -292,15 +409,32 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// <typeparam name="TContext">The type of the Entity Framework Core DbContext to use for data access.</typeparam>
         /// <param name="configuration">The configuration instance containing the connection string. Cannot be null.</param>
         /// <param name="connectionStringName">The name of the connection string in the configuration. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
+        public IServiceCollection AddSqlServerDbContext<TContext>(
+            IConfiguration configuration,
+            string connectionStringName)
+            where TContext : DbContext =>
+            services.AddSqlServerDbContext<TContext>(
+                configuration,
+                connectionStringName,
+                ServiceLifetime.Scoped);
+
+        /// <summary>Configures a SQL Server DbContext with an explicit service lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <param name="configuration">The application configuration.</param>
+        /// <param name="connectionStringName">The configured connection string name.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionStringName is null or consists only of white-space characters.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the specified connection string is not found in the configuration.</exception>
-        public IServiceCollection AddSqlServerDbContext<TContext>(IConfiguration configuration, string connectionStringName, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IServiceCollection AddSqlServerDbContext<TContext>(
+            IConfiguration configuration,
+            string connectionStringName,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
         {
-            ArgumentNullException.ThrowIfNull(services);
-            ArgumentNullException.ThrowIfNull(configuration);
+            _ = services ?? throw new ArgumentNullException(nameof(services));
+            _ = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
@@ -317,13 +451,25 @@ public static class HostBuilderEntityFrameworkCoreExtensions
         /// other sources such as environment variables or secret managers.</remarks>
         /// <typeparam name="TContext">The type of the Entity Framework Core DbContext to use for data access.</typeparam>
         /// <param name="connectionString">The SQL Server connection string. Cannot be null or whitespace.</param>
-        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service. Defaults to ServiceLifetime.Scoped.</param>
+        /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
+        public IServiceCollection AddSqlServerDbContextWithConnectionString<TContext>(string connectionString)
+            where TContext : DbContext =>
+            services.AddSqlServerDbContextWithConnectionString<TContext>(
+                connectionString,
+                ServiceLifetime.Scoped);
+
+        /// <summary>Configures a SQL Server DbContext from a connection string with an explicit lifetime.</summary>
+        /// <typeparam name="TContext">The Entity Framework Core DbContext type.</typeparam>
+        /// <param name="connectionString">The SQL Server connection string.</param>
+        /// <param name="serviceLifetime">The lifetime with which to register the DbContext service.</param>
         /// <returns>The same IServiceCollection instance so that additional calls can be chained.</returns>
         /// <exception cref="ArgumentException">Thrown if connectionString is null or consists only of white-space characters.</exception>
-        public IServiceCollection AddSqlServerDbContextWithConnectionString<TContext>(string connectionString, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+        public IServiceCollection AddSqlServerDbContextWithConnectionString<TContext>(
+            string connectionString,
+            ServiceLifetime serviceLifetime)
             where TContext : DbContext
         {
-            ArgumentNullException.ThrowIfNull(services);
+            _ = services ?? throw new ArgumentNullException(nameof(services));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 

--- a/src/Extensions.Hosting.MainUIThread/BaseUiContext.cs
+++ b/src/Extensions.Hosting.MainUIThread/BaseUiContext.cs
@@ -1,11 +1,11 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace ReactiveMarbles.Extensions.Hosting.UiThread;
 
 /// <inheritdoc />
-public abstract class BaseUiContext : IUiContext
+public class BaseUiContext : IUiContext
 {
     /// <inheritdoc />
     public bool IsLifetimeLinked { get; set; }

--- a/src/Extensions.Hosting.MainUIThread/BaseUiThread.cs
+++ b/src/Extensions.Hosting.MainUIThread/BaseUiThread.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace ReactiveMarbles.Extensions.Hosting.UiThread;
 
-/// <summary>Provides a base class for managing a UI thread and its associated context using dependency injection. Intended for use with UI frameworks that require operations to run on a dedicated thread.</summary>
+/// <summary>Provides a base class for managing a UI thread and its associated context using dependency injection.</summary>
 /// <remarks>This class is designed to be inherited by platform-specific UI thread implementations. It manages the
 /// lifecycle of a UI thread, including initialization, startup synchronization, and graceful shutdown. The class uses
 /// dependency injection to provide services and context to the UI thread. Derived classes must implement the <see
@@ -31,19 +31,26 @@ public abstract class BaseUiThread<T> : IDisposable
     /// <summary>Stores the disposed value.</summary>
     private bool _disposedValue;
 
-    /// <summary>Initializes a new instance of the <see cref="BaseUiThread{T}"/> class and starts a dedicated UI thread using the specified. service provider.</summary>
+    /// <summary>Initializes a new instance of the <see cref="BaseUiThread{T}"/> class using a dedicated UI thread.</summary>
+    /// <param name="serviceProvider">The service provider used to resolve required services for the UI thread. Cannot be null.</param>
+    protected BaseUiThread(IServiceProvider serviceProvider)
+        : this(serviceProvider, useDedicatedUiThread: true)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="BaseUiThread{T}"/> class.</summary>
     /// <remarks>The constructor creates and starts a new background thread to run the UI. On Windows
     /// platforms, the thread is set to single-threaded apartment (STA) state to support UI frameworks that require it.
     /// The provided service provider is used to resolve dependencies needed by the UI thread and is stored for later
     /// use.</remarks>
     /// <param name="serviceProvider">The service provider used to resolve required services for the UI thread. Cannot be null.</param>
-    /// <param name="useDedicatedUiThread">If set to <c>true</c>, a dedicated UI thread is created and started immediately; otherwise, UI initialization and startup run on the caller thread when <see cref="Start"/> is invoked.</param>
-    protected BaseUiThread(IServiceProvider serviceProvider, bool useDedicatedUiThread = true)
+    /// <param name="useDedicatedUiThread">
+    /// If set to <c>true</c>, a dedicated UI thread is created immediately; otherwise, UI startup runs on the caller
+    /// thread when <see cref="Start"/> is invoked.
+    /// </param>
+    protected BaseUiThread(IServiceProvider serviceProvider, bool useDedicatedUiThread)
     {
-        if (serviceProvider is null)
-        {
-            throw new ArgumentNullException(nameof(serviceProvider));
-        }
+        _ = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
 
         UiContext = serviceProvider.GetRequiredService<T>();
         _hostApplicationLifetime = serviceProvider.GetService<IHostApplicationLifetime>();
@@ -56,10 +63,7 @@ public abstract class BaseUiThread<T> : IDisposable
         }
 
         // Create a thread which runs the UI
-        var newUiThread = new Thread(InternalUiThreadStart)
-        {
-            IsBackground = true
-        };
+        var newUiThread = new Thread(InternalUiThreadStart) { IsBackground = true };
 
 #if NET5_0_OR_GREATER
         if (OperatingSystem.IsWindows())

--- a/src/Extensions.Hosting.MainUIThread/IUiContext.cs
+++ b/src/Extensions.Hosting.MainUIThread/IUiContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace ReactiveMarbles.Extensions.Hosting.UiThread;

--- a/src/Extensions.Hosting.Maui/HostBuilderMauiExtensions.cs
+++ b/src/Extensions.Hosting.Maui/HostBuilderMauiExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -42,25 +42,13 @@ public static class HostBuilderMauiExtensions
         return false;
     }
 
-    /// <summary>Uses the currently running MAUI application instance when it matches the configured application type.</summary>
-    /// <param name="mauiBuilder">The builder that contains application configuration.</param>
-    private static void CaptureCurrentMauiApplication(MauiBuilder mauiBuilder)
-    {
-        if (mauiBuilder.ApplicationType is null || mauiBuilder.Application is not null || Application.Current?.GetType() != mauiBuilder.ApplicationType)
-        {
-            return;
-        }
-
-        mauiBuilder.Application = Application.Current;
-    }
-
     /// <summary>Registers the core MAUI hosting services.</summary>
     /// <param name="services">The service collection to register services into.</param>
     /// <param name="mauiContext">The MAUI context instance to register.</param>
     private static void RegisterMauiHostingServices(IServiceCollection services, IMauiContext mauiContext) =>
         _ = services
             .AddSingleton(mauiContext)
-            .AddSingleton(serviceProvider => new MauiThread(serviceProvider))
+            .AddSingleton(static serviceProvider => new MauiThread(serviceProvider))
             .AddHostedService<MauiHostedService>();
 
     /// <summary>Registers a configured MAUI application type or instance.</summary>
@@ -128,7 +116,7 @@ public static class HostBuilderMauiExtensions
         /// <returns>The same instance of <see cref="IHostApplicationBuilder"/> for chaining further configuration.</returns>
         public IHostApplicationBuilder UseMauiLifetime()
         {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             _ = TryRetrieveMauiContext(hostBuilder.Properties, out var mauiContext);
             mauiContext.IsLifetimeLinked = true;
@@ -140,18 +128,22 @@ public static class HostBuilderMauiExtensions
         /// services and application types are registered with the dependency injection container. If an existing
         /// Application instance is available, it will be registered; otherwise, the Application type will be registered for
         /// instantiation by the container.</remarks>
-        /// <param name="configureDelegate">An optional delegate to further configure the MAUI builder before services are registered. If null, default
-        /// configuration is applied.</param>
+        /// <returns>The same host builder instance, configured with .NET MAUI services and application types.</returns>
+        public IHostApplicationBuilder ConfigureMaui() =>
+            hostBuilder.ConfigureMaui(null);
+
+        /// <summary>Configures .NET MAUI services and applies the supplied customization.</summary>
+        /// <param name="configureDelegate">A delegate to further configure the MAUI builder before services are registered.</param>
         /// <returns>The same host builder instance, configured with .NET MAUI services and application types.</returns>
         /// <exception cref="ArgumentException">Thrown if the registered Application type does not inherit from Microsoft.Maui.Controls.Application.</exception>
-        public IHostApplicationBuilder ConfigureMaui(Action<IMauiBuilder>? configureDelegate = null)
+        public IHostApplicationBuilder ConfigureMaui(Action<IMauiBuilder>? configureDelegate)
         {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             var mauiBuilder = new MauiBuilder();
             configureDelegate?.Invoke(mauiBuilder);
 
-            CaptureCurrentMauiApplication(mauiBuilder);
+            MauiApplicationCapture.Capture(mauiBuilder, Application.Current);
 
             if (!TryRetrieveMauiContext(hostBuilder.Properties, out var mauiContext))
             {
@@ -161,9 +153,6 @@ public static class HostBuilderMauiExtensions
             mauiBuilder.ConfigureContextAction?.Invoke(mauiContext);
             RegisterMauiApplication(hostBuilder.Services, mauiBuilder, nameof(configureDelegate));
             RegisterMauiPages(hostBuilder.Services, mauiBuilder);
-
-            var app = mauiBuilder.MauiAppBuilder.Build();
-            _ = hostBuilder.Services.AddSingleton(app);
 
             return hostBuilder;
         }
@@ -176,8 +165,8 @@ public static class HostBuilderMauiExtensions
         /// interface and derive from Page.</typeparam>
         /// <returns>The same IHostApplicationBuilder instance, enabling further configuration.</returns>
         public IHostApplicationBuilder ConfigureMauiShell<TShell>()
-            where TShell : Page, IMauiShell
-            => hostBuilder.ConfigureMaui(maui => maui.AddSingletonPage<TShell>());
+            where TShell : Page, IMauiShell =>
+            hostBuilder.ConfigureMaui(static maui => maui.AddSingletonPage<TShell>());
     }
 
     /// <summary>Provides extension members for this receiver.</summary>
@@ -202,20 +191,24 @@ public static class HostBuilderMauiExtensions
         /// injection and service registration for MAUI applications. This method should be called before building the host.
         /// If an application type is registered, it must inherit from <see
         /// cref="Microsoft.Maui.Controls.Application"/>.</remarks>
-        /// <param name="configureDelegate">An optional delegate to further configure the MAUI application, pages, and services before they are registered
-        /// with the host builder. May be null.</param>
+        /// <returns>The same instance of <see cref="IHostBuilder"/> with .NET MAUI services and configuration applied.</returns>
+        public IHostBuilder ConfigureMaui() =>
+            hostBuilder.ConfigureMaui(null);
+
+        /// <summary>Configures .NET MAUI and applies the supplied customization.</summary>
+        /// <param name="configureDelegate">A delegate to configure the MAUI application, pages, and services.</param>
         /// <returns>The same instance of <see cref="IHostBuilder"/> with .NET MAUI services and configuration applied. This enables
         /// further chaining of host builder configuration methods.</returns>
         /// <exception cref="ArgumentException">Thrown if the application type registered via <paramref name="configureDelegate"/> does not inherit from <see
         /// cref="Microsoft.Maui.Controls.Application"/>.</exception>
-        public IHostBuilder ConfigureMaui(Action<IMauiBuilder>? configureDelegate = null)
+        public IHostBuilder ConfigureMaui(Action<IMauiBuilder>? configureDelegate)
         {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             var mauiBuilder = new MauiBuilder();
             configureDelegate?.Invoke(mauiBuilder);
 
-            CaptureCurrentMauiApplication(mauiBuilder);
+            MauiApplicationCapture.Capture(mauiBuilder, Application.Current);
 
             _ = hostBuilder.ConfigureServices((context, serviceCollection) =>
             {
@@ -248,7 +241,7 @@ public static class HostBuilderMauiExtensions
         /// derive from Page.</typeparam>
         /// <returns>The configured host builder instance, or null if the input host builder is null.</returns>
         public IHostBuilder? ConfigureMauiShell<TShell>()
-            where TShell : Page, IMauiShell
-            => hostBuilder?.ConfigureMaui(maui => maui.AddSingletonPage<TShell>());
+            where TShell : Page, IMauiShell =>
+            hostBuilder?.ConfigureMaui(static maui => maui.AddSingletonPage<TShell>());
     }
 }

--- a/src/Extensions.Hosting.Maui/IMauiBuilder.cs
+++ b/src/Extensions.Hosting.Maui/IMauiBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.Maui/IMauiContext.cs
+++ b/src/Extensions.Hosting.Maui/IMauiContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Maui.Controls;

--- a/src/Extensions.Hosting.Maui/IMauiService.cs
+++ b/src/Extensions.Hosting.Maui/IMauiService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Maui.Controls;

--- a/src/Extensions.Hosting.Maui/IMauiShell.cs
+++ b/src/Extensions.Hosting.Maui/IMauiShell.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Maui;

--- a/src/Extensions.Hosting.Maui/Internals/IMauiApplicationStarter.cs
+++ b/src/Extensions.Hosting.Maui/Internals/IMauiApplicationStarter.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Maui.Controls;
+
+namespace ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+
+/// <summary>Creates a MAUI application and observes application exit.</summary>
+internal interface IMauiApplicationStarter
+{
+    /// <summary>Creates the MAUI application for the supplied service provider.</summary>
+    /// <param name="serviceProvider">The service provider used to resolve a registered MAUI application.</param>
+    /// <returns>The registered MAUI application, or a default application when none is registered.</returns>
+    Application Create(IServiceProvider serviceProvider);
+
+    /// <summary>Registers an action to run when the MAUI application exits.</summary>
+    /// <param name="mauiApplication">The MAUI application to observe.</param>
+    /// <param name="onApplicationExit">The action to run when the application exits.</param>
+    void RegisterApplicationExit(Application mauiApplication, Action onApplicationExit);
+}

--- a/src/Extensions.Hosting.Maui/Internals/IUiThreadStarter.cs
+++ b/src/Extensions.Hosting.Maui/Internals/IUiThreadStarter.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+
+/// <summary>Starts a platform UI thread.</summary>
+internal interface IUiThreadStarter
+{
+    /// <summary>Starts the UI thread.</summary>
+    void Start();
+}

--- a/src/Extensions.Hosting.Maui/Internals/MauiApplicationCapture.cs
+++ b/src/Extensions.Hosting.Maui/Internals/MauiApplicationCapture.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Maui.Controls;
+
+namespace ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+
+/// <summary>Selects a compatible current MAUI application for host registration.</summary>
+internal static class MauiApplicationCapture
+{
+    /// <summary>Uses the supplied MAUI application instance when it matches the configured application type.</summary>
+    /// <param name="mauiBuilder">The builder that contains application configuration.</param>
+    /// <param name="currentApplication">The current MAUI application, when one exists.</param>
+    internal static void Capture(MauiBuilder mauiBuilder, Application? currentApplication)
+    {
+        if (mauiBuilder.ApplicationType is null || mauiBuilder.Application is not null || currentApplication?.GetType() != mauiBuilder.ApplicationType)
+        {
+            return;
+        }
+
+        mauiBuilder.Application = currentApplication;
+    }
+}

--- a/src/Extensions.Hosting.Maui/Internals/MauiApplicationStarter.cs
+++ b/src/Extensions.Hosting.Maui/Internals/MauiApplicationStarter.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
+
+namespace ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+
+/// <summary>Provides the production MAUI application creation and exit-observation behavior.</summary>
+internal sealed class MauiApplicationStarter : IMauiApplicationStarter
+{
+    /// <inheritdoc />
+    public Application Create(IServiceProvider serviceProvider) =>
+        serviceProvider.GetService<Application>() ?? new Application();
+
+    /// <inheritdoc />
+    public void RegisterApplicationExit(Application mauiApplication, Action onApplicationExit) =>
+        RegisterApplicationExit(
+            handler => mauiApplication.ModalPopping += handler,
+            onApplicationExit);
+
+    /// <summary>Registers an application-exit callback through the supplied modal-pop subscription.</summary>
+    /// <param name="subscribe">The callback that subscribes the modal-pop event handler.</param>
+    /// <param name="onApplicationExit">The callback to invoke when the application exits.</param>
+    internal static void RegisterApplicationExit(
+        Action<EventHandler<ModalPoppingEventArgs>> subscribe,
+        Action onApplicationExit) =>
+        subscribe((sender, eventArgs) => onApplicationExit());
+}

--- a/src/Extensions.Hosting.Maui/Internals/MauiBuilder.cs
+++ b/src/Extensions.Hosting.Maui/Internals/MauiBuilder.cs
@@ -1,10 +1,11 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Hosting;
 
 namespace ReactiveMarbles.Extensions.Hosting.Maui.Internals;
@@ -12,6 +13,19 @@ namespace ReactiveMarbles.Extensions.Hosting.Maui.Internals;
 /// <inheritdoc/>
 internal sealed class MauiBuilder : IMauiBuilder
 {
+    /// <summary>Stores the action that applies MAUI application defaults to the underlying builder.</summary>
+    private readonly Action<MauiAppBuilder>? _configureMauiApplication;
+
+    /// <summary>Initializes a new instance of the <see cref="MauiBuilder"/> class.</summary>
+    internal MauiBuilder()
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="MauiBuilder"/> class with a composed MAUI application configurator.</summary>
+    /// <param name="configureMauiApplication">The action that applies MAUI application defaults to the underlying builder.</param>
+    internal MauiBuilder(Action<MauiAppBuilder>? configureMauiApplication) =>
+        _configureMauiApplication = configureMauiApplication;
+
     /// <inheritdoc/>
     public Type? ApplicationType { get; set; }
 
@@ -29,4 +43,19 @@ internal sealed class MauiBuilder : IMauiBuilder
     /// The maui application builder.
     /// </value>
     public MauiAppBuilder MauiAppBuilder { get; } = MauiApp.CreateBuilder();
+
+    /// <summary>Applies MAUI application defaults for the specified application type.</summary>
+    /// <typeparam name="TApplication">The application type to configure.</typeparam>
+    /// <returns>The underlying MAUI application builder.</returns>
+    internal MauiAppBuilder UseMauiApp<TApplication>()
+        where TApplication : Application
+    {
+        if (_configureMauiApplication is not null)
+        {
+            _configureMauiApplication(MauiAppBuilder);
+            return MauiAppBuilder;
+        }
+
+        return MauiAppBuilder.UseMauiApp<TApplication>();
+    }
 }

--- a/src/Extensions.Hosting.Maui/Internals/MauiContext.cs
+++ b/src/Extensions.Hosting.Maui/Internals/MauiContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Maui.Controls;

--- a/src/Extensions.Hosting.Maui/Internals/MauiThread.cs
+++ b/src/Extensions.Hosting.Maui/Internals/MauiThread.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -13,9 +13,28 @@ namespace ReactiveMarbles.Extensions.Hosting.Maui.Internals;
 /// <remarks>This class is typically used to host and manage a MAUI application's main UI thread in scenarios
 /// where integration with a custom host or dependency injection container is required. It ensures that the MAUI
 /// application and its services are properly initialized and managed on the correct thread.</remarks>
-/// <param name="serviceProvider">The service provider used to resolve application and service dependencies required by the MAUI UI thread.</param>
-public class MauiThread(IServiceProvider serviceProvider) : BaseUiThread<IMauiContext>(serviceProvider)
+public class MauiThread : BaseUiThread<IMauiContext>
 {
+    /// <summary>Stores the component that creates and observes the MAUI application.</summary>
+    private readonly IMauiApplicationStarter _mauiApplicationStarter;
+
+    /// <summary>Initializes a new instance of the <see cref="MauiThread"/> class.</summary>
+    /// <param name="serviceProvider">The service provider used to resolve application and service dependencies required by the MAUI UI thread.</param>
+    public MauiThread(IServiceProvider serviceProvider)
+        : this(serviceProvider, new MauiApplicationStarter(), useDedicatedUiThread: true)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="MauiThread"/> class with a composed MAUI application starter and thread mode.</summary>
+    /// <param name="serviceProvider">The service provider used to resolve application and service dependencies required by the MAUI UI thread.</param>
+    /// <param name="mauiApplicationStarter">The component that creates the MAUI application and observes its exit.</param>
+    /// <param name="useDedicatedUiThread">Whether to create a dedicated UI thread.</param>
+    internal MauiThread(IServiceProvider serviceProvider, IMauiApplicationStarter mauiApplicationStarter, bool useDedicatedUiThread)
+        : base(serviceProvider, useDedicatedUiThread)
+    {
+        _mauiApplicationStarter = mauiApplicationStarter ?? throw new ArgumentNullException(nameof(mauiApplicationStarter));
+    }
+
     /// <inheritdoc />
     protected override void PreUiThreadStart()
     {
@@ -27,10 +46,10 @@ public class MauiThread(IServiceProvider serviceProvider) : BaseUiThread<IMauiCo
         UiContext?.Dispatcher?.Dispatch(() =>
         {
             // Create the new MAUI application
-            var mauiApplication = ServiceProvider.GetService<Application>() ?? new Application();
+            var mauiApplication = _mauiApplicationStarter.Create(ServiceProvider);
 
             // Register to the MAUI application exit to stop the host application
-            mauiApplication.ModalPopping += (s, e) => HandleApplicationExit();
+            _mauiApplicationStarter.RegisterApplicationExit(mauiApplication, HandleApplicationExit);
 
             // Store the application for others to interact
             UiContext!.MauiApplication = mauiApplication;

--- a/src/Extensions.Hosting.Maui/Internals/MauiThreadStarter.cs
+++ b/src/Extensions.Hosting.Maui/Internals/MauiThreadStarter.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+
+/// <summary>Adapts a MAUI thread to the hosted-service startup seam.</summary>
+internal sealed class MauiThreadStarter : IUiThreadStarter
+{
+    /// <summary>Stores the action that starts the MAUI thread.</summary>
+    private readonly Action _start;
+
+    /// <summary>Initializes a new instance of the <see cref="MauiThreadStarter"/> class.</summary>
+    /// <param name="mauiThread">The MAUI thread to start.</param>
+    internal MauiThreadStarter(MauiThread mauiThread)
+        : this((mauiThread ?? throw new ArgumentNullException(nameof(mauiThread))).Start)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="MauiThreadStarter"/> class.</summary>
+    /// <param name="start">The action that starts the MAUI thread.</param>
+    internal MauiThreadStarter(Action start) =>
+        _start = start ?? throw new ArgumentNullException(nameof(start));
+
+    /// <inheritdoc />
+    public void Start() =>
+        _start();
+}

--- a/src/Extensions.Hosting.Maui/InternalsVisibleTo.cs
+++ b/src/Extensions.Hosting.Maui/InternalsVisibleTo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Extensions.Hosting.Maui.Platform.Tests")]
+[assembly: InternalsVisibleTo("Extensions.Hosting.ReactiveUI.Maui.Reactive.Platform.Tests")]

--- a/src/Extensions.Hosting.Maui/MauiBuilderExtensions.cs
+++ b/src/Extensions.Hosting.Maui/MauiBuilderExtensions.cs
@@ -1,11 +1,12 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Maui.Internals;
 
 namespace ReactiveMarbles.Extensions.Hosting.Maui;
 
@@ -34,16 +35,30 @@ public static class MauiBuilderExtensions
 
         /// <summary>Configures the Maui application to use the specified application type and applies optional additional configuration to the Maui app builder.</summary>
         /// <typeparam name="TApplication">The type of the application to use. Must derive from <see cref="Application"/>.</typeparam>
-        /// <param name="configureMauiApp">An optional delegate to further configure the <see cref="MauiAppBuilder"/> before building the application. If
-        /// null, no additional configuration is applied.</param>
         /// <returns>The same <see cref="IMauiBuilder"/> instance, configured to use the specified application type.</returns>
-        public IMauiBuilder UseMauiApp<TApplication>(Action<MauiAppBuilder>? configureMauiApp = null)
+        public IMauiBuilder UseMauiApp<TApplication>()
+            where TApplication : Application =>
+            mauiBuilder.UseMauiApp<TApplication>((Action<MauiAppBuilder>?)null);
+
+        /// <summary>Configures the MAUI application type and applies additional builder configuration.</summary>
+        /// <typeparam name="TApplication">The type of the application to use. Must derive from <see cref="Application"/>.</typeparam>
+        /// <param name="configureMauiApp">A delegate to further configure the <see cref="MauiAppBuilder"/>.</param>
+        /// <returns>The same <see cref="IMauiBuilder"/> instance, configured to use the specified application type.</returns>
+        public IMauiBuilder UseMauiApp<TApplication>(Action<MauiAppBuilder>? configureMauiApp)
             where TApplication : Application
         {
-            ArgumentNullException.ThrowIfNull(mauiBuilder);
+            _ = mauiBuilder ?? throw new ArgumentNullException(nameof(mauiBuilder));
 
             mauiBuilder.ApplicationType = typeof(TApplication);
-            _ = mauiBuilder.MauiAppBuilder.UseMauiApp<TApplication>();
+            if (mauiBuilder is MauiBuilder builder)
+            {
+                _ = builder.UseMauiApp<TApplication>();
+            }
+            else
+            {
+                _ = mauiBuilder.MauiAppBuilder.UseMauiApp<TApplication>();
+            }
+
             configureMauiApp?.Invoke(mauiBuilder.MauiAppBuilder);
             return mauiBuilder;
         }
@@ -51,16 +66,34 @@ public static class MauiBuilderExtensions
         /// <summary>Configures the Maui application to use the specified application instance and applies optional additional configuration to the Maui app builder.</summary>
         /// <typeparam name="TApplication">The type of the application to use. Must derive from Application.</typeparam>
         /// <param name="currentApplication">The application instance to use as the root of the Maui app. Cannot be null.</param>
-        /// <param name="configureMauiApp">An optional delegate to further configure the Maui app builder before building the application. May be null.</param>
         /// <returns>The same IMauiBuilder instance for chaining further configuration.</returns>
-        public IMauiBuilder UseMauiApp<TApplication>(TApplication currentApplication, Action<MauiAppBuilder>? configureMauiApp = null)
+        public IMauiBuilder UseMauiApp<TApplication>(TApplication currentApplication)
+            where TApplication : Application =>
+            mauiBuilder.UseMauiApp(currentApplication, null);
+
+        /// <summary>Configures the MAUI application instance and applies additional builder configuration.</summary>
+        /// <typeparam name="TApplication">The type of the application to use. Must derive from Application.</typeparam>
+        /// <param name="currentApplication">The application instance to use as the root of the MAUI app. Cannot be null.</param>
+        /// <param name="configureMauiApp">A delegate to further configure the Maui app builder.</param>
+        /// <returns>The same IMauiBuilder instance for chaining further configuration.</returns>
+        public IMauiBuilder UseMauiApp<TApplication>(
+            TApplication currentApplication,
+            Action<MauiAppBuilder>? configureMauiApp)
             where TApplication : Application
         {
-            ArgumentNullException.ThrowIfNull(mauiBuilder);
+            _ = mauiBuilder ?? throw new ArgumentNullException(nameof(mauiBuilder));
 
             mauiBuilder.ApplicationType = typeof(TApplication);
             mauiBuilder.Application = currentApplication;
-            _ = mauiBuilder.MauiAppBuilder.UseMauiApp<TApplication>();
+            if (mauiBuilder is MauiBuilder builder)
+            {
+                _ = builder.UseMauiApp<TApplication>();
+            }
+            else
+            {
+                _ = mauiBuilder.MauiAppBuilder.UseMauiApp<TApplication>();
+            }
+
             configureMauiApp?.Invoke(mauiBuilder.MauiAppBuilder);
             return mauiBuilder;
         }
@@ -74,7 +107,7 @@ public static class MauiBuilderExtensions
         /// <returns>The <see cref="IMauiBuilder"/> instance for chaining further configuration.</returns>
         public IMauiBuilder ConfigureContext(Action<IMauiContext> configureAction)
         {
-            ArgumentNullException.ThrowIfNull(mauiBuilder);
+            _ = mauiBuilder ?? throw new ArgumentNullException(nameof(mauiBuilder));
 
             mauiBuilder.ConfigureContextAction = configureAction;
             return mauiBuilder;

--- a/src/Extensions.Hosting.Maui/MauiHostedService.cs
+++ b/src/Extensions.Hosting.Maui/MauiHostedService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -15,14 +15,40 @@ namespace ReactiveMarbles.Extensions.Hosting.Maui;
 /// <remarks>This service enables integration of a MAUI application's startup and shutdown with the ASP.NET Core
 /// hosting model. It is typically used to coordinate application lifetime events between the MAUI UI thread and the
 /// host.</remarks>
-/// <param name="logger">The logger used to record diagnostic messages and operational events for the hosted service.</param>
-/// <param name="mauiThread">The thread responsible for running the MAUI application's UI loop.</param>
-/// <param name="mauiContext">The context that provides access to the MAUI application's services and dispatcher.</param>
-public class MauiHostedService(ILogger<MauiHostedService> logger, MauiThread mauiThread, IMauiContext mauiContext) : IHostedService
+public class MauiHostedService : IHostedService
 {
     /// <summary>Logs when the MAUI application is stopping.</summary>
     private static readonly Action<ILogger, Exception?> LogStoppingMaui =
-        LoggerMessage.Define(LogLevel.Debug, new EventId(1, nameof(LogStoppingMaui)), "Stopping MAUI due to application exit.");
+        LoggerMessage.Define(LogLevel.Debug, new(1, nameof(LogStoppingMaui)), "Stopping MAUI due to application exit.");
+
+    /// <summary>Stores the logger used to record lifecycle events.</summary>
+    private readonly ILogger<MauiHostedService> _logger;
+
+    /// <summary>Stores the MAUI UI-thread starter.</summary>
+    private readonly IUiThreadStarter _mauiThreadStarter;
+
+    /// <summary>Stores the context for the MAUI application.</summary>
+    private readonly IMauiContext _mauiContext;
+
+    /// <summary>Initializes a new instance of the <see cref="MauiHostedService"/> class.</summary>
+    /// <param name="logger">The logger used to record diagnostic messages and operational events for the hosted service.</param>
+    /// <param name="mauiThread">The thread responsible for running the MAUI application's UI loop.</param>
+    /// <param name="mauiContext">The context that provides access to the MAUI application's services and dispatcher.</param>
+    public MauiHostedService(ILogger<MauiHostedService> logger, MauiThread mauiThread, IMauiContext mauiContext)
+        : this(logger, new MauiThreadStarter(mauiThread), mauiContext)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="MauiHostedService"/> class with a composed UI-thread starter.</summary>
+    /// <param name="logger">The logger used to record diagnostic messages and operational events for the hosted service.</param>
+    /// <param name="mauiThreadStarter">The component that starts the MAUI UI thread.</param>
+    /// <param name="mauiContext">The context that provides access to the MAUI application's services and dispatcher.</param>
+    internal MauiHostedService(ILogger<MauiHostedService> logger, IUiThreadStarter mauiThreadStarter, IMauiContext mauiContext)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _mauiThreadStarter = mauiThreadStarter ?? throw new ArgumentNullException(nameof(mauiThreadStarter));
+        _mauiContext = mauiContext ?? throw new ArgumentNullException(nameof(mauiContext));
+    }
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
@@ -33,27 +59,34 @@ public class MauiHostedService(ILogger<MauiHostedService> logger, MauiThread mau
         }
 
         // Make the UI thread go
-        mauiThread.Start();
+        _mauiThreadStarter.Start();
         return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        if (!mauiContext.IsRunning)
+        if (!_mauiContext.IsRunning)
         {
             return;
         }
 
-        LogStoppingMaui(logger, null);
+        cancellationToken.ThrowIfCancellationRequested();
+        LogStoppingMaui(_logger, null);
 
         // Stop application
-        var completion = new TaskCompletionSource();
-        _ = mauiContext.Dispatcher?.Dispatch(() =>
+        var dispatcher = _mauiContext.Dispatcher
+            ?? throw new InvalidOperationException("The MAUI dispatcher is unavailable.");
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!dispatcher.Dispatch(() =>
         {
-            mauiContext.MauiApplication?.Quit();
+            _mauiContext.MauiApplication?.Quit();
             completion.SetResult();
-        });
-        await completion.Task;
+        }))
+        {
+            throw new InvalidOperationException("The MAUI dispatcher rejected the application shutdown request.");
+        }
+
+        await completion.Task.WaitAsync(cancellationToken);
     }
 }

--- a/src/Extensions.Hosting.PluginService/DefaultLogger.cs
+++ b/src/Extensions.Hosting.PluginService/DefaultLogger.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Logging;

--- a/src/Extensions.Hosting.PluginService/IServiceHostRuntime.cs
+++ b/src/Extensions.Hosting.PluginService/IServiceHostRuntime.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ServiceProcess;
+using Microsoft.Extensions.Hosting;
+
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+#else
+namespace ReactiveMarbles.Extensions.Hosting.PluginService;
+#endif
+
+/// <summary>Provides the operating-system interactions required to run a hosted Windows service.</summary>
+internal interface IServiceHostRuntime
+{
+    /// <summary>Runs a host for the supplied cancellation token.</summary>
+    /// <param name="host">The host to run.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that completes when the host stops.</returns>
+    Task RunAsync(IHost host, CancellationToken cancellationToken);
+
+    /// <summary>Runs a Windows service through the service control manager.</summary>
+    /// <param name="service">The service to run.</param>
+    void RunService(ServiceBase service);
+
+    /// <summary>Requests that a Windows service stops.</summary>
+    /// <param name="service">The service to stop.</param>
+    void StopService(ServiceBase service);
+}

--- a/src/Extensions.Hosting.PluginService/Properties/AssemblyInfo.cs
+++ b/src/Extensions.Hosting.PluginService/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Extensions.Hosting.PluginService.Platform.Tests")]
+[assembly: InternalsVisibleTo("Extensions.Hosting.PluginService.Reactive.Platform.Tests")]

--- a/src/Extensions.Hosting.PluginService/ServiceBaseLifetime.cs
+++ b/src/Extensions.Hosting.PluginService/ServiceBaseLifetime.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.ServiceProcess;
@@ -14,28 +14,46 @@ namespace ReactiveMarbles.Extensions.Hosting.PluginService;
 /// <summary>Provides an <see cref="IHostLifetime"/> implementation backed by <see cref="ServiceBase"/>.</summary>
 /// <seealso cref="ServiceBase" />
 /// <seealso cref="IHostLifetime" />
-/// <remarks>
-/// Initializes a new instance of the <see cref="ServiceBaseLifetime"/> class.
-/// </remarks>
-/// <param name="applicationLifetime">The application lifetime.</param>
-/// <exception cref="ArgumentNullException">applicationLifetime.</exception>
-public class ServiceBaseLifetime(IHostApplicationLifetime applicationLifetime) : ServiceBase, IHostLifetime
+public class ServiceBaseLifetime : ServiceBase, IHostLifetime
 {
     /// <summary>Stores the delay start value.</summary>
-    private readonly TaskCompletionSource<object> _delayStart = new();
+    private readonly TaskCompletionSource<object> _delayStart = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Stores the operating-system service runtime.</summary>
+    private readonly IServiceHostRuntime _runtime;
+
+    /// <summary>Initializes a new instance of the <see cref="ServiceBaseLifetime"/> class.</summary>
+    /// <param name="applicationLifetime">The application lifetime.</param>
+    public ServiceBaseLifetime(IHostApplicationLifetime applicationLifetime)
+        : this(applicationLifetime, ServiceHost.Runtime)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ServiceBaseLifetime"/> class with a service runtime.</summary>
+    /// <param name="applicationLifetime">The application lifetime.</param>
+    /// <param name="runtime">The operating-system service runtime.</param>
+    internal ServiceBaseLifetime(IHostApplicationLifetime applicationLifetime, IServiceHostRuntime runtime)
+    {
+        ApplicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+    }
 
     /// <summary>Gets the host application lifetime used to stop the application from service callbacks.</summary>
-    private IHostApplicationLifetime ApplicationLifetime { get; } = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
+    private IHostApplicationLifetime ApplicationLifetime { get; }
 
-    /// <summary>Called at the start of <see cref="IHost.StartAsync(CancellationToken)" /> which will wait until it's complete before continuing. This can be used to delay startup until signaled by an external event.</summary>
+    /// <summary>Called at the start of <see cref="IHost.StartAsync(CancellationToken)" /> and waits until startup is signaled by an external event.</summary>
     /// <param name="cancellationToken">Used to indicate when stop should no longer be graceful.</param>
     /// <returns>
     /// A <see cref="Task" />.
     /// </returns>
     public Task WaitForStartAsync(CancellationToken cancellationToken)
     {
-        _ = cancellationToken.Register(() => _delayStart.TrySetCanceled());
-        _ = ApplicationLifetime.ApplicationStopping.Register(Stop);
+        _ = cancellationToken.Register(
+            static state => _ = ((TaskCompletionSource<object>)state!).TrySetCanceled(),
+            _delayStart);
+        _ = ApplicationLifetime.ApplicationStopping.Register(
+            static state => ((ServiceBaseLifetime)state!).StopService(),
+            this);
 
         new Thread(Run).Start(); // Otherwise this would block and prevent IHost.StartAsync from finishing.
         return _delayStart.Task;
@@ -48,12 +66,13 @@ public class ServiceBaseLifetime(IHostApplicationLifetime applicationLifetime) :
     /// </returns>
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        Stop();
+        StopService();
         return Task.CompletedTask;
     }
 
     /// <summary>
-    /// When implemented in a derived class, executes when a Start command is sent to the service by the Service Control Manager (SCM) or when the operating system starts (for a service that starts automatically). Specifies actions to take when the service starts.
+    /// When implemented in a derived class, executes when a Start command is sent to the service by the Service Control
+    /// Manager or when the operating system starts. Specifies actions to take when the service starts.
     /// </summary>
     /// <param name="args">Data passed by the start command.</param>
     protected override void OnStart(string[] args)
@@ -74,7 +93,7 @@ public class ServiceBaseLifetime(IHostApplicationLifetime applicationLifetime) :
     {
         try
         {
-            Run(this); // This blocks until the service is stopped.
+            _runtime.RunService(this); // This blocks until the service is stopped.
             _ = _delayStart.TrySetException(new InvalidOperationException("Stopped without starting"));
         }
         catch (Exception ex)
@@ -82,4 +101,7 @@ public class ServiceBaseLifetime(IHostApplicationLifetime applicationLifetime) :
             _ = _delayStart.TrySetException(ex);
         }
     }
+
+    /// <summary>Requests that the configured runtime stops this service.</summary>
+    private void StopService() => _runtime.StopService(this);
 }

--- a/src/Extensions.Hosting.PluginService/ServiceBaseLifetimeHostExtensions.cs
+++ b/src/Extensions.Hosting.PluginService/ServiceBaseLifetimeHostExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +22,10 @@ public static class ServiceBaseLifetimeHostExtensions
     /// <param name="hostBuilder">The receiver instance.</param>
     extension(HostApplicationBuilder hostBuilder)
     {
+        /// <summary>Runs the application as a Windows service without cancellation.</summary>
+        /// <returns>A task that represents the service lifetime.</returns>
+        public Task RunAsServiceAsync() => hostBuilder.RunAsServiceAsync(CancellationToken.None);
+
         /// <summary>Runs the application as a Windows service using the specified host builder.</summary>
         /// <remarks>This method configures the application to use Windows service lifetime management. It should
         /// be called when running the application as a Windows service. If called in a non-Windows environment, the
@@ -29,10 +33,10 @@ public static class ServiceBaseLifetimeHostExtensions
         /// <param name="cancellationToken">A cancellation token that can be used to request cancellation of the service run operation. The default value is
         /// <see cref="CancellationToken.None"/>.</param>
         /// <returns>A task that represents the lifetime of the running service. The task completes when the service stops.</returns>
-        public Task RunAsServiceAsync(CancellationToken cancellationToken = default)
+        public Task RunAsServiceAsync(CancellationToken cancellationToken)
         {
             _ = UseServiceBaseLifetime((IHostApplicationBuilder)hostBuilder);
-            return hostBuilder.Build().RunAsync(cancellationToken);
+            return ServiceHost.RunAsync(hostBuilder.Build(), cancellationToken);
         }
     }
 
@@ -48,10 +52,7 @@ public static class ServiceBaseLifetimeHostExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         public IHostApplicationBuilder UseServiceBaseLifetime()
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             _ = hostBuilder.Services.AddSingleton<IHostLifetime, ServiceBaseLifetime>();
             return hostBuilder;
@@ -65,10 +66,7 @@ public static class ServiceBaseLifetimeHostExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         public IHostApplicationBuilder UseConsoleLifetime()
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             _ = hostBuilder.Services.AddSingleton<IHostLifetime, ConsoleLifetime>();
             return hostBuilder;
@@ -86,15 +84,16 @@ public static class ServiceBaseLifetimeHostExtensions
         /// <returns>The same instance of <see cref="IHostBuilder"/> for chaining, or <see langword="null"/> if <paramref
         /// name="hostBuilder"/> is null.</returns>
         public IHostBuilder? UseServiceBaseLifetime() =>
-            hostBuilder?.ConfigureServices(services => _ = services.AddSingleton<IHostLifetime, ServiceBaseLifetime>());
+            hostBuilder?.ConfigureServices(static services => _ = services.AddSingleton<IHostLifetime, ServiceBaseLifetime>());
 
-        /// <summary>Runs the host as a Windows service or systemd service, enabling integration with the operating system's service management.</summary>
-        /// <remarks>This method configures the host to run as a background service using the appropriate service
-        /// infrastructure for the current platform (Windows service or systemd on Linux). It should be called instead of
-        /// RunAsync when deploying as a service.</remarks>
-        /// <param name="cancellationToken">A cancellation token that can be used to request cancellation of the service run operation.</param>
-        /// <returns>A task that represents the lifetime of the service. The task completes when the service stops.</returns>
-        public Task RunAsServiceAsync(CancellationToken cancellationToken = default) =>
-            hostBuilder.UseServiceBaseLifetime()!.Build().RunAsync(cancellationToken);
+        /// <summary>Runs the host as a Windows service without cancellation.</summary>
+        /// <returns>A task that represents the service lifetime.</returns>
+        public Task RunAsServiceAsync() => hostBuilder.RunAsServiceAsync(CancellationToken.None);
+
+        /// <summary>Runs the host as a Windows service using the specified cancellation token.</summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task that represents the service lifetime.</returns>
+        public Task RunAsServiceAsync(CancellationToken cancellationToken) =>
+            ServiceHost.RunAsync(hostBuilder.UseServiceBaseLifetime()!.Build(), cancellationToken);
     }
 }

--- a/src/Extensions.Hosting.PluginService/ServiceHost.cs
+++ b/src/Extensions.Hosting.PluginService/ServiceHost.cs
@@ -1,18 +1,10 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-#if REACTIVE_SHIM
-using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
-#else
-using ReactiveMarbles.Extensions.Hosting.Plugins;
-#endif
-using ReactiveMarbles.Extensions.Logging;
 
 #if REACTIVE_SHIM
 namespace ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
@@ -21,19 +13,10 @@ namespace ReactiveMarbles.Extensions.Hosting.PluginService;
 #endif
 
 /// <summary>Provides static methods for configuring and running a host or application host with plugin and logging support.</summary>
-/// <remarks>The ServiceHost class simplifies the setup of .NET hosts, including configuration, logging, and
-/// plugin loading. It is intended for use in applications that require dynamic plugin discovery and flexible host
-/// configuration. All members are thread-safe for typical usage scenarios.</remarks>
 public static class ServiceHost
 {
-    /// <summary>Stores the app settings file prefix value.</summary>
-    private const string AppSettingsFilePrefix = "appsettings";
-
-    /// <summary>Stores the host settings file value.</summary>
-    private const string HostSettingsFile = "hostsettings.json";
-
-    /// <summary>Stores the prefix value.</summary>
-    private const string Prefix = "PREFIX_";
+    /// <summary>Stores the runtime used to interact with the host and service control manager.</summary>
+    private static IServiceHostRuntime _runtime = new ServiceHostRuntime();
 
     /// <summary>Stores the logger value.</summary>
     private static DefaultLogger? _logger;
@@ -41,291 +24,72 @@ public static class ServiceHost
     /// <summary>Gets the current logger instance used for application logging.</summary>
     public static ILogger? Logger => _logger?.Logger;
 
-    /// <summary>Creates and runs a host for the specified plugin type, configuring logging, services, and plugin discovery according to the provided parameters.</summary>
-    /// <remarks>This method sets up a .NET host with default configuration, logging, and plugin scanning
-    /// based on the specified parameters. It supports both service and console lifetimes, automatically selecting the
-    /// appropriate mode based on the execution context and command-line arguments. Plugins are discovered using the
-    /// provided namespace and runtime information. Additional host or host builder configuration can be supplied via
-    /// the optional delegates.</remarks>
-    /// <param name="type">The type representing the plugin to host. Cannot be null.</param>
-    /// <param name="args">The command-line arguments to use for host configuration and plugin startup.</param>
-    /// <param name="hostBuilder">An optional delegate to further configure the <see cref="IHostBuilder"/> before building the host. If null, no
-    /// additional configuration is applied.</param>
-    /// <param name="configureHost">An optional action to perform additional configuration on the built <see cref="IHost"/> before it is run. If
-    /// null, no additional configuration is performed.</param>
-    /// <param name="nameSpace">The namespace pattern used to locate plugin assemblies. Defaults to "ReactiveMarbles.Plugin".</param>
-    /// <param name="targetRuntime">The target runtime identifier used to determine the plugin directory. If null, the runtime is inferred from the
-    /// plugin assembly location.</param>
-    /// <returns>A task that represents the asynchronous operation of running the configured host.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="type"/> is null.</exception>
-    public static Task Create(
-        Type type,
-        string[] args,
-        Func<IHostBuilder?, IHostBuilder?>? hostBuilder = default,
-        Action<IHost>? configureHost = default,
-        string nameSpace = "ReactiveMarbles.Plugin",
-        string? targetRuntime = null)
-    {
-        if (type is null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
+    /// <summary>Gets the runtime used to interact with the host and service control manager.</summary>
+    internal static IServiceHostRuntime Runtime => Volatile.Read(ref _runtime);
 
-        var executableLocation = Path.GetDirectoryName(type.Assembly.Location);
-        var isService = IsServiceMode(args);
-        if (isService)
-        {
-            SetCurrentDirectoryToProcessRoot();
-        }
+    /// <summary>Creates and runs a host for the specified plugin type using the default host configuration.</summary>
+    /// <param name="type">The type representing the plugin to host.</param>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns>A task that represents the host lifetime.</returns>
+    public static Task Create(Type type, string[] args) =>
+        new ServiceHostRunner(Runtime).Create(type, args, null, null, "ReactiveMarbles.Plugin", null);
 
-        var builder = Host.CreateDefaultBuilder()
-            .UseContentRoot(Directory.GetCurrentDirectory());
+    /// <summary>Creates and runs a host for the specified plugin type with the supplied configuration.</summary>
+    /// <param name="type">The type representing the plugin to host.</param>
+    /// <param name="args">The command-line arguments.</param>
+    /// <param name="hostBuilder">An optional host-builder configuration callback.</param>
+    /// <param name="configureHost">An optional built-host configuration callback.</param>
+    /// <param name="nameSpace">The namespace pattern used to locate plugin assemblies.</param>
+    /// <param name="targetRuntime">The target runtime identifier.</param>
+    /// <returns>A task that represents the host lifetime.</returns>
+    public static Task Create(Type type, string[] args, Func<IHostBuilder?, IHostBuilder?>? hostBuilder, Action<IHost>? configureHost, string nameSpace, string? targetRuntime) =>
+        new ServiceHostRunner(Runtime).Create(type, args, hostBuilder, configureHost, nameSpace, targetRuntime);
 
-        builder = ConfigureLogging(builder)!;
-        builder = ConfigureExternal(builder, hostBuilder)!;
-        builder = ConfigureConfiguration(builder, args)!;
-        builder = builder
-            .ConfigurePlugins(pluginBuilder => ConfigurePluginScanning(pluginBuilder, executableLocation, targetRuntime, nameSpace))!
-            .ConfigureServices(serviceCollection => _ = serviceCollection.AddTransient<DefaultLogger>());
+    /// <summary>Creates and runs an application host using the default host configuration.</summary>
+    /// <param name="type">The application entry type.</param>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns>A task that represents the application lifetime.</returns>
+    public static Task CreateApplication(Type type, string[] args) =>
+        new ServiceHostRunner(Runtime).CreateApplication(type, args, null, null, "ReactiveMarbles.Plugin", null);
 
-        ConfigureLifetime(builder, isService);
-
-        var host = builder.Build();
-        _logger = host.Services.GetRequiredService<DefaultLogger>();
-        configureHost?.Invoke(host);
-
-        return host.RunAsync(CancellationToken.None);
-    }
-
-    /// <summary>Initializes and runs a plugin-based .NET application using the specified entry type, command-line arguments, and optional host configuration.</summary>
-    /// <remarks>This method configures the application host, logging, plugin discovery, and lifetime
-    /// management based on the provided parameters. It supports both console and Windows service modes, automatically
-    /// selecting the appropriate lifetime based on the execution context and command-line arguments. Plugins are loaded
-    /// from directories determined by the specified or inferred runtime and namespace. Use the optional delegates to
-    /// customize host building and post-build configuration as needed.</remarks>
-    /// <param name="type">The entry point type for the application. This type's assembly is used to determine the application location and
-    /// plugin scanning context. Cannot be null.</param>
-    /// <param name="args">The command-line arguments to pass to the application. Used for configuration and to determine the application
-    /// mode (console or service).</param>
-    /// <param name="hostBuilder">An optional delegate to further configure the <see cref="IHostApplicationBuilder"/> before building the host. If
-    /// null, no additional configuration is applied.</param>
-    /// <param name="configureHost">An optional action to configure the <see cref="IHost"/> after it is built but before it is run. If null, no
-    /// additional configuration is performed.</param>
-    /// <param name="nameSpace">The namespace pattern used to locate and include plugin assemblies. Defaults to "ReactiveMarbles.Plugin".</param>
-    /// <param name="targetRuntime">The target runtime identifier used to determine the plugin directory. If null, the runtime is inferred from the
-    /// entry assembly location.</param>
-    /// <returns>A task that represents the asynchronous operation of running the application. The task completes when the
-    /// application shuts down.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="type"/> is null.</exception>
+    /// <summary>Creates and runs an application host with the supplied configuration.</summary>
+    /// <param name="type">The application entry type.</param>
+    /// <param name="args">The command-line arguments.</param>
+    /// <param name="hostBuilder">An optional application-host-builder configuration callback.</param>
+    /// <param name="configureHost">An optional built-host configuration callback.</param>
+    /// <param name="nameSpace">The namespace pattern used to locate plugin assemblies.</param>
+    /// <param name="targetRuntime">The target runtime identifier.</param>
+    /// <returns>A task that represents the host lifetime.</returns>
     public static Task CreateApplication(
         Type type,
         string[] args,
-        Func<IHostApplicationBuilder?, IHostApplicationBuilder?>? hostBuilder = default,
-        Action<IHost>? configureHost = default,
-        string nameSpace = "ReactiveMarbles.Plugin",
-        string? targetRuntime = null)
+        Func<IHostApplicationBuilder?, IHostApplicationBuilder?>? hostBuilder,
+        Action<IHost>? configureHost,
+        string nameSpace,
+        string? targetRuntime) =>
+        new ServiceHostRunner(Runtime).CreateApplication(type, args, hostBuilder, configureHost, nameSpace, targetRuntime);
+
+    /// <summary>Runs a built host through the configured runtime.</summary>
+    /// <param name="host">The host to run.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that completes when the host stops.</returns>
+    internal static Task RunAsync(IHost host, CancellationToken cancellationToken) => Runtime.RunAsync(host, cancellationToken);
+
+    /// <summary>Sets the current default logger.</summary>
+    /// <param name="logger">The logger to retain.</param>
+    internal static void SetLogger(DefaultLogger logger) => _logger = logger;
+
+    /// <summary>Temporarily replaces the operating-system runtime.</summary>
+    /// <param name="runtime">The runtime to use while the returned scope is active.</param>
+    /// <returns>A scope that restores the previous runtime when disposed.</returns>
+    internal static IDisposable UseRuntime(IServiceHostRuntime runtime) =>
+        new RuntimeScope(Interlocked.Exchange(ref _runtime, runtime ?? throw new ArgumentNullException(nameof(runtime))));
+
+    /// <summary>Restores the runtime that was active before a test scope.</summary>
+    /// <param name="previousRuntime">The runtime to restore.</param>
+    private sealed class RuntimeScope(IServiceHostRuntime previousRuntime) : IDisposable
     {
-        if (type is null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
-
-        var executableLocation = Path.GetDirectoryName(type.Assembly.Location);
-        var isService = IsServiceMode(args);
-        if (isService)
-        {
-            SetCurrentDirectoryToProcessRoot();
-        }
-
-        var builder = Host.CreateApplicationBuilder();
-        _ = UseContentRoot(builder, Directory.GetCurrentDirectory());
-        _ = ConfigureLogging(builder);
-        _ = ConfigureExternal(builder, hostBuilder);
-        _ = ConfigureConfiguration(builder, args);
-        _ = builder.ConfigurePlugins(pluginBuilder => ConfigurePluginScanning(pluginBuilder, executableLocation, targetRuntime, nameSpace));
-        _ = builder.Services.AddTransient<DefaultLogger>();
-
-        ConfigureLifetime(builder, isService);
-
-        var host = builder.Build();
-        _logger = host.Services.GetRequiredService<DefaultLogger>();
-        configureHost?.Invoke(host);
-
-        return host.RunAsync(CancellationToken.None);
+        /// <inheritdoc/>
+        public void Dispose() => Volatile.Write(ref _runtime, previousRuntime);
     }
-
-    /// <summary>Determines whether the current process should run as a service.</summary>
-    /// <param name="args">The command-line arguments.</param>
-    /// <returns>true when the host should run as a service; otherwise, false.</returns>
-    private static bool IsServiceMode(string[] args) =>
-        !Debugger.IsAttached && (args.Length == 0 || args[0].IndexOf("--console", StringComparison.InvariantCultureIgnoreCase) < 0);
-
-    /// <summary>Sets the current directory to the executable directory.</summary>
-    private static void SetCurrentDirectoryToProcessRoot()
-    {
-        var pathToExe = Process.GetCurrentProcess().MainModule?.FileName;
-        var pathToContentRoot = Path.GetDirectoryName(pathToExe);
-        Directory.SetCurrentDirectory(pathToContentRoot!);
-    }
-
-    /// <summary>Configures the host lifetime for service or console execution.</summary>
-    /// <param name="hostBuilder">The host builder to configure.</param>
-    /// <param name="isService">true to use the service lifetime; otherwise, false.</param>
-    private static void ConfigureLifetime(IHostBuilder hostBuilder, bool isService)
-    {
-        if (isService)
-        {
-            _ = hostBuilder.UseServiceBaseLifetime();
-            return;
-        }
-
-        _ = hostBuilder.UseConsoleLifetime();
-    }
-
-    /// <summary>Configures the host application builder lifetime for service or console execution.</summary>
-    /// <param name="hostBuilder">The host application builder to configure.</param>
-    /// <param name="isService">true to use the service lifetime; otherwise, false.</param>
-    private static void ConfigureLifetime(IHostApplicationBuilder hostBuilder, bool isService)
-    {
-        if (isService)
-        {
-            _ = hostBuilder.UseServiceBaseLifetime();
-            return;
-        }
-
-        _ = hostBuilder.UseConsoleLifetime();
-    }
-
-    /// <summary>Configures plugin scanning using process and runtime information.</summary>
-    /// <param name="pluginBuilder">The plugin builder to configure.</param>
-    /// <param name="executableLocation">The executable location used to infer the runtime.</param>
-    /// <param name="targetRuntime">The target runtime override.</param>
-    /// <param name="nameSpace">The namespace prefix used to discover plugins.</param>
-    private static void ConfigurePluginScanning(IPluginBuilder? pluginBuilder, string? executableLocation, string? targetRuntime, string nameSpace)
-    {
-        var process = Process.GetCurrentProcess();
-        var fullPath = process.MainModule?.FileName?.Replace(process.MainModule.ModuleName!, string.Empty);
-        pluginBuilder?.AddScanDirectories(fullPath!);
-
-        pluginBuilder?.IncludeFrameworks(@"\netstandard2.0\*.FrameworkLib.dll");
-
-        var runtime = targetRuntime ?? Path.GetFileName(executableLocation);
-        pluginBuilder?.IncludePlugins(@$"\Plugins\{runtime}\{nameSpace}*.dll");
-    }
-
-    /// <summary>Sets the content root directory for the application host builder.</summary>
-    /// <param name="hostBuilder">The host application builder to configure.</param>
-    /// <param name="contentRoot">The absolute path to the directory that should be used as the content root. Cannot be null or empty.</param>
-    /// <returns>The same instance of <see cref="IHostApplicationBuilder"/> for chaining further configuration.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if contentRoot is null or empty.</exception>
-    private static IHostApplicationBuilder UseContentRoot(IHostApplicationBuilder hostBuilder, string contentRoot)
-    {
-        var checkedContentRoot = !string.IsNullOrEmpty(contentRoot)
-            ? contentRoot
-            : throw new ArgumentNullException(nameof(contentRoot), "Content root cannot be null or empty.");
-
-        _ = hostBuilder.Configuration.AddInMemoryCollection([new(HostDefaults.ContentRootKey, checkedContentRoot)]);
-
-        return hostBuilder;
-    }
-
-    /// <summary>Invokes an external host application builder configuration delegate when one was provided.</summary>
-    /// <param name="hostBuilder">The current host application builder.</param>
-    /// <param name="hostBuilderFunc">The optional external configuration delegate.</param>
-    /// <returns>The configured host application builder.</returns>
-    private static IHostApplicationBuilder? ConfigureExternal(IHostApplicationBuilder? hostBuilder, Func<IHostApplicationBuilder?, IHostApplicationBuilder?>? hostBuilderFunc) =>
-        hostBuilderFunc is null ? hostBuilder : hostBuilderFunc(hostBuilder);
-
-    /// <summary>Configures logging providers and settings for the specified host application builder.</summary>
-    /// <param name="hostBuilder">The host application builder to configure.</param>
-    /// <returns>The configured host application builder.</returns>
-    private static IHostApplicationBuilder? ConfigureLogging(IHostApplicationBuilder? hostBuilder)
-    {
-        if (hostBuilder is null)
-        {
-            return null;
-        }
-
-        _ = hostBuilder.Logging
-            .AddConfiguration(hostBuilder.Configuration.GetSection("Logging"))
-            .AddConsole()
-            .AddEventLog()
-            .AddLog4Net("log4net.config")
-            .AddDebug();
-
-        return hostBuilder;
-    }
-
-    /// <summary>Configures application configuration sources for the host application builder.</summary>
-    /// <param name="hostBuilder">The host application builder to configure.</param>
-    /// <param name="args">The command-line arguments to include as a configuration source.</param>
-    /// <returns>The configured host application builder.</returns>
-    private static IHostApplicationBuilder? ConfigureConfiguration(IHostApplicationBuilder? hostBuilder, string[] args)
-    {
-        if (hostBuilder is null)
-        {
-            return null;
-        }
-
-        _ = hostBuilder.Configuration.SetBasePath(Directory.GetCurrentDirectory());
-        _ = hostBuilder.Configuration.AddJsonFile(HostSettingsFile, optional: true);
-        _ = hostBuilder.Configuration.AddEnvironmentVariables(prefix: Prefix);
-        _ = hostBuilder.Configuration.AddCommandLine(args);
-
-        _ = hostBuilder.Configuration.AddJsonFile(AppSettingsFilePrefix + ".json", optional: true);
-        if (!string.IsNullOrEmpty(hostBuilder.Environment.EnvironmentName))
-        {
-            _ = hostBuilder.Configuration.AddJsonFile(AppSettingsFilePrefix + $".{hostBuilder.Environment.EnvironmentName}.json", optional: true);
-        }
-
-        _ = hostBuilder.Configuration.AddEnvironmentVariables(prefix: Prefix);
-        _ = hostBuilder.Configuration.AddCommandLine(args);
-        return hostBuilder;
-    }
-
-    /// <summary>Invokes an external host builder configuration delegate when one was provided.</summary>
-    /// <param name="hostBuilder">The current host builder.</param>
-    /// <param name="hostBuilderFunc">The optional external configuration delegate.</param>
-    /// <returns>The configured host builder.</returns>
-    private static IHostBuilder? ConfigureExternal(IHostBuilder? hostBuilder, Func<IHostBuilder?, IHostBuilder?>? hostBuilderFunc) =>
-        hostBuilderFunc is null ? hostBuilder : hostBuilderFunc(hostBuilder);
-
-    /// <summary>Configures logging providers for the specified host builder.</summary>
-    /// <param name="hostBuilder">The host builder to configure.</param>
-    /// <returns>The configured host builder.</returns>
-    private static IHostBuilder? ConfigureLogging(IHostBuilder? hostBuilder) =>
-        hostBuilder?.ConfigureLogging((hostContext, configLogging) =>
-        {
-            _ = configLogging
-                .AddConfiguration(hostContext.Configuration.GetSection("Logging"))
-                .AddConsole()
-                .AddEventLog()
-                .AddLog4Net("log4net.config")
-                .AddDebug();
-        });
-
-    /// <summary>Configures host and application configuration sources for the host builder.</summary>
-    /// <param name="hostBuilder">The host builder to configure.</param>
-    /// <param name="args">The command-line arguments to include in the configuration.</param>
-    /// <returns>The configured host builder.</returns>
-    private static IHostBuilder? ConfigureConfiguration(IHostBuilder? hostBuilder, string[] args) =>
-        hostBuilder?
-            .ConfigureHostConfiguration(configHost =>
-            {
-                _ = configHost.SetBasePath(Directory.GetCurrentDirectory());
-                _ = configHost.AddJsonFile(HostSettingsFile, optional: true);
-                _ = configHost.AddEnvironmentVariables(prefix: Prefix);
-                _ = configHost.AddCommandLine(args);
-            })
-            .ConfigureAppConfiguration((hostContext, configApp) =>
-            {
-                _ = configApp.AddJsonFile(AppSettingsFilePrefix + ".json", optional: true);
-                if (!string.IsNullOrEmpty(hostContext.HostingEnvironment.EnvironmentName))
-                {
-                    _ = configApp.AddJsonFile(AppSettingsFilePrefix + $".{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true);
-                }
-
-                _ = configApp.AddEnvironmentVariables(prefix: Prefix);
-                _ = configApp.AddCommandLine(args);
-            });
 }

--- a/src/Extensions.Hosting.PluginService/ServiceHostRunner.cs
+++ b/src/Extensions.Hosting.PluginService/ServiceHostRunner.cs
@@ -1,0 +1,342 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+#if REACTIVE_SHIM
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+#else
+using ReactiveMarbles.Extensions.Hosting.Plugins;
+#endif
+using ReactiveMarbles.Extensions.Logging;
+
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+#else
+namespace ReactiveMarbles.Extensions.Hosting.PluginService;
+#endif
+
+/// <summary>Builds hosts using configuration, plugin discovery, logging, and a supplied operating-system runtime.</summary>
+/// <remarks>The ServiceHostRunner class simplifies the setup of .NET hosts, including configuration, logging, and
+/// plugin loading. It is intended for use in applications that require dynamic plugin discovery and flexible host
+/// configuration. All members are thread-safe for typical usage scenarios.</remarks>
+internal sealed class ServiceHostRunner
+{
+    /// <summary>Stores the runtime used to run hosts.</summary>
+    private readonly IServiceHostRuntime _runtime;
+
+    /// <summary>Initializes a new instance of the <see cref="ServiceHostRunner"/> class.</summary>
+    /// <param name="runtime">The runtime used to run hosts.</param>
+    internal ServiceHostRunner(IServiceHostRuntime runtime)
+    {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+    }
+
+    /// <summary>Creates and runs a host for the specified plugin type using the default host configuration.</summary>
+    /// <param name="type">The type representing the plugin to host.</param>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns>A task that represents the host lifetime.</returns>
+    internal Task Create(Type type, string[] args) =>
+        Create(type, args, null, null, "ReactiveMarbles.Plugin", null);
+
+    /// <summary>Creates and runs a host for the specified plugin type, configuring logging, services, and plugin discovery according to the provided parameters.</summary>
+    /// <remarks>This method sets up a .NET host with default configuration, logging, and plugin scanning
+    /// based on the specified parameters. It supports both service and console lifetimes, automatically selecting the
+    /// appropriate mode based on the execution context and command-line arguments. Plugins are discovered using the
+    /// provided namespace and runtime information. Additional host or host builder configuration can be supplied via
+    /// the optional delegates.</remarks>
+    /// <param name="type">The type representing the plugin to host. Cannot be null.</param>
+    /// <param name="args">The command-line arguments to use for host configuration and plugin startup.</param>
+    /// <param name="hostBuilder">An optional delegate to further configure the <see cref="IHostBuilder"/> before building the host. If null, no
+    /// additional configuration is applied.</param>
+    /// <param name="configureHost">An optional action to perform additional configuration on the built <see cref="IHost"/> before it is run. If
+    /// null, no additional configuration is performed.</param>
+    /// <param name="nameSpace">The namespace pattern used to locate plugin assemblies. Defaults to "ReactiveMarbles.Plugin".</param>
+    /// <param name="targetRuntime">The target runtime identifier used to determine the plugin directory. If null, the runtime is inferred from the
+    /// plugin assembly location.</param>
+    /// <returns>A task that represents the asynchronous operation of running the configured host.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="type"/> is null.</exception>
+    internal Task Create(
+        Type type,
+        string[] args,
+        Func<IHostBuilder?, IHostBuilder?>? hostBuilder,
+        Action<IHost>? configureHost,
+        string nameSpace,
+        string? targetRuntime)
+    {
+        _ = type ?? throw new ArgumentNullException(nameof(type));
+
+        var executableLocation = Path.GetDirectoryName(type.Assembly.Location);
+        var isService = Configuration.IsServiceMode(args);
+        if (isService)
+        {
+            Configuration.SetCurrentDirectoryToProcessRoot();
+        }
+
+        var builder = Host.CreateDefaultBuilder()
+            .UseContentRoot(Directory.GetCurrentDirectory());
+
+        builder = Configuration.ConfigureHostLogging(builder)!;
+        builder = Configuration.ConfigureExternal(builder, hostBuilder)!;
+        builder = Configuration.ConfigureHostConfiguration(builder, args)!;
+        builder = builder
+            .ConfigurePlugins(pluginBuilder => Configuration.ConfigurePluginScanning(pluginBuilder, executableLocation, targetRuntime, nameSpace))!
+            .ConfigureServices(static serviceCollection => _ = serviceCollection.AddTransient<DefaultLogger>());
+
+        Configuration.ConfigureLifetime(
+            isService,
+            () => _ = builder.UseServiceBaseLifetime(),
+            () => _ = builder.UseConsoleLifetime());
+
+        var host = builder.Build();
+        ServiceHost.SetLogger(host.Services.GetRequiredService<DefaultLogger>());
+        configureHost?.Invoke(host);
+
+        return _runtime.RunAsync(host, CancellationToken.None);
+    }
+
+    /// <summary>Creates and runs an application host using the default host configuration.</summary>
+    /// <param name="type">The application entry type.</param>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns>A task that represents the application lifetime.</returns>
+    internal Task CreateApplication(Type type, string[] args) =>
+        CreateApplication(type, args, null, null, "ReactiveMarbles.Plugin", null);
+
+    /// <summary>Initializes and runs a plugin-based .NET application using the specified entry type and configuration.</summary>
+    /// <remarks>This method configures the application host, logging, plugin discovery, and lifetime
+    /// management based on the provided parameters. It supports both console and Windows service modes, automatically
+    /// selecting the appropriate lifetime based on the execution context and command-line arguments. Plugins are loaded
+    /// from directories determined by the specified or inferred runtime and namespace. Use the optional delegates to
+    /// customize host building and post-build configuration as needed.</remarks>
+    /// <param name="type">The entry point type for the application. This type's assembly is used to determine the application location and
+    /// plugin scanning context. Cannot be null.</param>
+    /// <param name="args">The command-line arguments to pass to the application. Used for configuration and to determine the application
+    /// mode (console or service).</param>
+    /// <param name="hostBuilder">An optional delegate to further configure the <see cref="IHostApplicationBuilder"/> before building the host. If
+    /// null, no additional configuration is applied.</param>
+    /// <param name="configureHost">An optional action to configure the <see cref="IHost"/> after it is built but before it is run. If null, no
+    /// additional configuration is performed.</param>
+    /// <param name="nameSpace">The namespace pattern used to locate and include plugin assemblies. Defaults to "ReactiveMarbles.Plugin".</param>
+    /// <param name="targetRuntime">The target runtime identifier used to determine the plugin directory. If null, the runtime is inferred from the
+    /// entry assembly location.</param>
+    /// <returns>A task that represents the asynchronous operation of running the application. The task completes when the
+    /// application shuts down.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="type"/> is null.</exception>
+    internal Task CreateApplication(
+        Type type,
+        string[] args,
+        Func<IHostApplicationBuilder?, IHostApplicationBuilder?>? hostBuilder,
+        Action<IHost>? configureHost,
+        string nameSpace,
+        string? targetRuntime)
+    {
+        _ = type ?? throw new ArgumentNullException(nameof(type));
+
+        var executableLocation = Path.GetDirectoryName(type.Assembly.Location);
+        var isService = Configuration.IsServiceMode(args);
+        if (isService)
+        {
+            Configuration.SetCurrentDirectoryToProcessRoot();
+        }
+
+        var builder = Host.CreateApplicationBuilder();
+        _ = Configuration.UseContentRoot(builder, Directory.GetCurrentDirectory());
+        _ = Configuration.ConfigureApplicationLogging(builder);
+        _ = Configuration.ConfigureExternal(builder, hostBuilder);
+        _ = Configuration.ConfigureApplicationConfiguration(builder, args);
+        _ = builder.ConfigurePlugins(pluginBuilder => Configuration.ConfigurePluginScanning(pluginBuilder, executableLocation, targetRuntime, nameSpace));
+        _ = builder.Services.AddTransient<DefaultLogger>();
+
+        Configuration.ConfigureLifetime(
+            isService,
+            () => _ = builder.UseServiceBaseLifetime(),
+            () => _ = builder.UseConsoleLifetime());
+
+        var host = builder.Build();
+        ServiceHost.SetLogger(host.Services.GetRequiredService<DefaultLogger>());
+        configureHost?.Invoke(host);
+
+        return _runtime.RunAsync(host, CancellationToken.None);
+    }
+
+    /// <summary>Provides reusable host-builder configuration operations.</summary>
+    internal static class Configuration
+    {
+    /// <summary>Stores the app settings file prefix value.</summary>
+    private const string AppSettingsFilePrefix = "appsettings";
+
+    /// <summary>Stores the host settings file value.</summary>
+    private const string HostSettingsFile = "hostsettings.json";
+
+    /// <summary>Stores the prefix value.</summary>
+    private const string Prefix = "PREFIX_";
+
+    /// <summary>Determines whether the current process should run as a service.</summary>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns>true when the host should run as a service; otherwise, false.</returns>
+    internal static bool IsServiceMode(string[] args) =>
+        !Debugger.IsAttached && (args.Length == 0 || args[0].IndexOf("--console", StringComparison.InvariantCultureIgnoreCase) < 0);
+
+    /// <summary>Sets the current directory to the executable directory.</summary>
+    internal static void SetCurrentDirectoryToProcessRoot()
+    {
+        var pathToExe = Process.GetCurrentProcess().MainModule?.FileName;
+        var pathToContentRoot = Path.GetDirectoryName(pathToExe);
+        Directory.SetCurrentDirectory(pathToContentRoot!);
+    }
+
+    /// <summary>Configures a host lifetime for service or console execution.</summary>
+    /// <param name="isService">true to use the service lifetime; otherwise, false.</param>
+    /// <param name="useServiceLifetime">The action that configures the service lifetime.</param>
+    /// <param name="useConsoleLifetime">The action that configures the console lifetime.</param>
+    internal static void ConfigureLifetime(
+        bool isService,
+        Action useServiceLifetime,
+        Action useConsoleLifetime)
+    {
+        if (isService)
+        {
+            useServiceLifetime();
+            return;
+        }
+
+        useConsoleLifetime();
+    }
+
+    /// <summary>Configures plugin scanning using process and runtime information.</summary>
+    /// <param name="pluginBuilder">The plugin builder to configure.</param>
+    /// <param name="executableLocation">The executable location used to infer the runtime.</param>
+    /// <param name="targetRuntime">The target runtime override.</param>
+    /// <param name="nameSpace">The namespace prefix used to discover plugins.</param>
+    internal static void ConfigurePluginScanning(IPluginBuilder? pluginBuilder, string? executableLocation, string? targetRuntime, string nameSpace)
+    {
+        var process = Process.GetCurrentProcess();
+        var fullPath = process.MainModule?.FileName?.Replace(process.MainModule.ModuleName!, string.Empty);
+        pluginBuilder?.AddScanDirectories(fullPath!);
+
+        pluginBuilder?.IncludeFrameworks(@"\netstandard2.0\*.FrameworkLib.dll");
+
+        var runtime = targetRuntime ?? Path.GetFileName(executableLocation);
+        pluginBuilder?.IncludePlugins(@$"\Plugins\{runtime}\{nameSpace}*.dll");
+    }
+
+    /// <summary>Sets the content root directory for the application host builder.</summary>
+    /// <param name="hostBuilder">The host application builder to configure.</param>
+    /// <param name="contentRoot">The absolute path to the directory that should be used as the content root. Cannot be null or empty.</param>
+    /// <returns>The same instance of <see cref="IHostApplicationBuilder"/> for chaining further configuration.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if contentRoot is null or empty.</exception>
+    internal static IHostApplicationBuilder UseContentRoot(IHostApplicationBuilder hostBuilder, string contentRoot)
+    {
+        var checkedContentRoot = !string.IsNullOrEmpty(contentRoot)
+            ? contentRoot
+            : throw new ArgumentNullException(nameof(contentRoot), "Content root cannot be null or empty.");
+
+        _ = hostBuilder.Configuration.AddInMemoryCollection([new(HostDefaults.ContentRootKey, checkedContentRoot)]);
+
+        return hostBuilder;
+    }
+
+    /// <summary>Invokes an external builder configuration delegate when one was provided.</summary>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
+    /// <param name="hostBuilder">The current builder.</param>
+    /// <param name="hostBuilderFunc">The optional external configuration delegate.</param>
+    /// <returns>The configured builder.</returns>
+    internal static TBuilder? ConfigureExternal<TBuilder>(
+        TBuilder? hostBuilder,
+        Func<TBuilder?, TBuilder?>? hostBuilderFunc)
+        where TBuilder : class =>
+        hostBuilderFunc is null ? hostBuilder : hostBuilderFunc(hostBuilder);
+
+    /// <summary>Configures logging providers and settings for the specified host application builder.</summary>
+    /// <param name="hostBuilder">The host application builder to configure.</param>
+    /// <returns>The configured host application builder.</returns>
+    internal static IHostApplicationBuilder? ConfigureApplicationLogging(IHostApplicationBuilder? hostBuilder)
+    {
+        if (hostBuilder is null)
+        {
+            return null;
+        }
+
+        _ = hostBuilder.Logging
+            .AddConfiguration(hostBuilder.Configuration.GetSection("Logging"))
+            .AddConsole()
+            .AddEventLog()
+            .AddLog4Net("log4net.config")
+            .AddDebug();
+
+        return hostBuilder;
+    }
+
+    /// <summary>Configures application configuration sources for the host application builder.</summary>
+    /// <param name="hostBuilder">The host application builder to configure.</param>
+    /// <param name="args">The command-line arguments to include as a configuration source.</param>
+    /// <returns>The configured host application builder.</returns>
+    internal static IHostApplicationBuilder? ConfigureApplicationConfiguration(
+        IHostApplicationBuilder? hostBuilder,
+        string[] args)
+    {
+        if (hostBuilder is null)
+        {
+            return null;
+        }
+
+        _ = hostBuilder.Configuration.SetBasePath(Directory.GetCurrentDirectory());
+        _ = hostBuilder.Configuration.AddJsonFile(HostSettingsFile, optional: true);
+        _ = hostBuilder.Configuration.AddEnvironmentVariables(prefix: Prefix);
+        _ = hostBuilder.Configuration.AddCommandLine(args);
+
+        _ = hostBuilder.Configuration.AddJsonFile($"{AppSettingsFilePrefix}.json", optional: true);
+        if (!string.IsNullOrEmpty(hostBuilder.Environment.EnvironmentName))
+        {
+            _ = hostBuilder.Configuration.AddJsonFile(AppSettingsFilePrefix + $".{hostBuilder.Environment.EnvironmentName}.json", optional: true);
+        }
+
+        _ = hostBuilder.Configuration.AddEnvironmentVariables(prefix: Prefix);
+        _ = hostBuilder.Configuration.AddCommandLine(args);
+        return hostBuilder;
+    }
+
+    /// <summary>Configures logging providers for the specified host builder.</summary>
+    /// <param name="hostBuilder">The host builder to configure.</param>
+    /// <returns>The configured host builder.</returns>
+    internal static IHostBuilder? ConfigureHostLogging(IHostBuilder? hostBuilder) =>
+        hostBuilder?.ConfigureLogging(static (hostContext, configLogging) =>
+        {
+            _ = configLogging
+                .AddConfiguration(hostContext.Configuration.GetSection("Logging"))
+                .AddConsole()
+                .AddEventLog()
+                .AddLog4Net("log4net.config")
+                .AddDebug();
+        });
+
+    /// <summary>Configures host and application configuration sources for the host builder.</summary>
+    /// <param name="hostBuilder">The host builder to configure.</param>
+    /// <param name="args">The command-line arguments to include in the configuration.</param>
+    /// <returns>The configured host builder.</returns>
+    internal static IHostBuilder? ConfigureHostConfiguration(IHostBuilder? hostBuilder, string[] args) =>
+        hostBuilder?
+            .ConfigureHostConfiguration(configHost =>
+            {
+                _ = configHost.SetBasePath(Directory.GetCurrentDirectory());
+                _ = configHost.AddJsonFile(HostSettingsFile, optional: true);
+                _ = configHost.AddEnvironmentVariables(prefix: Prefix);
+                _ = configHost.AddCommandLine(args);
+            })
+            .ConfigureAppConfiguration((hostContext, configApp) =>
+            {
+                _ = configApp.AddJsonFile($"{AppSettingsFilePrefix}.json", optional: true);
+                if (!string.IsNullOrEmpty(hostContext.HostingEnvironment.EnvironmentName))
+                {
+                    _ = configApp.AddJsonFile(AppSettingsFilePrefix + $".{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true);
+                }
+
+                _ = configApp.AddEnvironmentVariables(prefix: Prefix);
+                _ = configApp.AddCommandLine(args);
+            });
+    }
+}

--- a/src/Extensions.Hosting.PluginService/ServiceHostRuntime.cs
+++ b/src/Extensions.Hosting.PluginService/ServiceHostRuntime.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ServiceProcess;
+using Microsoft.Extensions.Hosting;
+
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+#else
+namespace ReactiveMarbles.Extensions.Hosting.PluginService;
+#endif
+
+/// <summary>Provides the production implementation of <see cref="IServiceHostRuntime"/>.</summary>
+internal sealed class ServiceHostRuntime : IServiceHostRuntime
+{
+    /// <inheritdoc/>
+    public Task RunAsync(IHost host, CancellationToken cancellationToken) => host.RunAsync(cancellationToken);
+
+    /// <inheritdoc/>
+    public void RunService(ServiceBase service) => ServiceBase.Run(service);
+
+    /// <inheritdoc/>
+    public void StopService(ServiceBase service) => service.Stop();
+}

--- a/src/Extensions.Hosting.Plugins/Extensions.Hosting.Plugins.csproj
+++ b/src/Extensions.Hosting.Plugins/Extensions.Hosting.Plugins.csproj
@@ -21,6 +21,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Extensions.Hosting.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Extensions.Hosting.Benchmarks</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/src/Extensions.Hosting.Plugins/HostBuilderPluginExtensions.cs
+++ b/src/Extensions.Hosting.Plugins/HostBuilderPluginExtensions.cs
@@ -1,12 +1,14 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
+#if NET5_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Hosting;
 #if REACTIVE_SHIM
@@ -30,6 +32,85 @@ public static class HostBuilderPluginExtensions
 {
     /// <summary>Stores the plugin builder key value.</summary>
     private const string PluginBuilderKey = nameof(PluginBuilder);
+
+    /// <summary>Scans the loaded assemblies and returns plugins in configured order.</summary>
+    /// <param name="pluginBuilder">The plugin builder that contains the assembly scanning delegate.</param>
+    /// <param name="scannedAssemblies">The assemblies to scan.</param>
+    /// <returns>The ordered plugins discovered from the loaded assemblies.</returns>
+    internal static List<IPlugin> GetOrderedPlugins(IPluginBuilder pluginBuilder, HashSet<Assembly> scannedAssemblies)
+    {
+        var plugins = new List<IPlugin>();
+
+        foreach (var assembly in scannedAssemblies)
+        {
+            var scannedPlugins = pluginBuilder.AssemblyScanFunc(assembly);
+            if (scannedPlugins is null)
+            {
+                continue;
+            }
+
+            foreach (var plugin in scannedPlugins)
+            {
+                if (plugin is null)
+                {
+                    continue;
+                }
+
+                plugins.Add(plugin);
+            }
+        }
+
+        if (plugins.Count < 2)
+        {
+            return plugins;
+        }
+
+        var pluginsByOrder = new Dictionary<int, List<IPlugin>>();
+        var ordersByPluginType = new Dictionary<Type, int>();
+        var orderKeys = new List<int>();
+        foreach (var plugin in plugins)
+        {
+            var pluginType = plugin.GetType();
+#if NET5_0_OR_GREATER
+            ref var order = ref CollectionsMarshal.GetValueRefOrAddDefault(ordersByPluginType, pluginType, out var orderExists);
+            if (!orderExists)
+            {
+                order = GetOrder(plugin);
+            }
+
+            ref var orderedPlugins = ref CollectionsMarshal.GetValueRefOrAddDefault(pluginsByOrder, order, out var orderGroupExists);
+            if (!orderGroupExists)
+            {
+                orderedPlugins = [];
+                orderKeys.Add(order);
+            }
+#else
+            if (!ordersByPluginType.TryGetValue(pluginType, out var order))
+            {
+                order = GetOrder(plugin);
+                ordersByPluginType.Add(pluginType, order);
+            }
+
+            if (!pluginsByOrder.TryGetValue(order, out var orderedPlugins))
+            {
+                orderedPlugins = [];
+                pluginsByOrder.Add(order, orderedPlugins);
+                orderKeys.Add(order);
+            }
+#endif
+
+            orderedPlugins!.Add(plugin);
+        }
+
+        orderKeys.Sort();
+        plugins.Clear();
+        foreach (var order in orderKeys)
+        {
+            plugins.AddRange(pluginsByOrder[order]);
+        }
+
+        return plugins;
+    }
 
     /// <summary>Attempts to retrieve an existing <see cref="IPluginBuilder"/> instance from the specified properties dictionary, or creates and adds a new instance if one does not exist.</summary>
     /// <remarks>This method ensures that the properties dictionary always contains a valid <see
@@ -61,7 +142,7 @@ public static class HostBuilderPluginExtensions
 
     /// <summary>Provides extension members for this receiver.</summary>
     /// <param name="hostBuilder">The receiver instance.</param>
-    extension(IHostApplicationBuilder? hostBuilder)
+    extension(IHostApplicationBuilder hostBuilder)
     {
         /// <summary>Configures plugins for the application by invoking the specified configuration action on the plugin builder.</summary>
         /// <remarks>This method ensures that plugin scanning and loading are configured only once per host
@@ -73,10 +154,7 @@ public static class HostBuilderPluginExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         public IHostApplicationBuilder ConfigurePlugins(Action<IPluginBuilder?> configurePlugin)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             var alreadyConfigured = TryRetrievePluginBuilder(hostBuilder.Properties, out var pluginBuilder);
             configurePlugin?.Invoke(pluginBuilder);
@@ -92,7 +170,7 @@ public static class HostBuilderPluginExtensions
 
     /// <summary>Provides extension members for this receiver.</summary>
     /// <param name="hostBuilder">The receiver instance.</param>
-    extension(IHostBuilder? hostBuilder)
+    extension(IHostBuilder hostBuilder)
     {
         /// <summary>Configures plugin support for the specified host builder by invoking the provided configuration action.</summary>
         /// <remarks>This method ensures that plugin support is configured only once for the host builder.
@@ -104,10 +182,7 @@ public static class HostBuilderPluginExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         public IHostBuilder ConfigurePlugins(Action<IPluginBuilder?> configurePlugin)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             var alreadyConfigured = TryRetrievePluginBuilder(hostBuilder.Properties, out var pluginBuilder);
             configurePlugin?.Invoke(pluginBuilder);
@@ -231,18 +306,6 @@ public static class HostBuilderPluginExtensions
             }
         }
     }
-
-    /// <summary>Scans the loaded assemblies and returns plugins in configured order.</summary>
-    /// <param name="pluginBuilder">The plugin builder that contains the assembly scanning delegate.</param>
-    /// <param name="scannedAssemblies">The assemblies to scan.</param>
-    /// <returns>The ordered plugins discovered from the loaded assemblies.</returns>
-    private static List<IPlugin> GetOrderedPlugins(IPluginBuilder pluginBuilder, HashSet<Assembly> scannedAssemblies) =>
-        scannedAssemblies
-            .SelectMany(assembly => pluginBuilder.AssemblyScanFunc(assembly) ?? Enumerable.Empty<IPlugin?>())
-            .Where(plugin => plugin is not null)
-            .Cast<IPlugin>()
-            .OrderBy(GetOrder)
-            .ToList();
 
     /// <summary>Loads a plugin assembly from the specified location using the provided plugin builder.</summary>
     /// <remarks>The method performs validation on the plugin assembly before attempting to load it. If the

--- a/src/Extensions.Hosting.Plugins/HostedServiceBase.cs
+++ b/src/Extensions.Hosting.Plugins/HostedServiceBase.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -26,19 +26,19 @@ public class HostedServiceBase<T>(ILogger<T> logger, IHostApplicationLifetime ho
 {
     /// <summary>Logs that the hosted service started.</summary>
     private static readonly Action<ILogger, string, Exception?> _serviceStarted =
-        LoggerMessage.Define<string>(LogLevel.Information, new EventId(1, nameof(_serviceStarted)), "{ServiceName} Service OnStarted has been called.");
+        LoggerMessage.Define<string>(LogLevel.Information, new(1, nameof(_serviceStarted)), "{ServiceName} Service OnStarted has been called.");
 
     /// <summary>Logs that the hosted service is stopping.</summary>
     private static readonly Action<ILogger, string, Exception?> _serviceStopping =
-        LoggerMessage.Define<string>(LogLevel.Information, new EventId(2, nameof(_serviceStopping)), "{ServiceName} Service OnStopping has been called.");
+        LoggerMessage.Define<string>(LogLevel.Information, new(2, nameof(_serviceStopping)), "{ServiceName} Service OnStopping has been called.");
 
     /// <summary>Logs that the hosted service stopped.</summary>
     private static readonly Action<ILogger, string, Exception?> _serviceStopped =
-        LoggerMessage.Define<string>(LogLevel.Information, new EventId(3, nameof(_serviceStopped)), "{ServiceName} Service OnStopped has been called.");
+        LoggerMessage.Define<string>(LogLevel.Information, new(3, nameof(_serviceStopped)), "{ServiceName} Service OnStopped has been called.");
 
     /// <summary>Logs that the hosted service start callback failed.</summary>
     private static readonly Action<ILogger, string, Exception?> _serviceStartFailed =
-        LoggerMessage.Define<string>(LogLevel.Error, new EventId(4, nameof(_serviceStartFailed)), "{ServiceName} Service OnStarted failed.");
+        LoggerMessage.Define<string>(LogLevel.Error, new(4, nameof(_serviceStartFailed)), "{ServiceName} Service OnStarted failed.");
 
     /// <summary>Stores the disposed value.</summary>
     private bool _disposedValue;
@@ -58,12 +58,9 @@ public class HostedServiceBase<T>(ILogger<T> logger, IHostApplicationLifetime ho
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _ = hostApplicationLifetime.ApplicationStarted.Register(() =>
-        {
-            _serviceStarted(Logger, nameof(T), null);
-            CleanUp = [];
-            _ = RunOnStartedAsync();
-        });
+        _ = hostApplicationLifetime.ApplicationStarted.Register(
+            static state => ((HostedServiceBase<T>)state!).OnApplicationStarted(),
+            this);
         _ = hostApplicationLifetime.ApplicationStopping.Register(OnStopping);
         _ = hostApplicationLifetime.ApplicationStopped.Register(OnStopped);
 
@@ -132,5 +129,13 @@ public class HostedServiceBase<T>(ILogger<T> logger, IHostApplicationLifetime ho
         {
             _serviceStartFailed(Logger, nameof(T), ex);
         }
+    }
+
+    /// <summary>Handles the application-started lifetime notification.</summary>
+    private void OnApplicationStarted()
+    {
+        _serviceStarted(Logger, nameof(T), null);
+        CleanUp = [];
+        _ = RunOnStartedAsync();
     }
 }

--- a/src/Extensions.Hosting.Plugins/IPlugin.cs
+++ b/src/Extensions.Hosting.Plugins/IPlugin.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Extensions.Hosting.Plugins/IPluginBuilder.cs
+++ b/src/Extensions.Hosting.Plugins/IPluginBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.Plugins/Internals/AssemblyDependencyResolver.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/AssemblyDependencyResolver.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
@@ -1,9 +1,10 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 
 #if REACTIVE_SHIM
@@ -26,7 +27,7 @@ public class AssemblyLoadContext(string name)
     /// <remarks>The default context is used to load assemblies that are part of the application or shared
     /// framework. Assemblies loaded into the default context are visible to all code in the application domain. Use
     /// this property to access the standard assembly loading behavior provided by .NET.</remarks>
-    public static AssemblyLoadContext Default { get; } = new AssemblyLoadContext("default");
+    public static AssemblyLoadContext Default { get; } = new("default");
 
     /// <summary>Gets the assemblies that are loaded into the current application domain.</summary>
     public static IEnumerable<Assembly> Assemblies => AppDomain.CurrentDomain.GetAssemblies();
@@ -35,12 +36,18 @@ public class AssemblyLoadContext(string name)
     public string Name { get; } = name;
 
     /// <summary>Loads an assembly from the specified file path.</summary>
-    /// <remarks>The assembly is loaded into the load-from context. If the assembly has already been loaded,
-    /// this method may return a reference to the existing assembly. This method does not resolve dependencies
-    /// automatically; dependent assemblies must be available to the loader.</remarks>
+    /// <remarks>The path is used to read the assembly's full identity before the runtime resolves that identity
+    /// through its normal trusted assembly-loading process.</remarks>
     /// <param name="assemblyPath">The path to the assembly file to load. The path must be a valid file system path to a managed assembly file.</param>
     /// <returns>The loaded assembly represented by the specified file path.</returns>
-    public static Assembly LoadFromAssemblyPath(string assemblyPath) => Assembly.LoadFrom(assemblyPath);
+    public static Assembly LoadFromAssemblyPath(string assemblyPath)
+    {
+        var validAssemblyPath = !string.IsNullOrWhiteSpace(assemblyPath)
+            ? assemblyPath
+            : throw new ArgumentException("The assembly path cannot be null or whitespace.", nameof(assemblyPath));
+        var fullPath = Path.GetFullPath(validAssemblyPath);
+        return Assembly.Load(AssemblyName.GetAssemblyName(fullPath));
+    }
 
     /// <summary>Loads an assembly given its display name.</summary>
     /// <remarks>This method loads the assembly into the current load context. If the assembly has already
@@ -50,10 +57,7 @@ public class AssemblyLoadContext(string name)
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="assemblyName"/> is null.</exception>
     public Assembly LoadFromAssemblyName(AssemblyName assemblyName)
     {
-        if (assemblyName is null)
-        {
-            throw new ArgumentNullException(nameof(assemblyName));
-        }
+        _ = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
 
         // Attempt to load the assembly, using the same ordering as static load, in the current load context.
         return Load(assemblyName);

--- a/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContextExtensions.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContextExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/src/Extensions.Hosting.Plugins/Internals/PluginBuilder.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/PluginBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -21,13 +21,13 @@ namespace ReactiveMarbles.Extensions.Hosting.Plugins.Internals;
 internal sealed class PluginBuilder : IPluginBuilder
 {
     /// <inheritdoc />
-    public Matcher FrameworkMatcher { get; } = new Matcher();
+    public Matcher FrameworkMatcher { get; } = new();
 
     /// <inheritdoc />
-    public Matcher PluginMatcher { get; } = new Matcher();
+    public Matcher PluginMatcher { get; } = new();
 
     /// <inheritdoc />
-    public Func<string, bool> ValidatePlugin { get; set; } = _ => true;
+    public Func<string, bool> ValidatePlugin { get; set; } = static _ => true;
 
     /// <inheritdoc />
     public Func<Assembly, IEnumerable<IPlugin?>?> AssemblyScanFunc { get; set; } = PluginScanner.ScanForPluginInstances;

--- a/src/Extensions.Hosting.Plugins/Internals/PluginLoadContext.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/PluginLoadContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -27,8 +27,14 @@ internal sealed class PluginLoadContext(string pluginPath, string name) : Assemb
     /// <summary>Resolves the file system path to the assembly specified by the given assembly name.</summary>
     /// <param name="assemblyName">The assembly name to resolve. Cannot be null.</param>
     /// <returns>The full path to the resolved assembly file, or null if the assembly cannot be found.</returns>
-    public string? ResolveAssemblyPath(AssemblyName assemblyName) =>
+    internal string? ResolveAssemblyPath(AssemblyName assemblyName) =>
         _resolver.ResolveAssemblyToPath(assemblyName);
+
+    /// <summary>Loads an unmanaged library by name through the plugin resolver.</summary>
+    /// <param name="unmanagedDllName">The unmanaged library name.</param>
+    /// <returns>The loaded library handle, or zero when it cannot be resolved.</returns>
+    internal IntPtr LoadUnmanagedLibrary(string unmanagedDllName) =>
+        LoadUnmanagedDll(unmanagedDllName);
 
     /// <inheritdoc />
     protected override Assembly Load(AssemblyName assemblyName) =>

--- a/src/Extensions.Hosting.Plugins/PluginBase{T1,T2,T3}.cs
+++ b/src/Extensions.Hosting.Plugins/PluginBase{T1,T2,T3}.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Extensions.Hosting.Plugins/PluginBase{T1,T2}.cs
+++ b/src/Extensions.Hosting.Plugins/PluginBase{T1,T2}.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Extensions.Hosting.Plugins/PluginBase{T}.cs
+++ b/src/Extensions.Hosting.Plugins/PluginBase{T}.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Extensions.Hosting.Plugins/PluginBuilderExtensions.cs
+++ b/src/Extensions.Hosting.Plugins/PluginBuilderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -30,10 +30,7 @@ public static class PluginBuilderExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="directories"/> is null.</exception>
         public void AddScanDirectories(params string[] directories)
         {
-            if (directories is null)
-            {
-                throw new ArgumentNullException(nameof(directories));
-            }
+            _ = directories ?? throw new ArgumentNullException(nameof(directories));
 
             foreach (var directory in directories)
             {
@@ -49,10 +46,7 @@ public static class PluginBuilderExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="frameworkGlobs"/> is <see langword="null"/>.</exception>
         public void ExcludeFrameworks(params string[] frameworkGlobs)
         {
-            if (frameworkGlobs is null)
-            {
-                throw new ArgumentNullException(nameof(frameworkGlobs));
-            }
+            _ = frameworkGlobs ?? throw new ArgumentNullException(nameof(frameworkGlobs));
 
             foreach (var glob in frameworkGlobs)
             {
@@ -69,10 +63,7 @@ public static class PluginBuilderExtensions
         /// <exception cref="ArgumentNullException">Thrown if pluginGlobs is null.</exception>
         public void ExcludePlugins(params string[] pluginGlobs)
         {
-            if (pluginGlobs is null)
-            {
-                throw new ArgumentNullException(nameof(pluginGlobs));
-            }
+            _ = pluginGlobs ?? throw new ArgumentNullException(nameof(pluginGlobs));
 
             foreach (var glob in pluginGlobs)
             {
@@ -89,10 +80,7 @@ public static class PluginBuilderExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="frameworkGlobs"/> is <see langword="null"/>.</exception>
         public void IncludeFrameworks(params string[] frameworkGlobs)
         {
-            if (frameworkGlobs is null)
-            {
-                throw new ArgumentNullException(nameof(frameworkGlobs));
-            }
+            _ = frameworkGlobs ?? throw new ArgumentNullException(nameof(frameworkGlobs));
 
             foreach (var glob in frameworkGlobs)
             {
@@ -107,10 +95,7 @@ public static class PluginBuilderExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="pluginGlobs"/> is null.</exception>
         public void IncludePlugins(params string[] pluginGlobs)
         {
-            if (pluginGlobs is null)
-            {
-                throw new ArgumentNullException(nameof(pluginGlobs));
-            }
+            _ = pluginGlobs ?? throw new ArgumentNullException(nameof(pluginGlobs));
 
             foreach (var glob in pluginGlobs)
             {
@@ -118,15 +103,16 @@ public static class PluginBuilderExtensions
             }
         }
 
-        /// <summary>Configures the plugin builder to require at least one plugin, optionally failing if no plugins are registered.</summary>
-        /// <param name="failIfNone">true to throw an exception if no plugins are registered; otherwise, false. The default is true.</param>
+        /// <summary>Configures the plugin builder to require at least one plugin.</summary>
         /// <exception cref="ArgumentNullException">Thrown if pluginBuilder is null.</exception>
-        public void RequirePlugins(bool failIfNone = true)
+        public void RequirePlugins() => pluginBuilder.RequirePlugins(failIfNone: true);
+
+        /// <summary>Configures whether the plugin builder requires at least one plugin.</summary>
+        /// <param name="failIfNone">true to throw an exception if no plugins are registered; otherwise, false.</param>
+        /// <exception cref="ArgumentNullException">Thrown if pluginBuilder is null.</exception>
+        public void RequirePlugins(bool failIfNone)
         {
-            if (pluginBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(pluginBuilder));
-            }
+            _ = pluginBuilder ?? throw new ArgumentNullException(nameof(pluginBuilder));
 
             pluginBuilder.FailIfNoPlugins = failIfNone;
         }

--- a/src/Extensions.Hosting.Plugins/PluginOrderAttribute.cs
+++ b/src/Extensions.Hosting.Plugins/PluginOrderAttribute.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.Plugins/PluginScanner.cs
+++ b/src/Extensions.Hosting.Plugins/PluginScanner.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -27,10 +27,7 @@ public static class PluginScanner
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="pluginAssembly"/> is null.</exception>
     public static IEnumerable<IPlugin> ByNamingConvention(Assembly pluginAssembly)
     {
-        if (pluginAssembly is null)
-        {
-            throw new ArgumentNullException(nameof(pluginAssembly));
-        }
+        _ = pluginAssembly ?? throw new ArgumentNullException(nameof(pluginAssembly));
 
         return ByNamingConventionCore(pluginAssembly);
     }
@@ -45,10 +42,7 @@ public static class PluginScanner
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="pluginAssembly"/> is null.</exception>
     public static IEnumerable<IPlugin> ScanForPluginInstances(Assembly pluginAssembly)
     {
-        if (pluginAssembly is null)
-        {
-            throw new ArgumentNullException(nameof(pluginAssembly));
-        }
+        _ = pluginAssembly ?? throw new ArgumentNullException(nameof(pluginAssembly));
 
         return ScanForPluginInstancesCore(pluginAssembly);
     }

--- a/src/Extensions.Hosting.ReactiveUI.Avalonia/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Avalonia/HostBuilderReactiveUiExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
@@ -58,14 +58,11 @@ public static class HostBuilderReactiveUiExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         public IHostApplicationBuilder ConfigureSplatForMicrosoftDependencyResolver()
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             hostBuilder.Services.UseMicrosoftDependencyResolver();
             var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                .WithRegistration(r => r.InitializeSplat())
+                .WithRegistration(static r => r.InitializeSplat())
                 .WithAvalonia();
             _ = reactiveUiBuilder.BuildApp();
             return hostBuilder;
@@ -82,11 +79,11 @@ public static class HostBuilderReactiveUiExtensions
         /// applications that utilize ReactiveUI and Splat for service location.</remarks>
         /// <returns>The same <see cref="IHostBuilder"/> instance so that additional configuration calls can be chained.</returns>
         public IHostBuilder ConfigureSplatForMicrosoftDependencyResolver() =>
-            hostBuilder.ConfigureServices((serviceCollection) =>
+            hostBuilder.ConfigureServices(static (serviceCollection) =>
             {
                 serviceCollection.UseMicrosoftDependencyResolver();
                 var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                    .WithRegistration(r => r.InitializeSplat())
+                    .WithRegistration(static r => r.InitializeSplat())
                     .WithAvalonia();
                 _ = reactiveUiBuilder.BuildApp();
             });

--- a/src/Extensions.Hosting.ReactiveUI.Maui/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Maui/HostBuilderReactiveUiExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
@@ -53,11 +53,11 @@ public static class HostBuilderReactiveUiExtensions
         /// <returns>The same <see cref="IHostApplicationBuilder"/> instance, enabling method chaining.</returns>
         public IHostApplicationBuilder ConfigureSplatForMicrosoftDependencyResolver()
         {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             hostBuilder.Services.UseMicrosoftDependencyResolver();
             var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                .WithRegistration(r => r.InitializeSplat())
+                .WithRegistration(static r => r.InitializeSplat())
                 .WithMaui();
             _ = reactiveUiBuilder.BuildApp();
             return hostBuilder;
@@ -74,11 +74,11 @@ public static class HostBuilderReactiveUiExtensions
         /// are properly integrated with the dependency injection system.</remarks>
         /// <returns>The same <see cref="IHostBuilder"/> instance so that additional configuration calls can be chained.</returns>
         public IHostBuilder ConfigureSplatForMicrosoftDependencyResolver() =>
-            hostBuilder.ConfigureServices((serviceCollection) =>
+            hostBuilder.ConfigureServices(static (serviceCollection) =>
             {
                 serviceCollection.UseMicrosoftDependencyResolver();
                 var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                    .WithRegistration(r => r.InitializeSplat())
+                    .WithRegistration(static r => r.InitializeSplat())
                     .WithMaui();
                 _ = reactiveUiBuilder.BuildApp();
             });

--- a/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
@@ -58,14 +58,11 @@ public static class HostBuilderReactiveUiExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         public IHostApplicationBuilder ConfigureSplatForMicrosoftDependencyResolver()
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             hostBuilder.Services.UseMicrosoftDependencyResolver();
             var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                .WithRegistration(r => r.InitializeSplat())
+                .WithRegistration(static r => r.InitializeSplat())
                 .WithWinForms();
             _ = reactiveUiBuilder.BuildApp();
             return hostBuilder;
@@ -82,11 +79,11 @@ public static class HostBuilderReactiveUiExtensions
         /// are available throughout the application.</remarks>
         /// <returns>The same <see cref="IHostBuilder"/> instance so that additional configuration calls can be chained.</returns>
         public IHostBuilder ConfigureSplatForMicrosoftDependencyResolver() =>
-            hostBuilder.ConfigureServices((serviceCollection) =>
+            hostBuilder.ConfigureServices(static (serviceCollection) =>
             {
                 serviceCollection.UseMicrosoftDependencyResolver();
                 var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                    .WithRegistration(r => r.InitializeSplat())
+                    .WithRegistration(static r => r.InitializeSplat())
                     .WithWinForms();
                 _ = reactiveUiBuilder.BuildApp();
             });

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
@@ -54,11 +54,11 @@ public static class HostBuilderReactiveUiExtensions
         /// <returns>The same <see cref="IHostApplicationBuilder"/> instance, enabling method chaining.</returns>
         public IHostApplicationBuilder ConfigureSplatForMicrosoftDependencyResolver()
         {
-            ArgumentNullException.ThrowIfNull(hostBuilder);
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             hostBuilder.Services.UseMicrosoftDependencyResolver();
             var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                .WithRegistration(r => r.InitializeSplat())
+                .WithRegistration(static r => r.InitializeSplat())
                 .WithWinUI();
             _ = reactiveUiBuilder.BuildApp();
             return hostBuilder;
@@ -76,11 +76,11 @@ public static class HostBuilderReactiveUiExtensions
         /// <returns>The same <see cref="IHostBuilder"/> instance, configured to use Microsoft.Extensions.DependencyInjection for
         /// Splat and ReactiveUI dependency resolution.</returns>
         public IHostBuilder ConfigureSplatForMicrosoftDependencyResolver() =>
-            hostBuilder.ConfigureServices((serviceCollection) =>
+            hostBuilder.ConfigureServices(static (serviceCollection) =>
             {
                 serviceCollection.UseMicrosoftDependencyResolver();
                 var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                    .WithRegistration(r => r.InitializeSplat())
+                    .WithRegistration(static r => r.InitializeSplat())
                     .WithWinUI();
                 _ = reactiveUiBuilder.BuildApp();
             });

--- a/src/Extensions.Hosting.ReactiveUI.Wpf.Reactive/Extensions.Hosting.ReactiveUI.Wpf.Reactive.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf.Reactive/Extensions.Hosting.ReactiveUI.Wpf.Reactive.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net462;net472;net48;net481;net8.0-windows10.0.19041;net9.0-windows10.0.19041;net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
     <PackageDescription>This extension adds reactive ReactiveUI support to generic host based WPF applications.</PackageDescription>
     <PackageId>CP.Extensions.Hosting.ReactiveUI.Wpf.Reactive</PackageId>
     <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
@@ -5,7 +5,8 @@
     <TargetFrameworks>net462;net472;net48;net481;net8.0-windows10.0.19041;net9.0-windows10.0.19041;net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageDescription>This extension adds ReactiveUI support to generic host based dotnet core 8.0 / 9.0 / 10.0 WPF applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc, together with this reactive MVVM framework.</PackageDescription>
+    <UseWPF>true</UseWPF>
+    <PackageDescription>This extension adds ReactiveUI support to generic host based dotnet core 8.0 / 9.0 / 10.0 / 11.0 WPF applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc, together with this reactive MVVM framework.</PackageDescription>
     <PackageId>CP.Extensions.Hosting.ReactiveUI.Wpf</PackageId>
   </PropertyGroup>
 

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
@@ -1,8 +1,11 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
 #if REACTIVE_SHIM
 using ReactiveUI.Reactive.Builder;
 #else
@@ -17,22 +20,40 @@ namespace ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
 namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
 #endif
 
-/// <summary>Provides extension methods for configuring ReactiveUI with Microsoft dependency injection in .NET host builder scenarios.</summary>
+/// <summary>
+/// Provides extension methods for configuring ReactiveUI with Microsoft dependency injection in .NET host builder
+/// scenarios.
+/// </summary>
 /// <remarks>These extension methods enable seamless integration of ReactiveUI and Splat with the Microsoft
 /// dependency injection system, supporting both generic host and application host builder patterns. Use these methods
 /// to set up ReactiveUI infrastructure when building WPF or other .NET applications that rely on dependency
 /// injection.</remarks>
 public static class HostBuilderReactiveUiExtensions
 {
+    /// <summary>Configures ReactiveUI, Splat, and the hosted WPF dispatcher binding.</summary>
+    /// <param name="services">The service collection to configure.</param>
+    private static void ConfigureReactiveUi(IServiceCollection services)
+    {
+        services.UseMicrosoftDependencyResolver();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IWpfService>(new ReactiveUiWpfSchedulerService()));
+        var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
+            .WithRegistration(static r => r.InitializeSplat())
+            .WithWpf();
+        _ = reactiveUiBuilder.BuildApp();
+    }
+
     /// <summary>Provides extension members for this receiver.</summary>
     /// <param name="host">The receiver instance.</param>
     extension(IHost host)
     {
-        /// <summary>Configures the Microsoft dependency resolver and invokes a custom container factory using the host's service provider.</summary>
+        /// <summary>Configures dependency resolution and invokes the custom container factory.</summary>
         /// <remarks>This method enables integration with the Microsoft dependency injection system and allows
         /// further customization of the service container. The method returns the same host instance to support fluent
         /// configuration.</remarks>
-        /// <param name="containerFactory">An action that receives the host's service provider for additional container configuration. Cannot be null.</param>
+        /// <param name="containerFactory">
+        /// An action that receives the host's service provider for additional container configuration. Cannot be null.
+        /// </param>
         /// <returns>The original host instance after configuration, or null if the input host is null.</returns>
         public IHost? MapSplatLocator(Action<IServiceProvider?> containerFactory)
         {
@@ -47,25 +68,20 @@ public static class HostBuilderReactiveUiExtensions
     /// <param name="hostBuilder">The receiver instance.</param>
     extension(IHostApplicationBuilder hostBuilder)
     {
-        /// <summary>Configures Splat to use the Microsoft dependency resolver within the specified host application builder.</summary>
+        /// <summary>Configures Splat to use Microsoft dependency injection for the host application builder.</summary>
         /// <remarks>This method enables Splat and ReactiveUI to resolve dependencies using the
         /// Microsoft.Extensions.DependencyInjection container. It should be called during application startup before
         /// building the host.</remarks>
-        /// <returns>The same instance of <see cref="IHostApplicationBuilder"/> with Splat configured to use the Microsoft dependency
-        /// resolver.</returns>
+        /// <returns>
+        /// The same instance of <see cref="IHostApplicationBuilder"/> with Splat configured to use the Microsoft
+        /// dependency resolver.
+        /// </returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         public IHostApplicationBuilder ConfigureSplatForMicrosoftDependencyResolver()
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
-            hostBuilder.Services.UseMicrosoftDependencyResolver();
-            var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                .WithRegistration(r => r.InitializeSplat())
-                .WithWpf();
-            _ = reactiveUiBuilder.BuildApp();
+            ConfigureReactiveUi(hostBuilder.Services);
             return hostBuilder;
         }
     }
@@ -74,19 +90,17 @@ public static class HostBuilderReactiveUiExtensions
     /// <param name="hostBuilder">The receiver instance.</param>
     extension(IHostBuilder hostBuilder)
     {
-        /// <summary>Configures the specified host builder to use Splat with the Microsoft dependency resolver for dependency injection in a WPF application.</summary>
+        /// <summary>
+        /// Configures the specified host builder to use Splat with the Microsoft dependency resolver for dependency
+        /// injection in a WPF application.
+        /// </summary>
         /// <remarks>This method sets up Splat and ReactiveUI to use the Microsoft dependency resolver, enabling
         /// seamless integration with the application's dependency injection system. It is intended for use in WPF
         /// applications that utilize ReactiveUI and Splat for service location.</remarks>
-        /// <returns>The same <see cref="IHostBuilder"/> instance so that additional configuration calls can be chained.</returns>
+        /// <returns>
+        /// The same <see cref="IHostBuilder"/> instance so that additional configuration calls can be chained.
+        /// </returns>
         public IHostBuilder ConfigureSplatForMicrosoftDependencyResolver() =>
-            hostBuilder.ConfigureServices((serviceCollection) =>
-            {
-                serviceCollection.UseMicrosoftDependencyResolver();
-                var reactiveUiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
-                    .WithRegistration(r => r.InitializeSplat())
-                    .WithWpf();
-                _ = reactiveUiBuilder.BuildApp();
-            });
+            hostBuilder.ConfigureServices(ConfigureReactiveUi);
     }
 }

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/ReactiveUiWpfSchedulerService.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/ReactiveUiWpfSchedulerService.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+#if REACTIVE_SHIM
+using DispatcherSequencer = ReactiveUI.Primitives.Reactive.Concurrency.DispatcherSequencer;
+using RxSchedulers = ReactiveUI.Reactive.RxSchedulers;
+#else
+using DispatcherSequencer = ReactiveUI.Primitives.Concurrency.DispatcherSequencer;
+using RxSchedulers = ReactiveUI.RxSchedulers;
+#endif
+
+#if REACTIVE_SHIM
+namespace ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
+namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
+
+/// <summary>Binds ReactiveUI scheduling to the dispatcher owned by the hosted WPF application.</summary>
+internal sealed class ReactiveUiWpfSchedulerService : IWpfService
+{
+    /// <inheritdoc />
+    public void Initialize(Application application)
+    {
+        _ = application ?? throw new ArgumentNullException(nameof(application));
+
+        RxSchedulers.MainThreadScheduler = new DispatcherSequencer(application.Dispatcher);
+    }
+}

--- a/src/Extensions.Hosting.SingleInstance/HostBuilderApplicationExtensions.cs
+++ b/src/Extensions.Hosting.SingleInstance/HostBuilderApplicationExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -40,12 +40,9 @@ public static class HostBuilderApplicationExtensions
     /// <summary>Adds the mutex services to the service collection.</summary>
     /// <param name="services">The service collection to update.</param>
     /// <param name="mutexBuilder">The configured mutex builder.</param>
-    private static void AddMutexServices(IServiceCollection services, IMutexBuilder mutexBuilder)
-    {
-        _ = services
+    private static void AddMutexServices(IServiceCollection services, IMutexBuilder mutexBuilder) => _ = services
             .AddSingleton(mutexBuilder)
             .AddHostedService<MutexLifetimeService>();
-    }
 
     /// <summary>Provides extension members for this receiver.</summary>
     /// <param name="hostBuilder">The receiver instance.</param>
@@ -62,10 +59,7 @@ public static class HostBuilderApplicationExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         public IHostApplicationBuilder ConfigureSingleInstance(Action<IMutexBuilder> configureAction)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             if (!TryRetrieveMutexBuilder(hostBuilder.Properties, out var mutexBuilder))
             {
@@ -99,10 +93,7 @@ public static class HostBuilderApplicationExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         public IHostBuilder ConfigureSingleInstance(Action<IMutexBuilder> configureAction)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             return hostBuilder.ConfigureServices((_, serviceCollection) =>
             {

--- a/src/Extensions.Hosting.SingleInstance/IMutexBuilder.cs
+++ b/src/Extensions.Hosting.SingleInstance/IMutexBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.SingleInstance/Internal/MutexBuilder.cs
+++ b/src/Extensions.Hosting.SingleInstance/Internal/MutexBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.SingleInstance/Internal/MutexLifetimeService.cs
+++ b/src/Extensions.Hosting.SingleInstance/Internal/MutexLifetimeService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -18,15 +18,19 @@ namespace ReactiveMarbles.Extensions.Hosting.AppServices.Internal;
 /// <param name="hostEnvironment">The host environment information for the current application instance.</param>
 /// <param name="hostApplicationLifetime">The application lifetime control used to manage startup and shutdown events.</param>
 /// <param name="mutexBuilder">The mutex builder that provides configuration for creating and identifying the application mutex.</param>
-internal sealed class MutexLifetimeService(ILogger<MutexLifetimeService> logger, IHostEnvironment hostEnvironment, IHostApplicationLifetime hostApplicationLifetime, IMutexBuilder mutexBuilder) : IHostedService
+internal sealed class MutexLifetimeService(
+    ILogger<MutexLifetimeService> logger,
+    IHostEnvironment hostEnvironment,
+    IHostApplicationLifetime hostApplicationLifetime,
+    IMutexBuilder mutexBuilder) : IHostedService
 {
     /// <summary>Logs that another application instance is already running.</summary>
     private static readonly Action<ILogger, string, Exception?> _applicationAlreadyRunning =
-        LoggerMessage.Define<string>(LogLevel.Debug, new EventId(1, nameof(_applicationAlreadyRunning)), "Application {ApplicationName} already running, stopping application.");
+        LoggerMessage.Define<string>(LogLevel.Debug, new(1, nameof(_applicationAlreadyRunning)), "Application {ApplicationName} already running, stopping application.");
 
     /// <summary>Logs that the mutex is closing during application stopping.</summary>
     private static readonly Action<ILogger, Exception?> _closingMutex =
-        LoggerMessage.Define(LogLevel.Information, new EventId(2, nameof(_closingMutex)), "OnStopping has been called, closing mutex.");
+        LoggerMessage.Define(LogLevel.Information, new(2, nameof(_closingMutex)), "OnStopping has been called, closing mutex.");
 
     /// <summary>Stores the logger value.</summary>
     private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/Extensions.Hosting.SingleInstance/ResourceMutex.cs
+++ b/src/Extensions.Hosting.SingleInstance/ResourceMutex.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -21,45 +21,54 @@ namespace ReactiveMarbles.Extensions.Hosting.AppServices;
 /// ResourceMutex instance.</remarks>
 public sealed class ResourceMutex : IDisposable
 {
+    /// <summary>Stores the default owner-thread join timeout in seconds.</summary>
+    private const int DefaultOwnerThreadJoinTimeoutSeconds = 5;
+
+    /// <summary>Stores the mutex acquisition timeout in milliseconds.</summary>
+    private const int MutexWaitTimeoutMilliseconds = 2000;
+
     /// <summary>Logs a mutex acquisition attempt.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _tryingToGetMutex =
-        LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(1, nameof(_tryingToGetMutex)), "{ResourceName} is trying to get Mutex {MutexId}");
+        LoggerMessage.Define<string, string>(LogLevel.Debug, new(1, nameof(_tryingToGetMutex)), "{ResourceName} is trying to get Mutex {MutexId}");
 
     /// <summary>Logs a mutex owner release timeout.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _mutexOwnerReleaseTimedOut =
-        LoggerMessage.Define<string, string>(LogLevel.Warning, new EventId(2, nameof(_mutexOwnerReleaseTimedOut)), "Timed out waiting for mutex owner thread to release Mutex {MutexId} for {ResourceName}");
+        LoggerMessage.Define<string, string>(LogLevel.Warning, new(2, nameof(_mutexOwnerReleaseTimedOut)), "Timed out waiting for mutex owner thread to release Mutex {MutexId} for {ResourceName}");
 
     /// <summary>Logs that a mutex is already in use.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _mutexAlreadyInUse =
-        LoggerMessage.Define<string, string>(LogLevel.Warning, new EventId(3, nameof(_mutexAlreadyInUse)), "Mutex {MutexId} is already in use and couldn't be locked for the caller {ResourceName}");
+        LoggerMessage.Define<string, string>(LogLevel.Warning, new(3, nameof(_mutexAlreadyInUse)), "Mutex {MutexId} is already in use and couldn't be locked for the caller {ResourceName}");
 
     /// <summary>Logs that an existing mutex was claimed.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _mutexClaimed =
-        LoggerMessage.Define<string, string>(LogLevel.Information, new EventId(4, nameof(_mutexClaimed)), "{ResourceName} has claimed the mutex {MutexId}");
+        LoggerMessage.Define<string, string>(LogLevel.Information, new(4, nameof(_mutexClaimed)), "{ResourceName} has claimed the mutex {MutexId}");
 
     /// <summary>Logs that a new mutex was created and claimed.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _mutexCreatedAndClaimed =
-        LoggerMessage.Define<string, string>(LogLevel.Information, new EventId(5, nameof(_mutexCreatedAndClaimed)), "{ResourceName} has created & claimed the mutex {MutexId}");
+        LoggerMessage.Define<string, string>(LogLevel.Information, new(5, nameof(_mutexCreatedAndClaimed)), "{ResourceName} has created & claimed the mutex {MutexId}");
 
     /// <summary>Logs that an abandoned mutex was recovered.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _abandonedMutexRecovered =
-        LoggerMessage.Define<string, string>(LogLevel.Warning, new EventId(6, nameof(_abandonedMutexRecovered)), "{ResourceName} didn't cleanup correctly, but we got the mutex {MutexId}.");
+        LoggerMessage.Define<string, string>(LogLevel.Warning, new(6, nameof(_abandonedMutexRecovered)), "{ResourceName} didn't cleanup correctly, but we got the mutex {MutexId}.");
 
     /// <summary>Logs that mutex access was unauthorized.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _mutexUnauthorized =
-        LoggerMessage.Define<string, string>(LogLevel.Error, new EventId(7, nameof(_mutexUnauthorized)), "{ResourceName} is most likely already running for a different user in the same session, can't create/get mutex {MutexId} due to error.");
+        LoggerMessage.Define<string, string>(
+            LogLevel.Error,
+            new(7, nameof(_mutexUnauthorized)),
+            "{ResourceName} is most likely already running for a different user in the same session, can't create/get mutex {MutexId} due to error.");
 
     /// <summary>Logs that mutex acquisition failed.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _mutexAcquisitionFailed =
-        LoggerMessage.Define<string, string>(LogLevel.Error, new EventId(8, nameof(_mutexAcquisitionFailed)), "Problem obtaining the Mutex {MutexId} for {ResourceName}, assuming it was already taken!");
+        LoggerMessage.Define<string, string>(LogLevel.Error, new(8, nameof(_mutexAcquisitionFailed)), "Problem obtaining the Mutex {MutexId} for {ResourceName}, assuming it was already taken!");
 
     /// <summary>Logs that a mutex was released.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _mutexReleased =
-        LoggerMessage.Define<string, string>(LogLevel.Information, new EventId(9, nameof(_mutexReleased)), "Released Mutex {MutexId} for {ResourceName}");
+        LoggerMessage.Define<string, string>(LogLevel.Information, new(9, nameof(_mutexReleased)), "Released Mutex {MutexId} for {ResourceName}");
 
     /// <summary>Logs that mutex release failed.</summary>
     private static readonly Action<ILogger, string, string, Exception?> _mutexReleaseFailed =
-        LoggerMessage.Define<string, string>(LogLevel.Error, new EventId(10, nameof(_mutexReleaseFailed)), "Error releasing Mutex {MutexId} for {ResourceName}");
+        LoggerMessage.Define<string, string>(LogLevel.Error, new(10, nameof(_mutexReleaseFailed)), "Error releasing Mutex {MutexId} for {ResourceName}");
 
     /// <summary>Stores the logger value.</summary>
     private readonly ILogger _logger;
@@ -125,12 +134,41 @@ public sealed class ResourceMutex : IDisposable
     /// <param name="mutexId">The unique identifier for the mutex. Used to distinguish this mutex from others.</param>
     /// <param name="resourceName">The name of the resource associated with the mutex. If null, the mutex identifier is used as the resource name.</param>
     private ResourceMutex(ILogger logger, string mutexId, string? resourceName = null)
-        : this(logger, mutexId, resourceName, CreateMutex, static mutex => mutex.ReleaseMutex(), TimeSpan.FromSeconds(5), null)
+        : this(
+            logger,
+            mutexId,
+            resourceName,
+            CreateMutex,
+            static mutex => mutex.ReleaseMutex(),
+            TimeSpan.FromSeconds(DefaultOwnerThreadJoinTimeoutSeconds))
     {
     }
 
     /// <summary>Gets a value indicating whether the object is locked.</summary>
     public bool IsLocked { get; private set; }
+
+    /// <summary>Creates and acquires a local resource mutex.</summary>
+    /// <param name="logger">The logger to use for diagnostic messages. If null, a default logger is created.</param>
+    /// <param name="mutexId">The unique identifier for the mutex.</param>
+    /// <returns>An acquired resource mutex.</returns>
+    public static ResourceMutex Create(ILogger? logger, string? mutexId) =>
+        Create(logger, mutexId, resourceName: null, global: false);
+
+    /// <summary>Creates and acquires a local resource mutex with a display name.</summary>
+    /// <param name="logger">The logger to use for diagnostic messages. If null, a default logger is created.</param>
+    /// <param name="mutexId">The unique identifier for the mutex.</param>
+    /// <param name="resourceName">The name of the protected resource.</param>
+    /// <returns>An acquired resource mutex.</returns>
+    public static ResourceMutex Create(ILogger? logger, string? mutexId, string? resourceName) =>
+        Create(logger, mutexId, resourceName, global: false);
+
+    /// <summary>Creates and acquires a local or global resource mutex.</summary>
+    /// <param name="logger">The logger to use for diagnostic messages. If null, a default logger is created.</param>
+    /// <param name="mutexId">The unique identifier for the mutex.</param>
+    /// <param name="global">true to create a global mutex; false to create a local mutex.</param>
+    /// <returns>An acquired resource mutex.</returns>
+    public static ResourceMutex Create(ILogger? logger, string? mutexId, bool global) =>
+        Create(logger, mutexId, resourceName: null, global);
 
     /// <summary>Creates and acquires a new resource mutex for synchronizing access to a named resource across processes.</summary>
     /// <remarks>The returned ResourceMutex is locked upon creation. Callers are responsible for releasing the
@@ -143,7 +181,7 @@ public sealed class ResourceMutex : IDisposable
     /// <returns>A ResourceMutex instance that is already acquired and can be used to synchronize access to the specified
     /// resource.</returns>
     /// <exception cref="ArgumentException">Thrown if mutexId is null, empty, or consists only of white-space characters.</exception>
-    public static ResourceMutex Create(ILogger? logger, string? mutexId, string? resourceName = null, bool global = false)
+    public static ResourceMutex Create(ILogger? logger, string? mutexId, string? resourceName, bool global)
     {
         var resourceMutexId = !string.IsNullOrWhiteSpace(mutexId)
             ? mutexId
@@ -167,11 +205,7 @@ public sealed class ResourceMutex : IDisposable
     {
         _tryingToGetMutex(_logger, _resourceName, _mutexId, null);
 
-        _ownerThread = new(AcquireAndHoldMutex)
-        {
-            IsBackground = true,
-            Name = $"ResourceMutex-{_resourceName}",
-        };
+        _ownerThread = new(AcquireAndHoldMutex) { IsBackground = true, Name = $"ResourceMutex-{_resourceName}", };
         _ownerThread.Start();
 
         // Wait until the dedicated thread has finished the acquire attempt.
@@ -246,7 +280,7 @@ public sealed class ResourceMutex : IDisposable
             // 2) if the mutex wasn't created new get the right to it, this returns false if it's already locked
             if (!createdNew)
             {
-                IsLocked = applicationMutex.WaitOne(2000, false);
+                IsLocked = applicationMutex.WaitOne(MutexWaitTimeoutMilliseconds);
                 if (!IsLocked)
                 {
                     _mutexAlreadyInUse(_logger, _mutexId, _resourceName, null);
@@ -295,6 +329,13 @@ public sealed class ResourceMutex : IDisposable
             return;
         }
 
+        HoldAndReleaseMutex(applicationMutex);
+    }
+
+    /// <summary>Waits for the release signal and releases the acquired mutex on its owning thread.</summary>
+    /// <param name="applicationMutex">The acquired application mutex.</param>
+    private void HoldAndReleaseMutex(Mutex? applicationMutex)
+    {
         // Hold until Dispose() signals that we should release.
         _releaseSignal.Wait();
         _beforeReleaseMutex?.Invoke();

--- a/src/Extensions.Hosting.WinForms/HostBuilderWinFormsExtensions.cs
+++ b/src/Extensions.Hosting.WinForms/HostBuilderWinFormsExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -11,25 +11,22 @@ using ReactiveMarbles.Extensions.Hosting.WinForms.Internals;
 
 namespace ReactiveMarbles.Extensions.Hosting.WinForms;
 
-/// <summary>Provides extension methods for configuring and integrating Windows Forms (WinForms) application lifetime and services with .NET Generic Host builders.</summary>
-/// <remarks>These extensions enable seamless integration of WinForms applications with the .NET hosting model,
-/// allowing developers to configure WinForms services, specify the main form (shell), and control application lifetime
-/// in relation to the host. Methods are provided for both IHostBuilder and IHostApplicationBuilder to support different
-/// hosting scenarios. Use these extensions to register WinForms components, configure the application context, and
-/// ensure proper startup and shutdown coordination between the WinForms UI and the host.</remarks>
+/// <summary>Provides extension methods for integrating Windows Forms applications with .NET Generic Host builders.</summary>
+/// <remarks>
+/// These extensions register WinForms services, configure the main form, and coordinate the UI lifetime with the host.
+/// </remarks>
 public static class HostBuilderWinFormsExtensions
 {
-    /// <summary>Stores the win forms context key value.</summary>
+    /// <summary>Stores the WinForms context key.</summary>
     private const string WinFormsContextKey = nameof(WinFormsContext);
 
     /// <summary>Attempts to retrieve an existing Windows Forms context from the specified property dictionary.</summary>
-    /// <remarks>If a Windows Forms context does not exist in the dictionary, this method creates a new
-    /// context, adds it to the dictionary, and returns it in the out parameter.</remarks>
     /// <param name="properties">The property dictionary used to store the context.</param>
-    /// <param name="winFormsContext">When this method returns, contains the retrieved Windows Forms context if found; otherwise, a new context
-    /// instance.</param>
-    /// <returns>true if an existing Windows Forms context was found in the dictionary; otherwise, false.</returns>
-    private static bool TryRetrieveWinFormsContext(IDictionary<object, object> properties, out IWinFormsContext winFormsContext)
+    /// <param name="winFormsContext">The existing or newly created context.</param>
+    /// <returns><see langword="true"/> when an existing context was found; otherwise, <see langword="false"/>.</returns>
+    private static bool TryRetrieveWinFormsContext(
+        IDictionary<object, object> properties,
+        out IWinFormsContext winFormsContext)
     {
         if (properties.TryGetValue(WinFormsContextKey, out var winFormsContextAsObject))
         {
@@ -46,44 +43,35 @@ public static class HostBuilderWinFormsExtensions
     /// <param name="hostBuilder">The receiver instance.</param>
     extension(IHostApplicationBuilder hostBuilder)
     {
-        /// <summary>Enables WinForms lifetime management for the application, allowing the host to be controlled by the WinForms message loop.</summary>
-        /// <remarks>When WinForms lifetime is enabled, the application's lifetime is tied to the WinForms message
-        /// loop. This is typically used in WinForms applications to ensure that the host shuts down when the main form
-        /// closes.</remarks>
-        /// <returns>The same instance of <see cref="IHostApplicationBuilder"/> for chaining further configuration.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
+        /// <summary>Enables WinForms lifetime management for the application.</summary>
+        /// <returns>The same host application builder.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="hostBuilder"/> is null.</exception>
         public IHostApplicationBuilder UseWinFormsLifetime()
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             _ = TryRetrieveWinFormsContext(hostBuilder.Properties, out var winFormsContext);
             winFormsContext.IsLifetimeLinked = true;
             return hostBuilder;
         }
 
-        /// <summary>Configures WinForms support for the specified host application builder and optionally allows additional WinForms-specific configuration.</summary>
-        /// <remarks>This method registers the necessary services to enable WinForms integration in a generic host
-        /// application. If called multiple times, WinForms services are only registered once. Use the <paramref
-        /// name="configureAction"/> parameter to customize the WinForms context as needed.</remarks>
-        /// <param name="configureAction">An optional delegate to configure the WinForms context after it is created. If null, no additional configuration
-        /// is performed.</param>
-        /// <returns>The same instance of <see cref="IHostApplicationBuilder"/> with WinForms services configured.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
-        public IHostApplicationBuilder ConfigureWinForms(Action<IWinFormsContext>? configureAction = null)
+        /// <summary>Configures WinForms support without additional context configuration.</summary>
+        /// <returns>The same host application builder.</returns>
+        public IHostApplicationBuilder ConfigureWinForms() => hostBuilder.ConfigureWinForms(null);
+
+        /// <summary>Configures WinForms support and applies the supplied context configuration.</summary>
+        /// <param name="configureAction">The optional context configuration.</param>
+        /// <returns>The same host application builder.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="hostBuilder"/> is null.</exception>
+        public IHostApplicationBuilder ConfigureWinForms(Action<IWinFormsContext>? configureAction)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             if (!TryRetrieveWinFormsContext(hostBuilder.Properties, out var winFormsContext))
             {
                 _ = hostBuilder.Services
                     .AddSingleton(winFormsContext)
-                    .AddSingleton(serviceProvider => new WinFormsThread(serviceProvider))
+                    .AddSingleton(static serviceProvider => new WinFormsThread(serviceProvider))
                     .AddHostedService<WinFormsHostedService>();
             }
 
@@ -91,102 +79,98 @@ public static class HostBuilderWinFormsExtensions
             return hostBuilder;
         }
 
-        /// <summary>Configures WinForms support for the application and registers the specified main form type as a singleton service.</summary>
-        /// <remarks>If <typeparamref name="TView"/> also implements <see cref="IWinFormsShell"/>, it is
-        /// registered as a singleton service for that interface as well. This enables dependency injection of the main form
-        /// and shell interface throughout the application.</remarks>
-        /// <typeparam name="TView">The type of the main form to register. Must inherit from <see cref="Form"/>.</typeparam>
-        /// <param name="configureAction">An optional delegate to configure additional WinForms services or settings. Can be <see langword="null"/>.</param>
-        /// <returns>The same <see cref="IHostApplicationBuilder"/> instance for chaining.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is <see langword="null"/>.</exception>
-        public IHostApplicationBuilder ConfigureWinForms<TView>(Action<IWinFormsContext>? configureAction = null)
+        /// <summary>Configures WinForms and registers the specified main form type.</summary>
+        /// <typeparam name="TView">The main form type.</typeparam>
+        /// <returns>The same host application builder.</returns>
+        public IHostApplicationBuilder ConfigureWinForms<TView>()
+            where TView : Form =>
+            hostBuilder.ConfigureWinForms<TView>(null);
+
+        /// <summary>Configures WinForms, registers the specified main form type, and configures the context.</summary>
+        /// <typeparam name="TView">The main form type.</typeparam>
+        /// <param name="configureAction">The optional context configuration.</param>
+        /// <returns>The same host application builder.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="hostBuilder"/> is null.</exception>
+        public IHostApplicationBuilder ConfigureWinForms<TView>(Action<IWinFormsContext>? configureAction)
             where TView : Form
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
-
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
             _ = hostBuilder.ConfigureWinForms(configureAction);
-
             _ = hostBuilder.Services.AddSingleton<TView>();
 
-            // Check if it also implements IWinFormsShell so we can register it as this
             var viewType = typeof(TView);
             var shellInterfaceType = typeof(IWinFormsShell);
             if (shellInterfaceType.IsAssignableFrom(viewType))
             {
-                _ = hostBuilder.Services.AddSingleton(shellInterfaceType, serviceProvider => serviceProvider.GetRequiredService<TView>());
+                _ = hostBuilder.Services.AddSingleton(
+                    shellInterfaceType,
+                    static serviceProvider => serviceProvider.GetRequiredService<TView>());
             }
 
             return hostBuilder;
         }
 
-        /// <summary>Configures the WinForms shell for the application using the specified shell form type.</summary>
-        /// <typeparam name="TShell">The type of the main shell form to use for the application. Must inherit from Form and implement IWinFormsShell.</typeparam>
-        /// <returns>The same IHostApplicationBuilder instance for chaining further configuration.</returns>
+        /// <summary>Configures the specified WinForms shell as the main form.</summary>
+        /// <typeparam name="TShell">The shell form type.</typeparam>
+        /// <returns>The same host application builder.</returns>
         public IHostApplicationBuilder ConfigureWinFormsShell<TShell>()
-            where TShell : Form, IWinFormsShell
-            => hostBuilder.ConfigureWinForms<TShell>();
+            where TShell : Form, IWinFormsShell =>
+            hostBuilder.ConfigureWinForms<TShell>();
     }
 
     /// <summary>Provides extension members for this receiver.</summary>
     /// <param name="hostBuilder">The receiver instance.</param>
     extension(IHostBuilder hostBuilder)
     {
-        /// <summary>Configures the host to use Windows Forms lifetime management, enabling the application to start and stop in coordination with the WinForms message loop.</summary>
-        /// <remarks>This method links the application's lifetime to the Windows Forms message loop, so the host
-        /// will start when the message loop begins and stop when it ends. Use this method when building WinForms
-        /// applications that require integration with the generic host infrastructure.</remarks>
-        /// <returns>The same instance of <see cref="IHostBuilder"/> for chaining further configuration, or null if <paramref
-        /// name="hostBuilder"/> is null.</returns>
+        /// <summary>Enables WinForms lifetime management for the host.</summary>
+        /// <returns>The configured host builder, or null when the receiver is null.</returns>
         public IHostBuilder? UseWinFormsLifetime() =>
-            hostBuilder?.ConfigureServices((context, services) =>
+            hostBuilder?.ConfigureServices((_, _) =>
             {
                 _ = TryRetrieveWinFormsContext(hostBuilder.Properties, out var winFormsContext);
                 winFormsContext.IsLifetimeLinked = true;
             });
 
-        /// <summary>Configures WinForms support for the specified host builder, enabling integration of Windows Forms message loop and services into the application's hosting environment.</summary>
-        /// <remarks>This method registers the necessary services to run a Windows Forms message loop within a
-        /// generic host. Call this method before building the host to ensure WinForms integration is available throughout
-        /// the application's lifetime.</remarks>
-        /// <param name="configureAction">An optional delegate to further configure the WinForms context. If null, no additional configuration is
-        /// performed.</param>
-        /// <returns>The same instance of <see cref="IHostBuilder"/> with WinForms services configured, or null if <paramref
-        /// name="hostBuilder"/> is null.</returns>
-        public IHostBuilder? ConfigureWinForms(Action<IWinFormsContext>? configureAction = null) =>
-            hostBuilder?.ConfigureServices((context, serviceCollection) =>
+        /// <summary>Configures WinForms support without additional context configuration.</summary>
+        /// <returns>The configured host builder, or null when the receiver is null.</returns>
+        public IHostBuilder? ConfigureWinForms() => hostBuilder?.ConfigureWinForms(null);
+
+        /// <summary>Configures WinForms support and applies the supplied context configuration.</summary>
+        /// <param name="configureAction">The optional context configuration.</param>
+        /// <returns>The configured host builder, or null when the receiver is null.</returns>
+        public IHostBuilder? ConfigureWinForms(Action<IWinFormsContext>? configureAction) =>
+            hostBuilder?.ConfigureServices((hostBuilderContext, serviceCollection) =>
             {
                 if (!TryRetrieveWinFormsContext(hostBuilder.Properties, out var winFormsContext))
                 {
                     _ = serviceCollection
                         .AddSingleton(winFormsContext)
-                        .AddSingleton(serviceProvider => new WinFormsThread(serviceProvider))
+                        .AddSingleton(static serviceProvider => new WinFormsThread(serviceProvider))
                         .AddHostedService<WinFormsHostedService>();
                 }
 
                 configureAction?.Invoke(winFormsContext);
             });
 
-        /// <summary>Configures WinForms support for the host builder and registers the specified main view form as a singleton service.</summary>
-        /// <remarks>If <typeparamref name="TView"/> also implements <see cref="IWinFormsShell"/>, it is
-        /// registered as a singleton service for that interface as well. This method enables dependency injection and
-        /// configuration for WinForms applications using the generic host.</remarks>
-        /// <typeparam name="TView">The type of the main WinForms form to register. Must inherit from <see cref="Form"/>.</typeparam>
-        /// <param name="configureAction">An optional action to further configure the WinForms context. May be <see langword="null"/>.</param>
-        /// <returns>The same <see cref="IHostBuilder"/> instance for chaining, or <see langword="null"/> if <paramref
-        /// name="hostBuilder"/> is <see langword="null"/>.</returns>
-        public IHostBuilder? ConfigureWinForms<TView>(Action<IWinFormsContext>? configureAction = null)
-            where TView : Form
-            =>
+        /// <summary>Configures WinForms and registers the specified main form type.</summary>
+        /// <typeparam name="TView">The main form type.</typeparam>
+        /// <returns>The configured host builder, or null when the receiver is null.</returns>
+        public IHostBuilder? ConfigureWinForms<TView>()
+            where TView : Form =>
+            hostBuilder?.ConfigureWinForms<TView>(null);
+
+        /// <summary>Configures WinForms, registers the specified main form type, and configures the context.</summary>
+        /// <typeparam name="TView">The main form type.</typeparam>
+        /// <param name="configureAction">The optional context configuration.</param>
+        /// <returns>The configured host builder, or null when the receiver is null.</returns>
+        public IHostBuilder? ConfigureWinForms<TView>(Action<IWinFormsContext>? configureAction)
+            where TView : Form =>
             hostBuilder?
                 .ConfigureWinForms(configureAction)?
-                .ConfigureServices((context, serviceCollection) =>
+                .ConfigureServices(static (hostBuilderContext, serviceCollection) =>
                 {
                     _ = serviceCollection.AddSingleton<TView>();
 
-                    // Check if it also implements IWinFormsShell so we can register it as this
                     var viewType = typeof(TView);
                     var shellInterfaceType = typeof(IWinFormsShell);
                     if (!shellInterfaceType.IsAssignableFrom(viewType))
@@ -194,16 +178,16 @@ public static class HostBuilderWinFormsExtensions
                         return;
                     }
 
-                    _ = serviceCollection.AddSingleton(shellInterfaceType, serviceProvider => serviceProvider.GetRequiredService<TView>());
+                    _ = serviceCollection.AddSingleton(
+                        shellInterfaceType,
+                        static serviceProvider => serviceProvider.GetRequiredService<TView>());
                 });
 
-        /// <summary>Configures the specified host builder to use a WinForms shell of the given type as the application's main window.</summary>
-        /// <typeparam name="TShell">The type of the WinForms shell form to use as the application's main window. Must inherit from <see
-        /// cref="Form"/> and implement <see cref="IWinFormsShell"/>.</typeparam>
-        /// <returns>The same <see cref="IHostBuilder"/> instance for chaining, or <see langword="null"/> if <paramref
-        /// name="hostBuilder"/> is null.</returns>
+        /// <summary>Configures the specified WinForms shell as the main form.</summary>
+        /// <typeparam name="TShell">The shell form type.</typeparam>
+        /// <returns>The configured host builder, or null when the receiver is null.</returns>
         public IHostBuilder? ConfigureWinFormsShell<TShell>()
-            where TShell : Form, IWinFormsShell
-            => hostBuilder?.ConfigureWinForms<TShell>();
+            where TShell : Form, IWinFormsShell =>
+            hostBuilder?.ConfigureWinForms<TShell>();
     }
 }

--- a/src/Extensions.Hosting.WinForms/IWinFormsContext.cs
+++ b/src/Extensions.Hosting.WinForms/IWinFormsContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows.Threading;

--- a/src/Extensions.Hosting.WinForms/IWinFormsService.cs
+++ b/src/Extensions.Hosting.WinForms/IWinFormsService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace ReactiveMarbles.Extensions.Hosting.WinForms;

--- a/src/Extensions.Hosting.WinForms/IWinFormsShell.cs
+++ b/src/Extensions.Hosting.WinForms/IWinFormsShell.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.ComponentModel;

--- a/src/Extensions.Hosting.WinForms/Internals/MultiShellContext.cs
+++ b/src/Extensions.Hosting.WinForms/Internals/MultiShellContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Threading;

--- a/src/Extensions.Hosting.WinForms/Internals/WinFormsContext.cs
+++ b/src/Extensions.Hosting.WinForms/Internals/WinFormsContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows.Threading;

--- a/src/Extensions.Hosting.WinForms/Internals/WinFormsThread.cs
+++ b/src/Extensions.Hosting.WinForms/Internals/WinFormsThread.cs
@@ -1,9 +1,9 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.Threading;
 using System.Windows.Forms;
 using System.Windows.Threading;
@@ -49,28 +49,35 @@ public class WinFormsThread(IServiceProvider serviceProvider) : BaseUiThread<IWi
         }
 
         // Run the WinForms application in this thread which was specifically created for it, with the specified shell
-        var shells = ServiceProvider.GetServices<IWinFormsShell>().Cast<Form>().ToArray();
+        var shells = new List<Form>();
+        foreach (var shell in ServiceProvider.GetServices<IWinFormsShell>())
+        {
+            if (shell is Form form)
+            {
+                shells.Add(form);
+            }
+        }
 
-        switch (shells.Length)
+        switch (shells.Count)
         {
             case 1:
-            {
-                Application.Run(shells[0]);
-                break;
-            }
+                {
+                    Application.Run(shells[0]);
+                    break;
+                }
 
             case 0:
-            {
-                Application.Run();
-                break;
-            }
+                {
+                    Application.Run();
+                    break;
+                }
 
             default:
-            {
-                var multiShellContext = new MultiShellContext(shells);
-                Application.Run(multiShellContext);
-                break;
-            }
+                {
+                    var multiShellContext = new MultiShellContext(shells.ToArray());
+                    Application.Run(multiShellContext);
+                    break;
+                }
         }
     }
 

--- a/src/Extensions.Hosting.WinForms/WinFormsHostedService.cs
+++ b/src/Extensions.Hosting.WinForms/WinFormsHostedService.cs
@@ -1,9 +1,8 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -25,11 +24,11 @@ public class WinFormsHostedService(ILogger<WinFormsHostedService> logger, WinFor
 {
     /// <summary>Logs when the WinForms application is stopping.</summary>
     private static readonly Action<ILogger, Exception?> LogStoppingWinForms =
-        LoggerMessage.Define(LogLevel.Debug, new EventId(1, nameof(LogStoppingWinForms)), "Stopping WinForms application.");
+        LoggerMessage.Define(LogLevel.Debug, new(1, nameof(LogStoppingWinForms)), "Stopping WinForms application.");
 
     /// <summary>Logs when a form cannot be cleaned up.</summary>
     private static readonly Action<ILogger, Exception?> LogFormCleanupFailed =
-        LoggerMessage.Define(LogLevel.Warning, new EventId(2, nameof(LogFormCleanupFailed)), "Couldn't cleanup a Form");
+        LoggerMessage.Define(LogLevel.Warning, new(2, nameof(LogFormCleanupFailed)), "Couldn't cleanup a Form");
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
@@ -55,7 +54,14 @@ public class WinFormsHostedService(ILogger<WinFormsHostedService> logger, WinFor
         await winFormsContext.Dispatcher!.InvokeAsync(() =>
         {
             // Graceful close, otherwise finalizes try to dispose forms.
-            foreach (var form in Application.OpenForms.Cast<Form>().ToList())
+            var openForms = Application.OpenForms;
+            var forms = new Form[openForms.Count];
+            for (var index = 0; index < forms.Length; index++)
+            {
+                forms[index] = openForms[index]!;
+            }
+
+            foreach (Form form in forms)
             {
                 try
                 {

--- a/src/Extensions.Hosting.WinUI/HostBuilderWinUIExtensions.cs
+++ b/src/Extensions.Hosting.WinUI/HostBuilderWinUIExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -47,22 +47,17 @@ public static class HostBuilderWinUIExtensions
     private static void RegisterWinUIHostingServices(IServiceCollection services, IWinUIContext winUIContext) =>
         _ = services
             .AddSingleton(winUIContext)
-            .AddSingleton(serviceProvider => new WinUIThread(serviceProvider))
+            .AddSingleton<WinUIThread>()
             .AddHostedService<WinUIHostedService>();
 
     /// <summary>Registers the WinUI application type.</summary>
     /// <typeparam name="TApp">The WinUI application type to register.</typeparam>
     /// <param name="services">The service collection to register services into.</param>
-    /// <exception cref="ArgumentException">Thrown if the application type does not derive from <see cref="Application"/>.</exception>
     private static void RegisterWinUIApplication<TApp>(IServiceCollection services)
         where TApp : Application
     {
         var appType = typeof(TApp);
         var baseApplicationType = typeof(Application);
-        if (!baseApplicationType.IsAssignableFrom(appType))
-        {
-            throw new ArgumentException("The registered Application type inherit System.Windows.Application", nameof(TApp));
-        }
 
         _ = services.AddSingleton<TApp>();
         if (appType == baseApplicationType)
@@ -70,7 +65,7 @@ public static class HostBuilderWinUIExtensions
             return;
         }
 
-        _ = services.AddSingleton<Application>(services => services.GetRequiredService<TApp>());
+        _ = services.AddSingleton<Application>(static services => services.GetRequiredService<TApp>());
     }
 
     /// <summary>Provides extension members for this receiver.</summary>
@@ -90,12 +85,9 @@ public static class HostBuilderWinUIExtensions
             where TApp : Application
             where TAppWindow : Window
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
-            var appType = typeof(TApp);
+            _ = typeof(TApp);
 
             if (!TryRetrieveWinUIContext(hostBuilder.Properties, out var winUIContext))
             {
@@ -144,7 +136,7 @@ public static class HostBuilderWinUIExtensions
                 winUIContext.IsLifetimeLinked = true;
             });
 
-            _ = hostBuilder.ConfigureServices((context, serviceCollection) => RegisterWinUIApplication<TApp>(serviceCollection));
+            _ = hostBuilder.ConfigureServices(static (context, serviceCollection) => RegisterWinUIApplication<TApp>(serviceCollection));
 
             return hostBuilder;
         }

--- a/src/Extensions.Hosting.WinUI/IWinUIContext.cs
+++ b/src/Extensions.Hosting.WinUI/IWinUIContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.WinUI/IWinUIService.cs
+++ b/src/Extensions.Hosting.WinUI/IWinUIService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.UI.Xaml;

--- a/src/Extensions.Hosting.WinUI/Internals/IUiThreadStarter.cs
+++ b/src/Extensions.Hosting.WinUI/Internals/IUiThreadStarter.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveMarbles.Extensions.Hosting.WinUI.Internals;
+
+/// <summary>Starts a platform UI thread.</summary>
+internal interface IUiThreadStarter
+{
+    /// <summary>Starts the UI thread.</summary>
+    void Start();
+}

--- a/src/Extensions.Hosting.WinUI/Internals/IWinUIThreadRuntime.cs
+++ b/src/Extensions.Hosting.WinUI/Internals/IWinUIThreadRuntime.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+
+namespace ReactiveMarbles.Extensions.Hosting.WinUI.Internals;
+
+/// <summary>Runs the WinUI application loop for a UI thread.</summary>
+internal interface IWinUIThreadRuntime
+{
+    /// <summary>Initializes COM wrappers required by the WinUI runtime.</summary>
+    void InitializeComWrappers();
+
+    /// <summary>Runs the application loop and invokes the supplied UI-thread initialization callback.</summary>
+    /// <param name="initialize">The callback that initializes WinUI services and the main window.</param>
+    void Start(Action<DispatcherQueue?, SynchronizationContext> initialize);
+
+    /// <summary>Resolves the WinUI application from the supplied services.</summary>
+    /// <param name="serviceProvider">The service provider from which to resolve the application.</param>
+    /// <returns>The resolved WinUI application.</returns>
+    Application GetApplication(IServiceProvider serviceProvider);
+
+    /// <summary>Creates the configured WinUI window.</summary>
+    /// <param name="serviceProvider">The service provider used to resolve window dependencies.</param>
+    /// <param name="windowType">The type of window to create.</param>
+    /// <returns>The created WinUI window.</returns>
+    Window CreateWindow(IServiceProvider serviceProvider, Type windowType);
+
+    /// <summary>Activates the specified WinUI window.</summary>
+    /// <param name="window">The window to activate.</param>
+    void ActivateWindow(Window window);
+}

--- a/src/Extensions.Hosting.WinUI/Internals/WinUIContext.cs
+++ b/src/Extensions.Hosting.WinUI/Internals/WinUIContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.WinUI/Internals/WinUIThread.cs
+++ b/src/Extensions.Hosting.WinUI/Internals/WinUIThread.cs
@@ -1,14 +1,11 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.UI.Dispatching;
-using Microsoft.UI.Xaml;
 using ReactiveMarbles.Extensions.Hosting.UiThread;
-using WinRT;
 
 namespace ReactiveMarbles.Extensions.Hosting.WinUI.Internals;
 
@@ -17,23 +14,45 @@ namespace ReactiveMarbles.Extensions.Hosting.WinUI.Internals;
 /// application. It ensures that the necessary WinUI services and synchronization context are initialized on the correct
 /// thread. The WinUI application and its main window are created and activated as part of the thread startup
 /// process.</remarks>
-/// <param name="serviceProvider">The service provider used to resolve WinUI application services and dependencies. Cannot be null.</param>
-public class WinUIThread(IServiceProvider serviceProvider) : BaseUiThread<IWinUIContext>(serviceProvider)
+public class WinUIThread : BaseUiThread<IWinUIContext>
 {
+    /// <summary>Stores the default platform application-loop runtime.</summary>
+    private static readonly IWinUIThreadRuntime DefaultRuntime = new WinUIThreadRuntime();
+
+    /// <summary>Stores the platform application-loop runtime.</summary>
+    private readonly IWinUIThreadRuntime? _runtime;
+
+    /// <summary>Initializes a new instance of the <see cref="WinUIThread"/> class.</summary>
+    /// <param name="serviceProvider">The service provider used to resolve WinUI application services and dependencies.</param>
+    public WinUIThread(IServiceProvider serviceProvider)
+        : base(serviceProvider)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="WinUIThread"/> class for controlled platform-runtime execution.</summary>
+    /// <param name="serviceProvider">The service provider used to resolve WinUI application services and dependencies.</param>
+    /// <param name="runtime">The platform application-loop runtime.</param>
+    /// <param name="useDedicatedUiThread">Whether to start work on a dedicated UI thread.</param>
+    internal WinUIThread(IServiceProvider serviceProvider, IWinUIThreadRuntime runtime, bool useDedicatedUiThread)
+        : base(serviceProvider, useDedicatedUiThread)
+    {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+    }
+
     /// <inheritdoc />
     protected override void PreUiThreadStart() =>
-        ComWrappersSupport.InitializeComWrappers();
+        (_runtime ?? DefaultRuntime).InitializeComWrappers();
 
     /// <inheritdoc />
     protected override void UiThreadStart()
     {
-        Application.Start(_ =>
+        (_runtime ?? DefaultRuntime).Start((dispatcher, synchronizationContext) =>
         {
-            UiContext!.Dispatcher = DispatcherQueue.GetForCurrentThread();
-            var context = new DispatcherQueueSynchronizationContext(UiContext.Dispatcher);
-            SynchronizationContext.SetSynchronizationContext(context);
+            UiContext!.Dispatcher = dispatcher;
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
 
-            UiContext.WinUIApplication = ServiceProvider.GetRequiredService<Application>();
+            var application = (_runtime ?? DefaultRuntime).GetApplication(ServiceProvider);
+            UiContext.WinUIApplication = application;
 
             // Use the provided IWinUIService
             var winUIServices = ServiceProvider.GetServices<IWinUIService>();
@@ -41,12 +60,13 @@ public class WinUIThread(IServiceProvider serviceProvider) : BaseUiThread<IWinUI
             {
                 foreach (var winUIService in winUIServices)
                 {
-                    winUIService.Initialize(UiContext.WinUIApplication);
+                    winUIService.Initialize(application);
                 }
             }
 
-            UiContext.AppWindow = (Window)ActivatorUtilities.CreateInstance(ServiceProvider, UiContext.AppWindowType!);
-            UiContext.AppWindow.Activate();
+            var appWindow = (_runtime ?? DefaultRuntime).CreateWindow(ServiceProvider, UiContext.AppWindowType!);
+            UiContext.AppWindow = appWindow;
+            (_runtime ?? DefaultRuntime).ActivateWindow(appWindow);
         });
         HandleApplicationExit();
     }

--- a/src/Extensions.Hosting.WinUI/Internals/WinUIThreadRuntime.cs
+++ b/src/Extensions.Hosting.WinUI/Internals/WinUIThreadRuntime.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using WinRT;
+
+namespace ReactiveMarbles.Extensions.Hosting.WinUI.Internals;
+
+/// <summary>Provides the production WinUI application-loop runtime.</summary>
+internal sealed class WinUIThreadRuntime : IWinUIThreadRuntime
+{
+    /// <inheritdoc />
+    public void InitializeComWrappers() =>
+        ComWrappersSupport.InitializeComWrappers();
+
+    /// <inheritdoc />
+    public void Start(Action<DispatcherQueue?, SynchronizationContext> initialize)
+    {
+        ArgumentNullException.ThrowIfNull(initialize);
+
+        Application.Start(_ =>
+        {
+            var dispatcher = DispatcherQueue.GetForCurrentThread();
+            initialize(dispatcher, new DispatcherQueueSynchronizationContext(dispatcher));
+        });
+    }
+
+    /// <inheritdoc />
+    public Application GetApplication(IServiceProvider serviceProvider) =>
+        serviceProvider.GetRequiredService<Application>();
+
+    /// <inheritdoc />
+    public Window CreateWindow(IServiceProvider serviceProvider, Type windowType) =>
+        (Window)ActivatorUtilities.CreateInstance(serviceProvider, windowType);
+
+    /// <inheritdoc />
+    public void ActivateWindow(Window window) =>
+        window.Activate();
+}

--- a/src/Extensions.Hosting.WinUI/Internals/WinUIThreadStarter.cs
+++ b/src/Extensions.Hosting.WinUI/Internals/WinUIThreadStarter.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ReactiveMarbles.Extensions.Hosting.WinUI.Internals;
+
+/// <summary>Adapts a WinUI thread to the hosted-service startup seam.</summary>
+internal sealed class WinUIThreadStarter : IUiThreadStarter
+{
+    /// <summary>Stores the action that starts the WinUI thread.</summary>
+    private readonly Action _start;
+
+    /// <summary>Initializes a new instance of the <see cref="WinUIThreadStarter"/> class.</summary>
+    /// <param name="winUIThread">The WinUI thread to start.</param>
+    internal WinUIThreadStarter(WinUIThread winUIThread)
+        : this((winUIThread ?? throw new ArgumentNullException(nameof(winUIThread))).Start)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="WinUIThreadStarter"/> class.</summary>
+    /// <param name="start">The action that starts the WinUI thread.</param>
+    internal WinUIThreadStarter(Action start) =>
+        _start = start ?? throw new ArgumentNullException(nameof(start));
+
+    /// <inheritdoc />
+    public void Start() =>
+        _start();
+}

--- a/src/Extensions.Hosting.WinUI/InternalsVisibleTo.cs
+++ b/src/Extensions.Hosting.WinUI/InternalsVisibleTo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Extensions.Hosting.WinUI.Platform.Tests")]
+[assembly: InternalsVisibleTo("Extensions.Hosting.ReactiveUI.WinUI.Reactive.Platform.Tests")]

--- a/src/Extensions.Hosting.WinUI/WinUIHostedService.cs
+++ b/src/Extensions.Hosting.WinUI/WinUIHostedService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -15,14 +15,54 @@ namespace ReactiveMarbles.Extensions.Hosting.WinUI;
 /// <remarks>This service enables integration of a WinUI application with the .NET Generic Host, allowing the
 /// application to participate in the host's startup and shutdown processes. It is typically registered as a singleton
 /// in the application's dependency injection container.</remarks>
-/// <param name="logger">The logger used to record diagnostic messages and operational events for the hosted service.</param>
-/// <param name="winUIThread">The WinUI thread responsible for running the application's UI event loop.</param>
-/// <param name="winUIContext">The context that provides access to the WinUI application's dispatcher and lifecycle management.</param>
-public class WinUIHostedService(ILogger<WinUIHostedService> logger, WinUIThread winUIThread, IWinUIContext winUIContext) : IHostedService
+public class WinUIHostedService : IHostedService
 {
     /// <summary>Logs when the WinUI application is stopping.</summary>
     private static readonly Action<ILogger, Exception?> LogStoppingWinUI =
-        LoggerMessage.Define(LogLevel.Debug, new EventId(1, nameof(LogStoppingWinUI)), "Stopping WinUI due to application exit.");
+        LoggerMessage.Define(LogLevel.Debug, new(1, nameof(LogStoppingWinUI)), "Stopping WinUI due to application exit.");
+
+    /// <summary>Stores the logger used to record lifecycle events.</summary>
+    private readonly ILogger<WinUIHostedService> _logger;
+
+    /// <summary>Stores the WinUI UI-thread starter.</summary>
+    private readonly IUiThreadStarter _winUIThreadStarter;
+
+    /// <summary>Stores the context for the WinUI application.</summary>
+    private readonly IWinUIContext _winUIContext;
+
+    /// <summary>Optionally stores a testable callback for scheduling work on the WinUI dispatcher.</summary>
+    private readonly Func<Action, bool>? _tryEnqueue;
+
+    /// <summary>Initializes a new instance of the <see cref="WinUIHostedService"/> class.</summary>
+    /// <param name="logger">The logger used to record diagnostic messages and operational events for the hosted service.</param>
+    /// <param name="winUIThread">The WinUI thread responsible for running the application's UI event loop.</param>
+    /// <param name="winUIContext">The context that provides access to the WinUI application's dispatcher and lifecycle management.</param>
+    public WinUIHostedService(ILogger<WinUIHostedService> logger, WinUIThread winUIThread, IWinUIContext winUIContext)
+        : this(logger, new WinUIThreadStarter(winUIThread), winUIContext)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="WinUIHostedService"/> class with a composed UI-thread starter.</summary>
+    /// <param name="logger">The logger used to record diagnostic messages and operational events for the hosted service.</param>
+    /// <param name="winUIThreadStarter">The component that starts the WinUI UI thread.</param>
+    /// <param name="winUIContext">The context that provides access to the WinUI application's dispatcher and lifecycle management.</param>
+    internal WinUIHostedService(ILogger<WinUIHostedService> logger, IUiThreadStarter winUIThreadStarter, IWinUIContext winUIContext)
+        : this(logger, winUIThreadStarter, winUIContext, null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="WinUIHostedService"/> class with a composed dispatcher callback.</summary>
+    /// <param name="logger">The logger used to record diagnostic messages and operational events for the hosted service.</param>
+    /// <param name="winUIThreadStarter">The component that starts the WinUI UI thread.</param>
+    /// <param name="winUIContext">The context that provides access to the WinUI application's dispatcher and lifecycle management.</param>
+    /// <param name="tryEnqueue">The callback that schedules work on the WinUI dispatcher, or <see langword="null"/> to use the context dispatcher.</param>
+    internal WinUIHostedService(ILogger<WinUIHostedService> logger, IUiThreadStarter winUIThreadStarter, IWinUIContext winUIContext, Func<Action, bool>? tryEnqueue)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _winUIThreadStarter = winUIThreadStarter ?? throw new ArgumentNullException(nameof(winUIThreadStarter));
+        _winUIContext = winUIContext ?? throw new ArgumentNullException(nameof(winUIContext));
+        _tryEnqueue = tryEnqueue;
+    }
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
@@ -33,27 +73,35 @@ public class WinUIHostedService(ILogger<WinUIHostedService> logger, WinUIThread 
         }
 
         // Make the UI thread go
-        winUIThread.Start();
+        _winUIThreadStarter.Start();
         return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        if (!winUIContext.IsRunning)
+        if (!_winUIContext.IsRunning)
         {
             return;
         }
 
-        LogStoppingWinUI(logger, null);
+        LogStoppingWinUI(_logger, null);
 
         // Stop application
-        var completion = new TaskCompletionSource();
-        _ = winUIContext.Dispatcher?.TryEnqueue(() =>
+        cancellationToken.ThrowIfCancellationRequested();
+        var tryEnqueue = _tryEnqueue ?? (_winUIContext.Dispatcher is { } dispatcher ? (Func<Action, bool>)(callback => dispatcher.TryEnqueue(() => callback())) : null)
+            ?? throw new InvalidOperationException("The WinUI dispatcher is not available while the application is running.");
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!tryEnqueue(() =>
         {
-            winUIContext.WinUIApplication?.Exit();
-            completion.SetResult();
-        });
-        await completion.Task;
+            _winUIContext.WinUIApplication?.Exit();
+            _ = completion.TrySetResult();
+        }))
+        {
+            throw new InvalidOperationException("The WinUI dispatcher rejected the application shutdown callback.");
+        }
+
+        await completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Extensions.Hosting.Wpf/HostBuilderWpfExtensions.cs
+++ b/src/Extensions.Hosting.Wpf/HostBuilderWpfExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -48,7 +48,7 @@ public static class HostBuilderWpfExtensions
     private static void RegisterWpfHostingServices(IServiceCollection services, IWpfContext wpfContext) =>
         _ = services
             .AddSingleton(wpfContext)
-            .AddSingleton(serviceProvider => new WpfThread(serviceProvider))
+            .AddSingleton(static serviceProvider => new WpfThread(serviceProvider))
             .AddHostedService<WpfHostedService>();
 
     /// <summary>Registers a configured WPF application type or instance.</summary>
@@ -109,6 +109,11 @@ public static class HostBuilderWpfExtensions
     /// <param name="hostBuilder">The receiver instance.</param>
     extension(IHostApplicationBuilder hostBuilder)
     {
+        /// <summary>Enables WPF lifetime management using <see cref="ShutdownMode.OnLastWindowClose"/>.</summary>
+        /// <returns>The same host application builder.</returns>
+        public IHostApplicationBuilder UseWpfLifetime() =>
+            hostBuilder.UseWpfLifetime(ShutdownMode.OnLastWindowClose);
+
         /// <summary>Enables WPF-specific application lifetime management for the host, configuring how the application shuts down based on the specified shutdown mode.</summary>
         /// <remarks>This method links the application's lifetime to the WPF application's lifetime, allowing the
         /// host to shut down according to the specified shutdown mode. Call this method after configuring WPF services and
@@ -117,12 +122,9 @@ public static class HostBuilderWpfExtensions
         /// <returns>The same instance of the host application builder, configured to use WPF lifetime management.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the hostBuilder parameter is null.</exception>
         /// <exception cref="NotSupportedException">Thrown if WPF has not been configured on the host builder before calling this method.</exception>
-        public IHostApplicationBuilder UseWpfLifetime(ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
+        public IHostApplicationBuilder UseWpfLifetime(ShutdownMode shutdownMode)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             if (!TryRetrieveWpfContext(hostBuilder.Properties, out var wpfContext))
             {
@@ -134,23 +136,16 @@ public static class HostBuilderWpfExtensions
             return hostBuilder;
         }
 
-        /// <summary>Configures WPF support for the application and registers required WPF services with the host builder.</summary>
-        /// <remarks>This method adds the necessary services to enable WPF integration in a generic host
-        /// application. It should be called during application startup before building the host. If an Application type or
-        /// main window is specified via the configureDelegate, they are registered as singletons in the service
-        /// container.</remarks>
-        /// <param name="configureDelegate">An optional delegate to further configure WPF-specific options using an IWpfBuilder instance. If null, default
-        /// configuration is applied.</param>
-        /// <returns>The same IHostApplicationBuilder instance for chaining further configuration.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if hostBuilder is null.</exception>
-        /// <exception cref="ArgumentException">Thrown if the Application type registered via configureDelegate does not inherit from
-        /// System.Windows.Application.</exception>
-        public IHostApplicationBuilder ConfigureWpf(Action<IWpfBuilder>? configureDelegate = null)
+        /// <summary>Configures WPF support using the default builder settings.</summary>
+        /// <returns>The same host application builder.</returns>
+        public IHostApplicationBuilder ConfigureWpf() => hostBuilder.ConfigureWpf(null);
+
+        /// <summary>Configures WPF support and applies the supplied builder configuration.</summary>
+        /// <param name="configureDelegate">The optional WPF builder configuration.</param>
+        /// <returns>The same host application builder.</returns>
+        public IHostApplicationBuilder ConfigureWpf(Action<IWpfBuilder>? configureDelegate)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             var wpfBuilder = new WpfBuilder();
             configureDelegate?.Invoke(wpfBuilder);
@@ -172,6 +167,11 @@ public static class HostBuilderWpfExtensions
     /// <param name="hostBuilder">The receiver instance.</param>
     extension(IHostBuilder hostBuilder)
     {
+        /// <summary>Enables WPF lifetime management using <see cref="ShutdownMode.OnLastWindowClose"/>.</summary>
+        /// <returns>The same host builder.</returns>
+        public IHostBuilder UseWpfLifetime() =>
+            hostBuilder.UseWpfLifetime(ShutdownMode.OnLastWindowClose);
+
         /// <summary>Enables WPF application lifetime integration for the host, configuring shutdown behavior according to the specified mode.</summary>
         /// <remarks>This method should be called after configuring WPF on the host builder. It links the host's
         /// lifetime to the WPF application's lifetime, ensuring that the host shuts down according to the specified
@@ -181,12 +181,9 @@ public static class HostBuilderWpfExtensions
         /// <returns>The same instance of <see cref="IHostBuilder"/> for chaining further configuration.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
         /// <exception cref="NotSupportedException">Thrown if WPF has not been configured on the host builder before calling this method.</exception>
-        public IHostBuilder UseWpfLifetime(ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
+        public IHostBuilder UseWpfLifetime(ShutdownMode shutdownMode)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             return hostBuilder.ConfigureServices((context, services) =>
             {
@@ -200,23 +197,16 @@ public static class HostBuilderWpfExtensions
             });
         }
 
-        /// <summary>Configures WPF support for the specified host builder, enabling integration of WPF application and window types into the hosting environment.</summary>
-        /// <remarks>This method registers WPF services and allows customization of the WPF application and main
-        /// window types through the <paramref name="configureDelegate"/>. It should be called before building the host to
-        /// ensure WPF integration is properly configured. Only one WPF context is registered per host builder
-        /// instance.</remarks>
-        /// <param name="configureDelegate">An optional delegate to further configure WPF-specific services and application or window types. If null,
-        /// default WPF configuration is applied.</param>
-        /// <returns>The same instance of <see cref="IHostBuilder"/> for chaining further configuration.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostBuilder"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown if the application type registered via <paramref name="configureDelegate"/> does not inherit from <see
-        /// cref="System.Windows.Application"/>.</exception>
-        public IHostBuilder ConfigureWpf(Action<IWpfBuilder>? configureDelegate = null)
+        /// <summary>Configures WPF support using the default builder settings.</summary>
+        /// <returns>The same host builder.</returns>
+        public IHostBuilder ConfigureWpf() => hostBuilder.ConfigureWpf(null);
+
+        /// <summary>Configures WPF support and applies the supplied builder configuration.</summary>
+        /// <param name="configureDelegate">The optional WPF builder configuration.</param>
+        /// <returns>The same host builder.</returns>
+        public IHostBuilder ConfigureWpf(Action<IWpfBuilder>? configureDelegate)
         {
-            if (hostBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(hostBuilder));
-            }
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
 
             var wpfBuilder = new WpfBuilder();
             configureDelegate?.Invoke(wpfBuilder);

--- a/src/Extensions.Hosting.Wpf/IWpfBuilder.cs
+++ b/src/Extensions.Hosting.Wpf/IWpfBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.Wpf/IWpfContext.cs
+++ b/src/Extensions.Hosting.Wpf/IWpfContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows;

--- a/src/Extensions.Hosting.Wpf/IWpfService.cs
+++ b/src/Extensions.Hosting.Wpf/IWpfService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows;

--- a/src/Extensions.Hosting.Wpf/IWpfShell.cs
+++ b/src/Extensions.Hosting.Wpf/IWpfShell.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows;

--- a/src/Extensions.Hosting.Wpf/Internals/WpfBuilder.cs
+++ b/src/Extensions.Hosting.Wpf/Internals/WpfBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Extensions.Hosting.Wpf/Internals/WpfContext.cs
+++ b/src/Extensions.Hosting.Wpf/Internals/WpfContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows;

--- a/src/Extensions.Hosting.Wpf/Internals/WpfThread.cs
+++ b/src/Extensions.Hosting.Wpf/Internals/WpfThread.cs
@@ -1,9 +1,9 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.Threading;
 using System.Windows;
 using System.Windows.Threading;
@@ -29,10 +29,7 @@ public class WpfThread(IServiceProvider serviceProvider) : BaseUiThread<IWpfCont
         SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher));
 
         // Create the new WPF application
-        var wpfApplication = ServiceProvider.GetService<Application>() ?? new()
-        {
-            ShutdownMode = UiContext!.ShutdownMode
-        };
+        var wpfApplication = ServiceProvider.GetService<Application>() ?? new() { ShutdownMode = UiContext!.ShutdownMode };
 
         // Register to the WPF application exit to stop the host application
         _ = wpfApplication.Dispatcher.InvokeAsync(() => wpfApplication.Exit += (s, e) => HandleApplicationExit());
@@ -42,30 +39,46 @@ public class WpfThread(IServiceProvider serviceProvider) : BaseUiThread<IWpfCont
     }
 
     /// <inheritdoc />
-    protected override void UiThreadStart() =>
-        UiContext?.WpfApplication?.Dispatcher.Invoke(() =>
+    protected override void UiThreadStart()
+    {
+        var wpfApplication = UiContext?.WpfApplication;
+        if (wpfApplication is null)
         {
-            // Mark the application as running
-            UiContext.IsRunning = true;
+            return;
+        }
 
-            // Use the provided IWpfService
-            foreach (var wpfService in ServiceProvider.GetServices<IWpfService>())
-            {
-                wpfService.Initialize(UiContext.WpfApplication);
-            }
+        var currentThreadOwnsApplicationDispatcher = wpfApplication.Dispatcher.Thread == Thread.CurrentThread;
 
-            // Run the WPF application in this thread which was specifically created for it, with the specified shell
-            var shellWindows = ServiceProvider.GetServices<IWpfShell>().Cast<Window>().ToList();
+        wpfApplication.Dispatcher.Invoke(
+            () => RunApplicationOnDispatcher(wpfApplication, currentThreadOwnsApplicationDispatcher));
+    }
 
-            switch (shellWindows.Count)
-            {
-                case 1:
+    /// <summary>Runs the configured WPF application from its dispatcher.</summary>
+    /// <param name="wpfApplication">The WPF application to run.</param>
+    /// <param name="currentThreadOwnsApplicationDispatcher">Whether the startup thread owns the application dispatcher.</param>
+    private void RunApplicationOnDispatcher(Application wpfApplication, bool currentThreadOwnsApplicationDispatcher)
+    {
+        // Mark the application as running
+        UiContext!.IsRunning = true;
+
+        // Use the provided IWpfService
+        foreach (var wpfService in ServiceProvider.GetServices<IWpfService>())
+        {
+            wpfService.Initialize(wpfApplication);
+        }
+
+        // Run the WPF application in this thread which was specifically created for it, with the specified shell
+        var shellWindows = GetShellWindows();
+
+        switch (shellWindows.Count)
+        {
+            case 1:
                 {
-                    if (UiContext.WpfApplication.Dispatcher.Thread.ThreadState != ThreadState.Running)
+                    if (currentThreadOwnsApplicationDispatcher)
                     {
-                        _ = UiContext.WpfApplication.Run(shellWindows[0]);
+                        _ = wpfApplication.Run(shellWindows[0]);
                     }
-                    else if (UiContext.WpfApplication.StartupUri is not null)
+                    else if (wpfApplication.StartupUri is not null)
                     {
                         _ = MessageBox.Show("Please remove the StartupUri configuration in App.xaml");
                     }
@@ -77,16 +90,15 @@ public class WpfThread(IServiceProvider serviceProvider) : BaseUiThread<IWpfCont
                     break;
                 }
 
-                case 0:
+            case 0:
                 {
-                    if (UiContext.WpfApplication.Dispatcher.Thread.ThreadState != ThreadState.Running)
+                    if (currentThreadOwnsApplicationDispatcher)
                     {
-                        _ = UiContext.WpfApplication.Run();
+                        _ = wpfApplication.Run();
                     }
-                    else if (UiContext.WpfApplication.MainWindow is not null)
+                    else if (wpfApplication.MainWindow is not null)
                     {
-                        // show window if possible
-                        UiContext.WpfApplication.MainWindow.Show();
+                        wpfApplication.MainWindow.Show();
                     }
                     else
                     {
@@ -96,9 +108,9 @@ public class WpfThread(IServiceProvider serviceProvider) : BaseUiThread<IWpfCont
                     break;
                 }
 
-                default:
+            default:
                 {
-                    UiContext.WpfApplication.Startup += (sender, args) =>
+                    wpfApplication.Startup += (sender, args) =>
                     {
                         foreach (var window in shellWindows)
                         {
@@ -106,13 +118,29 @@ public class WpfThread(IServiceProvider serviceProvider) : BaseUiThread<IWpfCont
                         }
                     };
 
-                    if (UiContext.WpfApplication.Dispatcher.Thread.ThreadState != ThreadState.Running)
+                    if (currentThreadOwnsApplicationDispatcher)
                     {
-                        _ = UiContext.WpfApplication.Run();
+                        _ = wpfApplication.Run();
                     }
 
                     break;
                 }
+        }
+    }
+
+    /// <summary>Resolves the registered WPF shell windows.</summary>
+    /// <returns>The registered shell windows.</returns>
+    private List<Window> GetShellWindows()
+    {
+        var shellWindows = new List<Window>();
+        foreach (var shell in ServiceProvider.GetServices<IWpfShell>())
+        {
+            if (shell is Window window)
+            {
+                shellWindows.Add(window);
             }
-        });
+        }
+
+        return shellWindows;
+    }
 }

--- a/src/Extensions.Hosting.Wpf/WpfBuilderExtensions.cs
+++ b/src/Extensions.Hosting.Wpf/WpfBuilderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -35,10 +35,7 @@ public static class WpfBuilderExtensions
         public IWpfBuilder UseApplication<TApplication>()
             where TApplication : Application
         {
-            if (wpfBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(wpfBuilder));
-            }
+            _ = wpfBuilder ?? throw new ArgumentNullException(nameof(wpfBuilder));
 
             wpfBuilder.ApplicationType = typeof(TApplication);
             return wpfBuilder;
@@ -52,10 +49,7 @@ public static class WpfBuilderExtensions
         public IWpfBuilder UseCurrentApplication<TApplication>(TApplication currentApplication)
             where TApplication : Application
         {
-            if (wpfBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(wpfBuilder));
-            }
+            _ = wpfBuilder ?? throw new ArgumentNullException(nameof(wpfBuilder));
 
             wpfBuilder.ApplicationType = typeof(TApplication);
             wpfBuilder.Application = currentApplication;
@@ -69,10 +63,7 @@ public static class WpfBuilderExtensions
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="wpfBuilder"/> is null.</exception>
         public IWpfBuilder ConfigureContext(Action<IWpfContext> configureAction)
         {
-            if (wpfBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(wpfBuilder));
-            }
+            _ = wpfBuilder ?? throw new ArgumentNullException(nameof(wpfBuilder));
 
             wpfBuilder.ConfigureContextAction = configureAction;
             return wpfBuilder;

--- a/src/Extensions.Hosting.Wpf/WpfHostedService.cs
+++ b/src/Extensions.Hosting.Wpf/WpfHostedService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -22,7 +22,7 @@ public class WpfHostedService(ILogger<WpfHostedService> logger, WpfThread wpfThr
 {
     /// <summary>Logs when the WPF application is stopping.</summary>
     private static readonly Action<ILogger, Exception?> LogStoppingWpf =
-        LoggerMessage.Define(LogLevel.Debug, new EventId(1, nameof(LogStoppingWpf)), "Stopping WPF due to application exit.");
+        LoggerMessage.Define(LogLevel.Debug, new(1, nameof(LogStoppingWpf)), "Stopping WPF due to application exit.");
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)

--- a/src/Extensions.Hosting.slnx
+++ b/src/Extensions.Hosting.slnx
@@ -1,4 +1,7 @@
 <Solution>
+  <Folder Name="/Benchmarks/">
+    <Project Path="benchmarks/Extensions.Hosting.Benchmarks/Extensions.Hosting.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/Examples/">
     <Project Path="examples/Extensions.Hosting.Avalonia.Example/Extensions.Hosting.Avalonia.Example.csproj" />
     <Project Path="examples/Extensions.Hosting.Console.Example/Extensions.Hosting.Console.Example.csproj" />
@@ -30,6 +33,29 @@
     <File Path="../README.md" />
     <File Path="Directory.Build.props" />
   </Folder>
+  <Folder Name="/Tests/">
+    <Project Path="tests/Extensions.Hosting.Avalonia.Lifecycle.Tests/Extensions.Hosting.Avalonia.Lifecycle.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Avalonia.MultipleWindow.Tests/Extensions.Hosting.Avalonia.MultipleWindow.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Avalonia.OneWindow.Tests/Extensions.Hosting.Avalonia.OneWindow.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Avalonia.Reactive.Tests/Extensions.Hosting.Avalonia.Reactive.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Avalonia.Tests/Extensions.Hosting.Avalonia.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.DataLogging.Tests/Extensions.Hosting.DataLogging.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.Maui.Platform.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.ReactiveUI.Maui.Reactive.Platform.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Platform.Tests/PluginService/Extensions.Hosting.PluginService.Platform.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Platform.Tests/PluginService/Extensions.Hosting.PluginService.Reactive.Platform.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Platform.Tests/WinUI/Extensions.Hosting.ReactiveUI.WinUI.Reactive.Platform.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Platform.Tests/WinUI/Extensions.Hosting.WinUI.Platform.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.ReactiveUI.Wpf.Reactive.Tests/Extensions.Hosting.ReactiveUI.Wpf.Reactive.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.ReactiveUI.Wpf.Tests/Extensions.Hosting.ReactiveUI.Wpf.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.WinForms.Tests/Extensions.Hosting.ReactiveUI.WinForms.Reactive.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.WinForms.Tests/Extensions.Hosting.WinForms.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Wpf.BuilderCoverage.Tests/Extensions.Hosting.Wpf.BuilderCoverage.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests.csproj" />
+    <Project Path="tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests.csproj" />
+  </Folder>
   <Project Path="../build/_build.csproj">
     <Build Project="false" />
   </Project>
@@ -50,5 +76,4 @@
   <Project Path="Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj" />
   <Project Path="Extensions.Hosting.Wpf/Extensions.Hosting.Wpf.csproj" />
   <Project Path="Extensions.Logging.Log4Net/Extensions.Logging.Log4Net.csproj" />
-  <Project Path="tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj" />
 </Solution>

--- a/src/Extensions.Logging.Log4Net/Entities/MessageCandidate.cs
+++ b/src/Extensions.Logging.Log4Net/Entities/MessageCandidate.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -15,7 +15,7 @@ namespace ReactiveMarbles.Extensions.Logging.Log4Net.Entities;
 /// the log entry.</typeparam>
 public readonly record struct MessageCandidate<TState>
 {
-    /// <summary>Initializes a new instance of the <see cref="MessageCandidate{TState}"/> struct. Initializes a new instance of the MessageCandidate class with the specified log level, event identifier, state, exception, and formatter.</summary>
+    /// <summary>Initializes a new instance of the <see cref="MessageCandidate{TState}"/> class.</summary>
     /// <param name="logLevel">The severity level of the log entry.</param>
     /// <param name="eventId">The identifier for the event associated with the log entry.</param>
     /// <param name="state">The state object to be logged. Represents the primary content or context for the log entry.</param>

--- a/src/Extensions.Logging.Log4Net/Entities/NodeInfo.cs
+++ b/src/Extensions.Logging.Log4Net/Entities/NodeInfo.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -21,9 +21,9 @@ public class NodeInfo
     /// </value>
     public string? NodeContent { get; set; }
 
-    /// <summary>Gets or sets the attributes.</summary>
+    /// <summary>Gets the attributes.</summary>
     /// <value>
     /// The attributes.
     /// </value>
-    public Dictionary<string, string>? Attributes { get; set; }
+    public Dictionary<string, string> Attributes { get; } = [];
 }

--- a/src/Extensions.Logging.Log4Net/Extensions/DocumentExtensions.cs
+++ b/src/Extensions.Logging.Log4Net/Extensions/DocumentExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -17,16 +17,13 @@ internal static class DocumentExtensions
     {
         /// <summary>Converts a XDocument object into XmlDocument.</summary>
         /// <returns>The XDocument converted to XmlDocument.</returns>
-        public XmlDocument ToXmlDocument()
+        internal XmlDocument ToXmlDocument()
         {
             using var memoryStream = new MemoryStream();
             document.Save(memoryStream);
             _ = memoryStream.Seek(0, SeekOrigin.Begin);
 
-            var xmlDocument = new XmlDocument
-            {
-                XmlResolver = null,
-            };
+            var xmlDocument = new XmlDocument { XmlResolver = null, };
             using var reader = XmlReader.Create(memoryStream, CreateSecureXmlReaderSettings());
             xmlDocument.Load(reader);
             return xmlDocument;
@@ -39,7 +36,7 @@ internal static class DocumentExtensions
     {
         /// <summary>Converts a XmlDocument object into xDocument.</summary>
         /// <returns>The XmlDocument converted to XDocument.</returns>
-        public XDocument ToXDocument()
+        internal XDocument ToXDocument()
         {
             using var memoryStream = new MemoryStream();
             xmlDocument.Save(memoryStream);
@@ -53,9 +50,5 @@ internal static class DocumentExtensions
     /// <summary>Creates XML reader settings that prevent DTD processing.</summary>
     /// <returns>The secure XML reader settings.</returns>
     private static XmlReaderSettings CreateSecureXmlReaderSettings() =>
-        new()
-        {
-            DtdProcessing = DtdProcessing.Prohibit,
-            XmlResolver = null,
-        };
+        new() { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null, };
 }

--- a/src/Extensions.Logging.Log4Net/Extensions/Log4NetProviderExtensions.cs
+++ b/src/Extensions.Logging.Log4Net/Extensions/Log4NetProviderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -18,24 +18,21 @@ public static class Log4NetProviderExtensions
         /// <remarks>This extension method simplifies logger creation by associating the logger with the
         /// full name of the specified category type. Only logger providers of type Log4NetProvider are
         /// supported.</remarks>
-        /// <typeparam name="TName">The category type for which to create a logger. Typically, this is the class type that will use the logger.</typeparam>
+        /// <param name="nameType">The category type for which to create a logger.</param>
         /// <returns>An ILogger instance associated with the specified category type.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the logger provider is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if the logger provider is not of type Log4NetProvider.</exception>
-        public ILogger CreateLogger<TName>()
-            where TName : class
+        public ILogger CreateLogger(Type nameType)
         {
-            if (self is null)
-            {
-                throw new ArgumentNullException(nameof(self));
-            }
+            _ = self ?? throw new ArgumentNullException(nameof(self));
+            _ = nameType ?? throw new ArgumentNullException(nameof(nameType));
 
             if (self is not Log4NetProvider)
             {
                 throw new ArgumentOutOfRangeException(nameof(self), "The ILoggerProvider should be of type Log4NetProvider.");
             }
 
-            return self.CreateLogger(typeof(TName).FullName!);
+            return self.CreateLogger(nameType.FullName!);
         }
     }
 }

--- a/src/Extensions.Logging.Log4Net/Extensions/LogExtensions.cs
+++ b/src/Extensions.Logging.Log4Net/Extensions/LogExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -19,13 +19,13 @@ public static class LogExtensions
         /// <summary>Criticals the specified message.</summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        public void Critical(object message, Exception exception)
-            => log?.Logger.Log(null!, log4net.Core.Level.Critical, message, exception);
+        public void Critical(object message, Exception exception) =>
+            log?.Logger.Log(null!, log4net.Core.Level.Critical, message, exception);
 
         /// <summary>Traces the specified message.</summary>
         /// <param name="message">The message.</param>
         /// <param name="exception">The exception.</param>
-        public void Trace(object message, Exception exception)
-            => log?.Logger.Log(null!, log4net.Core.Level.Trace, message, exception);
+        public void Trace(object message, Exception exception) =>
+            log?.Logger.Log(null!, log4net.Core.Level.Trace, message, exception);
     }
 }

--- a/src/Extensions.Logging.Log4Net/ILog4NetLogLevelTranslator.cs
+++ b/src/Extensions.Logging.Log4Net/ILog4NetLogLevelTranslator.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Logging;

--- a/src/Extensions.Logging.Log4Net/ILog4NetLoggingEventFactory.cs
+++ b/src/Extensions.Logging.Log4Net/ILog4NetLoggingEventFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Logging;

--- a/src/Extensions.Logging.Log4Net/Log4NetExtensions.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -17,31 +17,28 @@ public static class Log4NetExtensions
     {
         /// <summary>Adds the log4net.</summary>
         /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider.</returns>
-        public ILoggerFactory AddLog4Net()
-            => factory.AddLog4Net(new Log4NetProviderOptions());
+        public ILoggerFactory AddLog4Net() =>
+            factory.AddLog4Net(new Log4NetProviderOptions());
 
         /// <summary>Adds the log4net.</summary>
         /// <param name="log4NetConfigFile">The log4net Config File.</param>
         /// <returns>The <see cref="ILoggerFactory"/> after adding the log4net provider.</returns>
-        public ILoggerFactory AddLog4Net(string log4NetConfigFile)
-            => factory.AddLog4Net(log4NetConfigFile, false);
+        public ILoggerFactory AddLog4Net(string log4NetConfigFile) =>
+            factory.AddLog4Net(log4NetConfigFile, false);
 
         /// <summary>Adds the log4net logging provider.</summary>
         /// <param name="log4NetConfigFile">The log4 net configuration file.</param>
         /// <param name="watch">if set to <c>true</c> [watch].</param>
         /// <returns>The <see cref="ILoggerFactory"/> after adding the log4net provider.</returns>
-        public ILoggerFactory AddLog4Net(string log4NetConfigFile, bool watch)
-            => factory.AddLog4Net(new Log4NetProviderOptions(log4NetConfigFile, watch));
+        public ILoggerFactory AddLog4Net(string log4NetConfigFile, bool watch) =>
+            factory.AddLog4Net(new Log4NetProviderOptions(log4NetConfigFile, watch));
 
         /// <summary>Adds the log4net logging provider.</summary>
         /// <param name="options">The options for log4net provider.</param>
         /// <returns>The <see cref="ILoggerFactory"/> after adding the log4net provider.</returns>
         public ILoggerFactory AddLog4Net(Log4NetProviderOptions options)
         {
-            if (factory is null)
-            {
-                throw new ArgumentNullException(nameof(factory));
-            }
+            _ = factory ?? throw new ArgumentNullException(nameof(factory));
 
             factory.AddProvider(new Log4NetProvider(options));
             return factory;
@@ -88,10 +85,7 @@ public static class Log4NetExtensions
         /// <returns>The same instance of <see cref="ILoggingBuilder"/> for chaining.</returns>
         public ILoggingBuilder AddLog4Net(Log4NetProviderOptions options)
         {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
             _ = builder.Services.AddSingleton<ILoggerProvider>(new Log4NetProvider(options));
             return builder;

--- a/src/Extensions.Logging.Log4Net/Log4NetLogLevelTranslator.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetLogLevelTranslator.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -31,10 +31,7 @@ public sealed class Log4NetLogLevelTranslator : ILog4NetLogLevelTranslator
     /// <exception cref="ArgumentNullException">Thrown when options is null.</exception>
     private static Level TranslateCriticalLevel(Log4NetProviderOptions options)
     {
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        _ = options ?? throw new ArgumentNullException(nameof(options));
 
         var overrideCriticalLevelWith = options.OverrideCriticalLevelWith;
         var useCriticalLevel = !string.IsNullOrEmpty(overrideCriticalLevelWith)

--- a/src/Extensions.Logging.Log4Net/Log4NetLogger.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetLogger.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -34,8 +34,8 @@ public class Log4NetLogger : ILogger
     }
 
     /// <summary>Gets the name.</summary>
-    public string Name
-        => _logger.Name;
+    public string Name =>
+        _logger.Name;
 
     /// <summary>Gets a get-only property for accessing the <see cref="Log4NetProviderOptions"/> within the instance.</summary>
     internal Log4NetProviderOptions Options { get; }
@@ -47,8 +47,8 @@ public class Log4NetLogger : ILogger
     /// An IDisposable that ends the logical operation scope on dispose.
     /// </returns>
     public IDisposable? BeginScope<TState>(TState state)
-        where TState : notnull
-        => _externalScopeProvider.Push(state);
+        where TState : notnull =>
+        _externalScopeProvider.Push(state);
 
     /// <summary>Determines whether the logging level is enabled.</summary>
     /// <param name="logLevel">The log level.</param>

--- a/src/Extensions.Logging.Log4Net/Log4NetLoggingEventFactory.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetLoggingEventFactory.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -16,8 +16,8 @@ namespace ReactiveMarbles.Extensions.Logging;
 /// <inheritdoc cref="ILog4NetLoggingEventFactory"/>
 public class Log4NetLoggingEventFactory : ILog4NetLoggingEventFactory
 {
-    /// <summary>The default property name for scopes that don't provide their own property name by implementing an <see cref="IEnumerable{T}"/> where T is <see cref="KeyValuePair{TKey,TValue}"/> and where TKey is <see cref="string"/>.</summary>
-    protected const string DefaultScopeProperty = "scope";
+    /// <summary>The default property name for scopes that do not provide their own property name.</summary>
+    private const string DefaultScopeProperty = "scope";
 
     /// <summary>Stores the event id property value.</summary>
     private const string EventIdProperty = "eventId";
@@ -47,15 +47,9 @@ public class Log4NetLoggingEventFactory : ILog4NetLoggingEventFactory
         Log4NetProviderOptions options,
         IExternalScopeProvider scopeProvider)
     {
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        _ = options ?? throw new ArgumentNullException(nameof(options));
 
-        if (logger is null)
-        {
-            throw new ArgumentNullException(nameof(logger));
-        }
+        _ = logger ?? throw new ArgumentNullException(nameof(logger));
 
         var callerStackBoundaryDeclaringType = typeof(LoggerExtensions);
         var message = messageCandidate.Formatter(messageCandidate.State, messageCandidate.Exception);
@@ -193,5 +187,5 @@ public class Log4NetLoggingEventFactory : ILog4NetLoggingEventFactory
     /// <param name="newValue">The new property value.</param>
     /// <returns>The combined value.</returns>
     private static string? JoinOldAndNewValue(string? previousValue, string? newValue) =>
-        string.IsNullOrEmpty(previousValue) ? newValue : previousValue + " " + newValue;
+        string.IsNullOrEmpty(previousValue) ? newValue : $"{previousValue} {newValue}";
 }

--- a/src/Extensions.Logging.Log4Net/Log4NetProvider.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetProvider.cs
@@ -1,12 +1,11 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Xml;
 using System.Xml.Linq;
@@ -82,14 +81,14 @@ public class Log4NetProvider : ILoggerProvider, ISupportExternalScope
 
     /// <summary>Creates the logger.</summary>
     /// <returns>An instance of the <see cref="ILogger"/>.</returns>
-    public ILogger CreateLogger()
-        => CreateLogger(_options?.Name ?? string.Empty);
+    public ILogger CreateLogger() =>
+        CreateLogger(_options?.Name ?? string.Empty);
 
     /// <summary>Creates the logger.</summary>
     /// <param name="categoryName">The category name.</param>
     /// <returns>An instance of the <see cref="ILogger"/>.</returns>
-    public ILogger CreateLogger(string categoryName)
-        => _loggers.GetOrAdd(categoryName, CreateLoggerImplementation);
+    public ILogger CreateLogger(string categoryName) =>
+        _loggers.GetOrAdd(categoryName, CreateLoggerImplementation);
 
     /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
     public void Dispose()
@@ -129,11 +128,6 @@ public class Log4NetProvider : ILoggerProvider, ISupportExternalScope
     /// <returns>An <see cref="XmlDocument"/> within the overriding values replaced.</returns>
     private static XmlDocument UpdateNodesWithOverridingValues(XmlDocument configXmlDocument, IEnumerable<NodeInfo> overridingNodes)
     {
-        if (overridingNodes is null)
-        {
-            return configXmlDocument;
-        }
-
         var configDocument = configXmlDocument.ToXDocument();
         foreach (var nodeInfo in overridingNodes)
         {
@@ -159,15 +153,20 @@ public class Log4NetProvider : ILoggerProvider, ISupportExternalScope
     /// <param name="nodeInfo">The node information.</param>
     private static void AddOrUpdateAttributes(XElement node, NodeInfo nodeInfo)
     {
-        if (nodeInfo.Attributes is null)
-        {
-            return;
-        }
-
         foreach (var attribute in nodeInfo.Attributes)
         {
-            var nodeAttribute = node.Attributes()
-                .FirstOrDefault(a => a.Name.LocalName.Equals(attribute.Key, StringComparison.OrdinalIgnoreCase));
+            XAttribute? nodeAttribute = null;
+            foreach (var candidateAttribute in node.Attributes())
+            {
+                if (!candidateAttribute.Name.LocalName.Equals(attribute.Key, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                nodeAttribute = candidateAttribute;
+                break;
+            }
+
             if (nodeAttribute is not null)
             {
                 nodeAttribute.Value = attribute.Value;
@@ -184,16 +183,9 @@ public class Log4NetProvider : ILoggerProvider, ISupportExternalScope
     private static XmlDocument ParseLog4NetConfigFile(string filename)
     {
         using var stream = File.OpenRead(filename);
-        var settings = new XmlReaderSettings
-        {
-            DtdProcessing = DtdProcessing.Prohibit,
-            XmlResolver = null,
-        };
+        var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null, };
 
-        var log4netConfig = new XmlDocument
-        {
-            XmlResolver = null,
-        };
+        var log4netConfig = new XmlDocument { XmlResolver = null, };
         using var reader = XmlReader.Create(stream, settings);
         log4netConfig.Load(reader);
         return log4netConfig;
@@ -213,12 +205,12 @@ public class Log4NetProvider : ILoggerProvider, ISupportExternalScope
             LogLevelTranslator = _options?.LogLevelTranslator ?? new Log4NetLogLevelTranslator(),
         };
 
-        return new Log4NetLogger(loggerOptions, ExternalScopeProvider);
+        return new(loggerOptions, ExternalScopeProvider);
     }
 
     /// <summary>Gets the current executing assembly considering the target framework.</summary>
     /// <returns>The assembly to be used as the reference logging assembly.</returns>
-    private Assembly GetLoggingReferenceAssembly() => _options?.ConfigurationAssembly ?? Assembly.GetExecutingAssembly();
+    private Assembly GetLoggingReferenceAssembly() => _options?.ConfigurationAssembly ?? typeof(Log4NetProvider).Assembly;
 
     /// <summary>Ensures that provided options combinations are valid, and sets the class field if everything is ok.</summary>
     /// <param name="options">The options to validate.</param>
@@ -230,10 +222,7 @@ public class Log4NetProvider : ILoggerProvider, ISupportExternalScope
     /// </exception>
     private void SetOptionsIfValid(Log4NetProviderOptions options)
     {
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        _ = options ?? throw new ArgumentNullException(nameof(options));
 
         if (options.Watch
             && options.PropertyOverrides.Count > 0)
@@ -261,7 +250,7 @@ public class Log4NetProvider : ILoggerProvider, ISupportExternalScope
         var fileNamePath = CreateLog4NetFilePath();
         if (_options.Watch)
         {
-            _ = XmlConfigurator.ConfigureAndWatch(_loggerRepository!, new FileInfo(fileNamePath));
+            _ = XmlConfigurator.ConfigureAndWatch(_loggerRepository!, new(fileNamePath));
             return;
         }
 

--- a/src/Extensions.Logging.Log4Net/Log4NetProviderOptions.cs
+++ b/src/Extensions.Logging.Log4Net/Log4NetProviderOptions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -47,7 +47,7 @@ public sealed class Log4NetProviderOptions(string log4NetConfigFileName, bool wa
     public string OverrideCriticalLevelWith { get; set; } = string.Empty;
 
     /// <summary>Gets or sets the property overrides.</summary>
-    public List<NodeInfo> PropertyOverrides { get; set; } = new();
+    public List<NodeInfo> PropertyOverrides { get; } = new();
 
     /// <summary>Gets or sets a value indicating whether this <see cref="Log4NetProviderOptions"/> is watch.</summary>
     public bool Watch { get; set; } = watch;

--- a/src/Extensions.Logging.Log4Net/Scope/NullScope.cs
+++ b/src/Extensions.Logging.Log4Net/Scope/NullScope.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -15,7 +15,7 @@ internal sealed class NullScope : IDisposable
     }
 
     /// <summary>Gets the singleton instance that represent every <see cref="NullScope"/>.</summary>
-    internal static NullScope Instance { get; } = new NullScope();
+    internal static NullScope Instance { get; } = new();
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/Extensions.Logging.Log4Net/Scope/NullScopeProvider.cs
+++ b/src/Extensions.Logging.Log4Net/Scope/NullScopeProvider.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -16,7 +16,7 @@ internal sealed class NullScopeProvider : IExternalScopeProvider
     }
 
     /// <summary>Gets the singleton instance that represents every <see cref="NullScopeProvider"/>.</summary>
-    internal static NullScopeProvider Instance { get; } = new NullScopeProvider();
+    internal static NullScopeProvider Instance { get; } = new();
 
     /// <inheritdoc/>
     public void ForEachScope<TState>(Action<object, TState> callback, TState state)

--- a/src/benchmarks/Extensions.Hosting.Benchmarks/Extensions.Hosting.Benchmarks.csproj
+++ b/src/benchmarks/Extensions.Hosting.Benchmarks/Extensions.Hosting.Benchmarks.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <ProjectReference Include="..\..\Extensions.Hosting.Plugins\Extensions.Hosting.Plugins.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/benchmarks/Extensions.Hosting.Benchmarks/PluginOrderingBenchmarks.cs
+++ b/src/benchmarks/Extensions.Hosting.Benchmarks/PluginOrderingBenchmarks.cs
@@ -1,0 +1,98 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileSystemGlobbing;
+using ReactiveMarbles.Extensions.Hosting.Plugins;
+
+namespace Extensions.Hosting.Benchmarks;
+
+/// <summary>Measures the plugin filtering and ordering path used during host startup.</summary>
+[MemoryDiagnoser]
+public class PluginOrderingBenchmarks
+{
+    /// <summary>The number of plugin order variants in the benchmark fixture.</summary>
+    private const int PluginOrderVariants = 2;
+
+    /// <summary>Stores the assemblies passed to the production ordering path.</summary>
+    private readonly HashSet<Assembly> _assemblies = [typeof(PluginOrderingBenchmarks).Assembly];
+
+    /// <summary>Stores the configured plugin builder.</summary>
+    private BenchmarkPluginBuilder _pluginBuilder = null!;
+
+    /// <summary>Gets or sets the number of discovered plugins to order.</summary>
+    [Params(1, 32, 256)]
+    public int PluginCount { get; set; }
+
+    /// <summary>Creates the plugin sequence used by each benchmark invocation.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var plugins = new IPlugin?[PluginCount];
+        for (var index = 0; index < plugins.Length; index++)
+        {
+            plugins[index] = index % PluginOrderVariants == 0 ? new EarlyPlugin() : new LatePlugin();
+        }
+
+        _pluginBuilder = new() { AssemblyScanFunc = _ => plugins };
+    }
+
+    /// <summary>Filters nullable results and orders all discovered plugins.</summary>
+    /// <returns>The ordered plugin list.</returns>
+    [Benchmark]
+    public List<IPlugin> OrderPlugins() =>
+        HostBuilderPluginExtensions.GetOrderedPlugins(_pluginBuilder, _assemblies);
+
+    /// <summary>Provides the minimal builder needed by the production ordering path.</summary>
+    private sealed class BenchmarkPluginBuilder : IPluginBuilder
+    {
+        /// <inheritdoc />
+        public IList<string> PluginDirectories { get; } = [];
+
+        /// <inheritdoc />
+        public IList<string> FrameworkDirectories { get; } = [];
+
+        /// <inheritdoc />
+        public bool UseContentRoot { get; set; }
+
+        /// <inheritdoc />
+        public bool FailIfNoPlugins { get; set; }
+
+        /// <inheritdoc />
+        public Matcher FrameworkMatcher { get; } = new();
+
+        /// <inheritdoc />
+        public Matcher PluginMatcher { get; } = new();
+
+        /// <inheritdoc />
+        public Func<string, bool> ValidatePlugin { get; set; } = static _ => true;
+
+        /// <inheritdoc />
+        public Func<Assembly, IEnumerable<IPlugin?>?> AssemblyScanFunc { get; set; } = static _ => [];
+    }
+
+    /// <summary>Represents a plugin configured to run before the default order.</summary>
+    [PluginOrder(-1)]
+    private sealed class EarlyPlugin : IPlugin
+    {
+        /// <inheritdoc />
+        public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
+        {
+        }
+    }
+
+    /// <summary>Represents a plugin configured to run after the default order.</summary>
+    [PluginOrder(1)]
+    private sealed class LatePlugin : IPlugin
+    {
+        /// <inheritdoc />
+        public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
+        {
+        }
+    }
+}

--- a/src/benchmarks/Extensions.Hosting.Benchmarks/Program.cs
+++ b/src/benchmarks/Extensions.Hosting.Benchmarks/Program.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Running;
+
+namespace Extensions.Hosting.Benchmarks;
+
+/// <summary>Runs the hosting benchmark suite.</summary>
+public static class Program
+{
+    /// <summary>Runs all selected benchmarks.</summary>
+    /// <param name="args">The BenchmarkDotNet command-line arguments.</param>
+    public static void Main(string[] args) =>
+        _ = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+}

--- a/src/examples/Extensions.Hosting.Avalonia.Example/App.axaml.cs
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/App.axaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Avalonia;

--- a/src/examples/Extensions.Hosting.Avalonia.Example/HostBuilderExtensions.cs
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/HostBuilderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -30,7 +30,7 @@ public static class HostBuilderExtensions
         /// configuration and enables both console and debug logging providers.</remarks>
         /// <returns>The same host builder instance, enabling method chaining.</returns>
         internal IHostBuilder ConfigureLogging() =>
-            hostBuilder.ConfigureLogging((hostContext, configLogging) =>
+            hostBuilder.ConfigureLogging(static (hostContext, configLogging) =>
                 configLogging
                     .AddConfiguration(hostContext.Configuration.GetSection("Logging"))
                     .AddConsole()
@@ -50,7 +50,7 @@ public static class HostBuilderExtensions
                     .AddCommandLine(args))
                 .ConfigureAppConfiguration((hostContext, configApp) =>
                 {
-                    _ = configApp.AddJsonFile(AppSettingsFilePrefix + ".json", optional: true);
+                    _ = configApp.AddJsonFile($"{AppSettingsFilePrefix}.json", optional: true);
                     if (!string.IsNullOrEmpty(hostContext.HostingEnvironment.EnvironmentName))
                     {
                         _ = configApp.AddJsonFile(AppSettingsFilePrefix + $".{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true);

--- a/src/examples/Extensions.Hosting.Avalonia.Example/MainWindow.axaml.cs
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/MainWindow.axaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -18,7 +18,7 @@ public partial class MainWindow : Window, IAvaloniaShell
 {
     /// <summary>Logs exit button clicks.</summary>
     private static readonly Action<ILogger, Exception?> ExitButtonClicked =
-        LoggerMessage.Define(LogLevel.Information, new EventId(1, nameof(ExitButton_Click)), "Exit-Button was clicked!");
+        LoggerMessage.Define(LogLevel.Information, new(1, nameof(ExitButton_Click)), "Exit-Button was clicked!");
 
     /// <summary>Stores the logger value.</summary>
     private readonly ILogger<MainWindow> _logger;

--- a/src/examples/Extensions.Hosting.Avalonia.Example/Program.cs
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -27,7 +27,7 @@ public static class Program
         var host = new HostBuilder()
             .ConfigureLogging()
             .ConfigureConfiguration(args)
-            .ConfigureAvalonia(avaloniaBuilder =>
+            .ConfigureAvalonia(static avaloniaBuilder =>
             {
                 // Use the custom application
                 _ = avaloniaBuilder.UseApplication<App>();

--- a/src/examples/Extensions.Hosting.Avalonia.Example/ViewLocator.cs
+++ b/src/examples/Extensions.Hosting.Avalonia.Example/ViewLocator.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -36,11 +36,11 @@ public class ViewLocator : IDataTemplate
             }
             catch
             {
-                return new TextBlock { Text = "Failed to create: " + name };
+                return new TextBlock { Text = $"Failed to create: {name}" };
             }
         }
 
-        return new TextBlock { Text = "Not Found: " + name };
+        return new TextBlock { Text = $"Not Found: {name}" };
     }
 
     /// <summary>Determines whether the specified data object is not null.</summary>

--- a/src/examples/Extensions.Hosting.Console.Example/Program.cs
+++ b/src/examples/Extensions.Hosting.Console.Example/Program.cs
@@ -1,7 +1,17 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveMarbles.Extensions.Hosting.PluginService;
 
-await ServiceHost.Create(typeof(Program), args!).ConfigureAwait(false);
+namespace ReactiveMarbles.Extensions.Hosting.Console.Example;
+
+/// <summary>Provides the console example entry point.</summary>
+internal static class Program
+{
+    /// <summary>Runs the plugin service host.</summary>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns>A task representing the host lifetime.</returns>
+    internal static Task Main(string[] args) =>
+        ServiceHost.Create(typeof(Program), args);
+}

--- a/src/examples/Extensions.Hosting.Maui.Example/App.xaml.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/App.xaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace Extensions.Hosting.Maui.Example;

--- a/src/examples/Extensions.Hosting.Maui.Example/AppShell.xaml.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/AppShell.xaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace Extensions.Hosting.Maui.Example;

--- a/src/examples/Extensions.Hosting.Maui.Example/ExampleMauiService.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/ExampleMauiService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Logging;
@@ -14,12 +14,9 @@ public class ExampleMauiService(ILogger<ExampleMauiService> logger) : IMauiServi
 {
     /// <summary>Logs that the MAUI application was initialized.</summary>
     private static readonly Action<ILogger, Exception?> ApplicationInitialized =
-        LoggerMessage.Define(LogLevel.Information, new EventId(1, nameof(ApplicationInitialized)), "MAUI application initialized via IMauiService");
+        LoggerMessage.Define(LogLevel.Information, new(1, nameof(ApplicationInitialized)), "MAUI application initialized via IMauiService");
 
     /// <summary>Initializes the specified application.</summary>
     /// <param name="application">The application.</param>
-    public void Initialize(Application application)
-    {
-        ApplicationInitialized(logger, null);
-    }
+    public void Initialize(Application application) => ApplicationInitialized(logger, null);
 }

--- a/src/examples/Extensions.Hosting.Maui.Example/MainPage.xaml.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/MainPage.xaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveMarbles.Extensions.Hosting.Maui;

--- a/src/examples/Extensions.Hosting.Maui.Example/MauiProgram.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/MauiProgram.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
@@ -20,12 +20,12 @@ public static class MauiProgram
         var builder = Host.CreateApplicationBuilder();
         _ = builder.Services.AddSingleton<IMauiService, ExampleMauiService>();
         _ = builder
-            .ConfigureMaui(maui =>
+            .ConfigureMaui(static maui =>
             {
-                _ = maui.UseMauiApp<App>(mauiapp =>
+                _ = maui.UseMauiApp<App>(static mauiapp =>
                 {
                     _ = mauiapp
-                        .ConfigureFonts(fonts =>
+                        .ConfigureFonts(static fonts =>
                     {
                         _ = fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                         _ = fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
@@ -37,7 +37,7 @@ public static class MauiProgram
                 });
                 _ = maui.AddSingletonPage<MainPage>();
                 _ = maui.AddSingletonPage<SecondPage>();
-                _ = maui.ConfigureContext(ctx =>
+                _ = maui.ConfigureContext(static ctx =>
                 {
                     // Example: configure the MAUI context
                     ctx.IsLifetimeLinked = true;

--- a/src/examples/Extensions.Hosting.Maui.Example/Platforms/Android/MainActivity.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/Platforms/Android/MainActivity.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Android.App;
@@ -8,5 +8,15 @@ using Android.Content.PM;
 namespace Extensions.Hosting.Maui.Example;
 
 /// <summary>Represents the Android entry activity for the sample MAUI application.</summary>
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(
+    Theme = "@style/Maui.SplashTheme",
+    MainLauncher = true,
+    LaunchMode = LaunchMode.SingleTop,
+    ConfigurationChanges =
+        ConfigChanges.ScreenSize
+        | ConfigChanges.Orientation
+        | ConfigChanges.UiMode
+        | ConfigChanges.ScreenLayout
+        | ConfigChanges.SmallestScreenSize
+        | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity;

--- a/src/examples/Extensions.Hosting.Maui.Example/Platforms/Android/MainApplication.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/Platforms/Android/MainApplication.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Android.App;

--- a/src/examples/Extensions.Hosting.Maui.Example/Platforms/MacCatalyst/AppDelegate.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
 using Foundation;
 
 namespace Extensions.Hosting.Maui.Example;

--- a/src/examples/Extensions.Hosting.Maui.Example/Platforms/MacCatalyst/Program.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/Platforms/MacCatalyst/Program.cs
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
 using ObjCRuntime;
 using UIKit;
 

--- a/src/examples/Extensions.Hosting.Maui.Example/Platforms/Windows/App.xaml.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/Platforms/Windows/App.xaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace Extensions.Hosting.Maui.Example.WinUI;

--- a/src/examples/Extensions.Hosting.Maui.Example/Platforms/iOS/AppDelegate.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/Platforms/iOS/AppDelegate.cs
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
 using Foundation;
 
 namespace Extensions.Hosting.Maui.Example;

--- a/src/examples/Extensions.Hosting.Maui.Example/Platforms/iOS/Program.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/Platforms/iOS/Program.cs
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
 using ObjCRuntime;
 using UIKit;
 

--- a/src/examples/Extensions.Hosting.Maui.Example/SecondPage.xaml.cs
+++ b/src/examples/Extensions.Hosting.Maui.Example/SecondPage.xaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace Extensions.Hosting.Maui.Example;

--- a/src/examples/Extensions.Hosting.Plugin.Example/LifetimeEventsHostedService.cs
+++ b/src/examples/Extensions.Hosting.Plugin.Example/LifetimeEventsHostedService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -13,23 +13,25 @@ namespace ReactiveMarbles.Plugin.Example;
 /// <summary>Example for a IHostedService which tracks live-time events.</summary>
 /// <param name="logger">The logger used to record lifetime events.</param>
 /// <param name="hostApplicationLifetime">The host lifetime used to receive application lifecycle notifications.</param>
-public class LifetimeEventsHostedService(ILogger<LifetimeEventsHostedService> logger, IHostApplicationLifetime hostApplicationLifetime) : HostedServiceBase<LifetimeEventsHostedService>(logger, hostApplicationLifetime)
+public class LifetimeEventsHostedService(
+    ILogger<LifetimeEventsHostedService> logger,
+    IHostApplicationLifetime hostApplicationLifetime) : HostedServiceBase<LifetimeEventsHostedService>(logger, hostApplicationLifetime)
 {
     /// <summary>Logs that the hosted service started callback has run.</summary>
     private static readonly Action<ILogger, Exception?> OnStartedCalled =
-        LoggerMessage.Define(LogLevel.Information, new EventId(1, nameof(OnStarted)), "OnStarted has been called.");
+        LoggerMessage.Define(LogLevel.Information, new(1, nameof(OnStarted)), "OnStarted has been called.");
 
     /// <summary>Logs that the hosted service stopping callback has run.</summary>
     private static readonly Action<ILogger, Exception?> OnStoppingCalled =
-        LoggerMessage.Define(LogLevel.Information, new EventId(2, nameof(OnStopping)), "OnStopping has been called.");
+        LoggerMessage.Define(LogLevel.Information, new(2, nameof(OnStopping)), "OnStopping has been called.");
 
     /// <summary>Logs that the hosted service stopped callback has run.</summary>
     private static readonly Action<ILogger, Exception?> OnStoppedCalled =
-        LoggerMessage.Define(LogLevel.Information, new EventId(3, nameof(OnStopped)), "OnStopped has been called.");
+        LoggerMessage.Define(LogLevel.Information, new(3, nameof(OnStopped)), "OnStopped has been called.");
 
     /// <summary>Logs that the hosted service dispose callback has run.</summary>
     private static readonly Action<ILogger, Exception?> DisposeCalled =
-        LoggerMessage.Define(LogLevel.Information, new EventId(4, nameof(Dispose)), "Dispose has been called.");
+        LoggerMessage.Define(LogLevel.Information, new(4, nameof(Dispose)), "Dispose has been called.");
 
     /// <summary>Called when [started].</summary>
     /// <returns>

--- a/src/examples/Extensions.Hosting.Plugin.Example/Plugin.cs
+++ b/src/examples/Extensions.Hosting.Plugin.Example/Plugin.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveMarbles.Extensions.Hosting.Plugins;

--- a/src/examples/Extensions.Hosting.Plugin.Example/TimedHostedService.cs
+++ b/src/examples/Extensions.Hosting.Plugin.Example/TimedHostedService.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -16,21 +16,24 @@ namespace ReactiveMarbles.Plugin.Example;
 /// <param name="hostApplicationLifetime">The host lifetime used to receive application lifecycle notifications.</param>
 public class TimedHostedService(ILogger<TimedHostedService> logger, IHostApplicationLifetime hostApplicationLifetime) : HostedServiceBase<TimedHostedService>(logger, hostApplicationLifetime)
 {
+    /// <summary>The interval between timer callbacks, in seconds.</summary>
+    private const int TimerIntervalSeconds = 5;
+
     /// <summary>Logs that the timed service is starting.</summary>
     private static readonly Action<ILogger, Exception?> ServiceStarting =
-        LoggerMessage.Define(LogLevel.Information, new EventId(1, nameof(OnStarted)), "Timed Background Service is starting.");
+        LoggerMessage.Define(LogLevel.Information, new(1, nameof(OnStarted)), "Timed Background Service is starting.");
 
     /// <summary>Logs that the timed service is stopping.</summary>
     private static readonly Action<ILogger, Exception?> ServiceStopping =
-        LoggerMessage.Define(LogLevel.Information, new EventId(2, nameof(OnStopping)), "Timed Background Service is stopping.");
+        LoggerMessage.Define(LogLevel.Information, new(2, nameof(OnStopping)), "Timed Background Service is stopping.");
 
     /// <summary>Logs that the timed service has stopped.</summary>
     private static readonly Action<ILogger, Exception?> ServiceStopped =
-        LoggerMessage.Define(LogLevel.Information, new EventId(3, nameof(OnStopping)), "Plugin Service Stopped");
+        LoggerMessage.Define(LogLevel.Information, new(3, nameof(OnStopping)), "Plugin Service Stopped");
 
     /// <summary>Logs that the timed service is processing work.</summary>
     private static readonly Action<ILogger, Exception?> ServiceWorking =
-        LoggerMessage.Define(LogLevel.Information, new EventId(4, nameof(ServiceWorking)), "Timed Background Service is working.");
+        LoggerMessage.Define(LogLevel.Information, new(4, nameof(ServiceWorking)), "Timed Background Service is working.");
 
     /// <summary>Stores the timer value.</summary>
     private Timer? _timer;
@@ -43,7 +46,11 @@ public class TimedHostedService(ILogger<TimedHostedService> logger, IHostApplica
     {
         ServiceStarting(Logger, null);
 
-        _timer = new(_ => ServiceWorking(Logger, null), null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+        _timer = new(
+            _ => ServiceWorking(Logger, null),
+            null,
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(TimerIntervalSeconds));
 
         return Task.CompletedTask;
     }

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/App.axaml.cs
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/App.axaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Avalonia;

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/AppViewModel.cs
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/AppViewModel.cs
@@ -1,10 +1,9 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
@@ -16,45 +15,34 @@ namespace Extensions.Hosting.ReactiveAvalonia.Example;
 /// <summary>Represents the root view model for the sample NuGet browser application.</summary>
 public class AppViewModel : ReactiveObject
 {
+    /// <summary>Gets the search debounce in milliseconds.</summary>
+    private const int SearchDelayMilliseconds = 800;
+
+    /// <summary>Gets the maximum number of package search results.</summary>
+    private const int MaximumSearchResults = 10;
+
     /// <summary>Stores the search results value.</summary>
-    private readonly ObservableAsPropertyHelper<IEnumerable<NugetDetailsViewModel>> _searchResults;
+    private ObservableAsPropertyHelper<IEnumerable<NugetDetailsViewModel>>? _searchResults;
 
     /// <summary>Stores the is available value.</summary>
-    private readonly ObservableAsPropertyHelper<bool> _isAvailable;
-
-    /// <summary>Initializes a new instance of the <see cref="AppViewModel"/> class.</summary>
-    public AppViewModel()
-    {
-        _searchResults = this
-            .WhenAnyValue(x => x.SearchTerm)
-            .Throttle(TimeSpan.FromMilliseconds(800))
-            .Select(term => term?.Trim())
-            .DistinctUntilChanged()
-            .Where(term => !string.IsNullOrWhiteSpace(term))
-            .SelectMany(term => Signal.FromAsync(token => SearchNuGetPackages(term, token)))
-            .ObserveOn(RxSchedulers.MainThreadScheduler)
-            .ToProperty(this, x => x.SearchResults);
-
-        _ = _searchResults.ThrownExceptions.Subscribe(error => { });
-
-        _isAvailable = this
-            .WhenAnyValue(x => x.SearchResults)
-            .Select(searchResults => searchResults is not null)
-            .ToProperty(this, x => x.IsAvailable);
-    }
+    private ObservableAsPropertyHelper<bool>? _isAvailable;
 
     /// <summary>Gets or sets the search term.</summary>
     public string? SearchTerm
     {
         get;
-        set => this.RaiseAndSetIfChanged(ref field, value);
+        set
+        {
+            EnsurePropertiesInitialized();
+            _ = this.RaiseAndSetIfChanged(ref field, value);
+        }
     }
 
     /// <summary>Gets the search results.</summary>
-    public IEnumerable<NugetDetailsViewModel> SearchResults => _searchResults.Value;
+    public IEnumerable<NugetDetailsViewModel> SearchResults => EnsureSearchResultsInitialized().Value;
 
     /// <summary>Gets a value indicating whether results are available.</summary>
-    public bool IsAvailable => _isAvailable.Value;
+    public bool IsAvailable => EnsureAvailabilityInitialized().Value;
 
     /// <summary>Searches NuGet packages that match the supplied term.</summary>
     /// <param name="term">The search term.</param>
@@ -62,14 +50,72 @@ public class AppViewModel : ReactiveObject
     /// <returns>The package detail view models that match the search term.</returns>
     private static async Task<IEnumerable<NugetDetailsViewModel>> SearchNuGetPackages(string? term, CancellationToken token)
     {
-        var providers = new List<Lazy<INuGetResourceProvider>>();
-        providers.AddRange(Repository.Provider.GetCoreV3());
+        var providers = new List<Lazy<INuGetResourceProvider>>(Repository.Provider.GetCoreV3());
         var package = new PackageSource("https://api.nuget.org/v3/index.json");
         var source = new SourceRepository(package, providers);
 
         var filter = new SearchFilter(false);
         var resource = await source.GetResourceAsync<PackageSearchResource>().ConfigureAwait(false);
-        var metadata = await resource.SearchAsync(term, filter, 0, 10, new NuGet.Common.NullLogger(), token).ConfigureAwait(false);
-        return metadata.Select(x => new NugetDetailsViewModel(x));
+        var metadata = await resource.SearchAsync(
+                term,
+                filter,
+                0,
+                MaximumSearchResults,
+                new NuGet.Common.NullLogger(),
+                token)
+            .ConfigureAwait(false);
+        var results = new List<NugetDetailsViewModel>();
+        foreach (var packageMetadata in metadata)
+        {
+            results.Add(new(packageMetadata));
+        }
+
+        return results;
+    }
+
+    /// <summary>Initializes the lazily-created observable properties.</summary>
+    private void EnsurePropertiesInitialized()
+    {
+        _ = EnsureSearchResultsInitialized();
+        _ = EnsureAvailabilityInitialized();
+    }
+
+    /// <summary>Gets or initializes the observable search-results helper.</summary>
+    /// <returns>The initialized search-results helper.</returns>
+    private ObservableAsPropertyHelper<IEnumerable<NugetDetailsViewModel>> EnsureSearchResultsInitialized()
+    {
+        if (_searchResults is not null)
+        {
+            return _searchResults;
+        }
+
+        _searchResults = this
+            .WhenAnyValue(x => x.SearchTerm)
+            .Throttle(TimeSpan.FromMilliseconds(SearchDelayMilliseconds))
+            .Select(static term => term?.Trim())
+            .DistinctUntilChanged()
+            .Where(static term => !string.IsNullOrWhiteSpace(term))
+            .SelectMany(term => Signal.FromAsync(token => SearchNuGetPackages(term, token)))
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .ToProperty(this, x => x.SearchResults);
+        _ = _searchResults.ThrownExceptions.Subscribe(static error => { });
+        return _searchResults;
+    }
+
+    /// <summary>Gets or initializes the observable availability helper.</summary>
+    /// <returns>The initialized availability helper.</returns>
+    private ObservableAsPropertyHelper<bool> EnsureAvailabilityInitialized()
+    {
+        if (_isAvailable is not null)
+        {
+            return _isAvailable;
+        }
+
+        _ = EnsureSearchResultsInitialized();
+        _isAvailable = this
+            .WhenAnyValue(x => x.SearchResults)
+            .Select(static searchResults => searchResults is not null)
+            .ToProperty(this, x => x.IsAvailable);
+        return _isAvailable;
     }
 }

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/HostBuilderExtensions.cs
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/HostBuilderExtensions.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -28,7 +28,7 @@ public static class HostBuilderExtensions
         /// <summary>Configures logging for the sample host.</summary>
         /// <returns>The configured host builder.</returns>
         internal IHostBuilder ConfigureLogging() =>
-            hostBuilder.ConfigureLogging((hostContext, configLogging) =>
+            hostBuilder.ConfigureLogging(static (hostContext, configLogging) =>
                 configLogging
                     .AddConfiguration(hostContext.Configuration.GetSection("Logging"))
                     .AddConsole()
@@ -45,7 +45,7 @@ public static class HostBuilderExtensions
                     .AddCommandLine(args))
                 .ConfigureAppConfiguration((hostContext, configApp) =>
                 {
-                    _ = configApp.AddJsonFile(AppSettingsFilePrefix + ".json", optional: true);
+                    _ = configApp.AddJsonFile($"{AppSettingsFilePrefix}.json", optional: true);
                     if (!string.IsNullOrEmpty(hostContext.HostingEnvironment.EnvironmentName))
                     {
                         _ = configApp.AddJsonFile(AppSettingsFilePrefix + $".{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true);

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/MainWindow.axaml.cs
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/MainWindow.axaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveMarbles.Extensions.Hosting.Avalonia;

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/NugetDetailsView.axaml.cs
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/NugetDetailsView.axaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.Avalonia;

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/NugetDetailsViewModel.cs
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/NugetDetailsViewModel.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -26,8 +26,8 @@ public class NugetDetailsViewModel : ReactiveObject
     /// <summary>Stores the default url value.</summary>
     private readonly Uri _defaultUrl;
 
-    /// <summary>Stores the icon value.</summary>
-    private readonly ObservableAsPropertyHelper<Bitmap?> _icon;
+    /// <summary>Stores whether icon loading has started.</summary>
+    private int _iconLoadStarted;
 
     /// <summary>Initializes a new instance of the <see cref="NugetDetailsViewModel"/> class.</summary>
     /// <param name="metadata">The NuGet package metadata.</param>
@@ -36,21 +36,21 @@ public class NugetDetailsViewModel : ReactiveObject
         _metadata = metadata;
         _defaultUrl = new("https://git.io/fAlfh");
 
-        var startInfo = new ProcessStartInfo(ProjectUrl?.ToString() ?? _defaultUrl.ToString())
-        {
-            UseShellExecute = true
-        };
-
-        OpenPage = ReactiveCommand.Create(() => OpenPackagePage(startInfo));
-
-        _icon = Signal
-            .FromAsync(cancellationToken => LoadIconAsync(IconUrl, cancellationToken))
-            .ObserveOn(RxSchedulers.MainThreadScheduler)
-            .ToProperty(this, x => x.Icon);
+        var projectUrl = ProjectUrl ?? _defaultUrl;
+        OpenPage = ReactiveCommand.Create(() => OpenPackagePage(projectUrl));
     }
 
     /// <summary>Gets the package icon.</summary>
-    public Bitmap? Icon => _icon.Value;
+    public Bitmap? Icon
+    {
+        get
+        {
+            BeginIconLoad();
+            return field;
+        }
+
+        private set => _ = this.RaiseAndSetIfChanged(ref field, value);
+    }
 
     /// <summary>Gets the icon URI.</summary>
     public Uri IconUrl => _metadata.IconUrl ?? _defaultUrl;
@@ -79,7 +79,7 @@ public class NugetDetailsViewModel : ReactiveObject
             await using var iconMemoryStream = new MemoryStream();
             await iconStream.CopyToAsync(iconMemoryStream, cancellationToken).ConfigureAwait(false);
             iconMemoryStream.Position = 0;
-            return new Bitmap(iconMemoryStream);
+            return new(iconMemoryStream);
         }
         catch (HttpRequestException)
         {
@@ -108,6 +108,48 @@ public class NugetDetailsViewModel : ReactiveObject
     }
 
     /// <summary>Opens the package page in the default system browser.</summary>
-    /// <param name="startInfo">The process start information.</param>
-    private static void OpenPackagePage(ProcessStartInfo startInfo) => _ = Process.Start(startInfo);
+    /// <param name="projectUrl">The package project URL.</param>
+    private static void OpenPackagePage(Uri projectUrl)
+    {
+        if (!string.Equals(projectUrl.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(projectUrl.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            var windowsStartInfo = new ProcessStartInfo("explorer.exe") { UseShellExecute = false };
+            windowsStartInfo.ArgumentList.Add(projectUrl.AbsoluteUri);
+            _ = Process.Start(windowsStartInfo);
+            return;
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            var macOsStartInfo = new ProcessStartInfo("/usr/bin/open") { UseShellExecute = false };
+            macOsStartInfo.ArgumentList.Add(projectUrl.AbsoluteUri);
+            _ = Process.Start(macOsStartInfo);
+            return;
+        }
+
+        var linuxStartInfo = new ProcessStartInfo("xdg-open") { UseShellExecute = false };
+        linuxStartInfo.ArgumentList.Add(projectUrl.AbsoluteUri);
+        _ = Process.Start(linuxStartInfo);
+    }
+
+    /// <summary>Starts loading the package icon the first time it is requested.</summary>
+    private void BeginIconLoad()
+    {
+        if (Interlocked.Exchange(ref _iconLoadStarted, 1) != 0)
+        {
+            return;
+        }
+
+        _ = LoadAndPublishIconAsync();
+    }
+
+    /// <summary>Loads the package icon and publishes it to the binding.</summary>
+    /// <returns>A task that represents the asynchronous load.</returns>
+    private async Task LoadAndPublishIconAsync() => Icon = await LoadIconAsync(IconUrl, CancellationToken.None);
 }

--- a/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/Program.cs
+++ b/src/examples/Extensions.Hosting.ReactiveAvalonia.Example/Program.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
@@ -22,11 +22,11 @@ public static class Program
 {
     /// <summary>Logs that another instance is already running.</summary>
     private static readonly Action<ILogger, string, Exception?> ApplicationAlreadyRunning =
-        LoggerMessage.Define<string>(LogLevel.Warning, new EventId(1, nameof(ApplicationAlreadyRunning)), "Application {ApplicationName} already running.");
+        LoggerMessage.Define<string>(LogLevel.Warning, new(1, nameof(ApplicationAlreadyRunning)), "Application {ApplicationName} already running.");
 
     /// <summary>Logs that the application is running.</summary>
     private static readonly Action<ILogger, Exception?> ApplicationRunning =
-        LoggerMessage.Define(LogLevel.Information, new EventId(2, nameof(ApplicationRunning)), "Application running.");
+        LoggerMessage.Define(LogLevel.Information, new(2, nameof(ApplicationRunning)), "Application running.");
 
     /// <summary>Initializes and runs the Avalonia application with configured logging, application settings, and main window.</summary>
     /// <remarks>This method sets up the application host with logging, configuration, and Avalonia-specific
@@ -41,14 +41,14 @@ public static class Program
             .ConfigureSplatForMicrosoftDependencyResolver()
             .ConfigureLogging()
             .ConfigureConfiguration(args)
-            .ConfigureSingleInstance(builder =>
+            .ConfigureSingleInstance(static builder =>
             {
                 builder.MutexId = "{691A4D6D-2CE0-4D47-B7F4-D99D8C02161E}";
-                builder.WhenNotFirstInstance = (hostingEnvironment, logger) =>
+                builder.WhenNotFirstInstance = static (hostingEnvironment, logger) =>
                     ApplicationAlreadyRunning(logger, hostingEnvironment.ApplicationName, null);
             })
-            .ConfigureServices(services => services.AddTransient<IViewFor<NugetDetailsViewModel>, NugetDetailsView>())
-            .ConfigureAvalonia(avaloniaBuilder =>
+            .ConfigureServices(static services => services.AddTransient<IViewFor<NugetDetailsViewModel>, NugetDetailsView>())
+            .ConfigureAvalonia(static avaloniaBuilder =>
             {
                 _ = avaloniaBuilder.UseApplication<App>();
                 _ = avaloniaBuilder.UseWindow<MainWindow>();

--- a/src/examples/Extensions.Hosting.ReactiveWpf.Example/App.xaml.cs
+++ b/src/examples/Extensions.Hosting.ReactiveWpf.Example/App.xaml.cs
@@ -1,7 +1,8 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Windows;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -17,22 +18,24 @@ public partial class App
 {
     /// <summary>Logs that another instance is already running.</summary>
     private static readonly Action<ILogger, string, Exception?> ApplicationAlreadyRunning =
-        LoggerMessage.Define<string>(LogLevel.Warning, new EventId(1, nameof(ApplicationAlreadyRunning)), "Application {ApplicationName} already running.");
+        LoggerMessage.Define<string>(LogLevel.Warning, new(1, nameof(ApplicationAlreadyRunning)), "Application {ApplicationName} already running.");
 
-    /// <summary>Initializes a new instance of the <see cref="App"/> class.</summary>
-    public App()
+    /// <inheritdoc />
+    protected override void OnStartup(StartupEventArgs e)
     {
+        base.OnStartup(e);
+
         var host = Host.CreateDefaultBuilder()
             .ConfigureSplatForMicrosoftDependencyResolver()
             .ConfigureLogging()
             .ConfigureConfiguration(Environment.GetCommandLineArgs())
-            .ConfigureSingleInstance(builder =>
+            .ConfigureSingleInstance(static builder =>
             {
                 builder.MutexId = "{691A4D6D-2CE0-4D47-B7F4-D99D8C02161E}";
-                builder.WhenNotFirstInstance = (hostingEnvironment, logger) =>
+                builder.WhenNotFirstInstance = static (hostingEnvironment, logger) =>
                     ApplicationAlreadyRunning(logger, hostingEnvironment.ApplicationName, null);
             })
-            .ConfigureServices(services => services.AddTransient<IViewFor<NugetDetailsViewModel>, NugetDetailsView>())
+            .ConfigureServices(static services => services.AddTransient<IViewFor<NugetDetailsViewModel>, NugetDetailsView>())
             .ConfigureWpf(wpfBuilder => wpfBuilder.UseCurrentApplication(this).UseWindow<MainWindow>())
             .UseWpfLifetime()
             .UseConsoleLifetime()

--- a/src/examples/Extensions.Hosting.ReactiveWpf.Example/AppMixins.cs
+++ b/src/examples/Extensions.Hosting.ReactiveWpf.Example/AppMixins.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -28,7 +28,7 @@ public static class AppMixins
         /// <summary>Configures logging for the sample host.</summary>
         /// <returns>The configured host builder.</returns>
         internal IHostBuilder ConfigureLogging() =>
-            hostBuilder.ConfigureLogging((hostContext, configLogging) =>
+            hostBuilder.ConfigureLogging(static (hostContext, configLogging) =>
                 configLogging
                     .AddConfiguration(hostContext.Configuration.GetSection("Logging"))
                     .AddConsole()
@@ -44,7 +44,7 @@ public static class AppMixins
                 .AddCommandLine(args))
                 .ConfigureAppConfiguration((hostContext, configApp) =>
                 {
-                    _ = configApp.AddJsonFile(AppSettingsFilePrefix + ".json", optional: true);
+                    _ = configApp.AddJsonFile($"{AppSettingsFilePrefix}.json", optional: true);
                     if (!string.IsNullOrEmpty(hostContext.HostingEnvironment.EnvironmentName))
                     {
                         _ = configApp.AddJsonFile(AppSettingsFilePrefix + $".{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true);

--- a/src/examples/Extensions.Hosting.ReactiveWpf.Example/AppViewModel.cs
+++ b/src/examples/Extensions.Hosting.ReactiveWpf.Example/AppViewModel.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using NuGet.Configuration;
@@ -17,32 +17,17 @@ namespace Extensions.Hosting.Reactive.Example;
 /// <seealso cref="ReactiveObject" />
 public class AppViewModel : ReactiveObject
 {
+    /// <summary>Gets the search debounce in milliseconds.</summary>
+    private const int SearchDelayMilliseconds = 800;
+
+    /// <summary>Gets the maximum number of package search results.</summary>
+    private const int MaximumSearchResults = 10;
+
     /// <summary>Stores the search results value.</summary>
-    private readonly ObservableAsPropertyHelper<IEnumerable<NugetDetailsViewModel>> _searchResults;
+    private ObservableAsPropertyHelper<IEnumerable<NugetDetailsViewModel>>? _searchResults;
 
     /// <summary>Stores the is available value.</summary>
-    private readonly ObservableAsPropertyHelper<bool> _isAvailable;
-
-    /// <summary>Initializes a new instance of the <see cref="AppViewModel"/> class.</summary>
-    public AppViewModel()
-    {
-        _searchResults = this
-            .WhenAnyValue(x => x.SearchTerm)
-            .Throttle(TimeSpan.FromMilliseconds(800))
-            .Select(term => term?.Trim())
-            .DistinctUntilChanged()
-            .Where(term => !string.IsNullOrWhiteSpace(term))
-            .SelectMany(term => Signal.FromAsync(token => SearchNuGetPackages(term, token)))
-            .ObserveOn(RxSchedulers.MainThreadScheduler)
-            .ToProperty(this, x => x.SearchResults);
-
-        _ = _searchResults.ThrownExceptions.Subscribe(error => { /* Handle errors here */ });
-
-        _isAvailable = this
-            .WhenAnyValue(x => x.SearchResults)
-            .Select(searchResults => searchResults is not null)
-            .ToProperty(this, x => x.IsAvailable);
-    }
+    private ObservableAsPropertyHelper<bool>? _isAvailable;
 
     /// <summary>Gets or sets the search term.</summary>
     /// <value>
@@ -51,20 +36,24 @@ public class AppViewModel : ReactiveObject
     public string? SearchTerm
     {
         get;
-        set => this.RaiseAndSetIfChanged(ref field, value);
+        set
+        {
+            EnsurePropertiesInitialized();
+            _ = this.RaiseAndSetIfChanged(ref field, value);
+        }
     }
 
     /// <summary>Gets the search results.</summary>
     /// <value>
     /// The search results.
     /// </value>
-    public IEnumerable<NugetDetailsViewModel> SearchResults => _searchResults.Value;
+    public IEnumerable<NugetDetailsViewModel> SearchResults => EnsureSearchResultsInitialized().Value;
 
     /// <summary>Gets a value indicating whether this instance is available.</summary>
     /// <value>
     ///   <c>true</c> if this instance is available; otherwise, <c>false</c>.
     /// </value>
-    public bool IsAvailable => _isAvailable.Value;
+    public bool IsAvailable => EnsureAvailabilityInitialized().Value;
 
     /// <summary>Searches NuGet packages that match the supplied term.</summary>
     /// <param name="term">The search term.</param>
@@ -72,14 +61,72 @@ public class AppViewModel : ReactiveObject
     /// <returns>The package detail view models that match the search term.</returns>
     private static async Task<IEnumerable<NugetDetailsViewModel>> SearchNuGetPackages(string? term, CancellationToken token)
     {
-        var providers = new List<Lazy<INuGetResourceProvider>>();
-        providers.AddRange(Repository.Provider.GetCoreV3()); // Add v3 API support
+        var providers = new List<Lazy<INuGetResourceProvider>>(Repository.Provider.GetCoreV3());
         var package = new PackageSource("https://api.nuget.org/v3/index.json");
         var source = new SourceRepository(package, providers);
 
         var filter = new SearchFilter(false);
         var resource = await source.GetResourceAsync<PackageSearchResource>().ConfigureAwait(false);
-        var metadata = await resource.SearchAsync(term, filter, 0, 10, new NuGet.Common.NullLogger(), token).ConfigureAwait(false);
-        return metadata.Select(x => new NugetDetailsViewModel(x));
+        var metadata = await resource.SearchAsync(
+                term,
+                filter,
+                0,
+                MaximumSearchResults,
+                new NuGet.Common.NullLogger(),
+                token)
+            .ConfigureAwait(false);
+        var results = new List<NugetDetailsViewModel>();
+        foreach (var packageMetadata in metadata)
+        {
+            results.Add(new(packageMetadata));
+        }
+
+        return results;
+    }
+
+    /// <summary>Initializes the lazily-created observable properties.</summary>
+    private void EnsurePropertiesInitialized()
+    {
+        _ = EnsureSearchResultsInitialized();
+        _ = EnsureAvailabilityInitialized();
+    }
+
+    /// <summary>Gets or initializes the observable search-results helper.</summary>
+    /// <returns>The initialized search-results helper.</returns>
+    private ObservableAsPropertyHelper<IEnumerable<NugetDetailsViewModel>> EnsureSearchResultsInitialized()
+    {
+        if (_searchResults is not null)
+        {
+            return _searchResults;
+        }
+
+        _searchResults = this
+            .WhenAnyValue(x => x.SearchTerm)
+            .Throttle(TimeSpan.FromMilliseconds(SearchDelayMilliseconds))
+            .Select(static term => term?.Trim())
+            .DistinctUntilChanged()
+            .Where(static term => !string.IsNullOrWhiteSpace(term))
+            .SelectMany(term => Signal.FromAsync(token => SearchNuGetPackages(term, token)))
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .ToProperty(this, x => x.SearchResults);
+        _ = _searchResults.ThrownExceptions.Subscribe(static error => { /* Handle errors here */ });
+        return _searchResults;
+    }
+
+    /// <summary>Gets or initializes the observable availability helper.</summary>
+    /// <returns>The initialized availability helper.</returns>
+    private ObservableAsPropertyHelper<bool> EnsureAvailabilityInitialized()
+    {
+        if (_isAvailable is not null)
+        {
+            return _isAvailable;
+        }
+
+        _ = EnsureSearchResultsInitialized();
+        _isAvailable = this
+            .WhenAnyValue(x => x.SearchResults)
+            .Select(static searchResults => searchResults is not null)
+            .ToProperty(this, x => x.IsAvailable);
+        return _isAvailable;
     }
 }

--- a/src/examples/Extensions.Hosting.ReactiveWpf.Example/MainWindow.xaml.cs
+++ b/src/examples/Extensions.Hosting.ReactiveWpf.Example/MainWindow.xaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveMarbles.Extensions.Hosting.Wpf;
@@ -21,7 +21,12 @@ public partial class MainWindow : ReactiveWindow<AppViewModel>, IWpfShell
     {
         InitializeComponent();
         ViewModel = new();
+    }
 
+    /// <inheritdoc />
+    protected override void OnInitialized(EventArgs e)
+    {
+        base.OnInitialized(e);
         _ = this.WhenActivated(disposableRegistration =>
         {
             _ = this.OneWayBind(

--- a/src/examples/Extensions.Hosting.ReactiveWpf.Example/NugetDetailsView.xaml.cs
+++ b/src/examples/Extensions.Hosting.ReactiveWpf.Example/NugetDetailsView.xaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows.Media.Imaging;
@@ -20,6 +20,12 @@ public partial class NugetDetailsView : ReactiveUserControl<NugetDetailsViewMode
     public NugetDetailsView()
     {
         InitializeComponent();
+    }
+
+    /// <inheritdoc />
+    protected override void OnInitialized(EventArgs e)
+    {
+        base.OnInitialized(e);
         _ = this.WhenActivated(disposableRegistration =>
         {
             // Our 4th parameter we convert from Url into a BitmapImage.
@@ -28,7 +34,7 @@ public partial class NugetDetailsView : ReactiveUserControl<NugetDetailsViewMode
                     ViewModel,
                     viewModel => viewModel.IconUrl,
                     view => view.IconImage.Source,
-                    url => url is null ? null : new BitmapImage(url))
+                    static url => url is null ? null : new BitmapImage(url))
                 .DisposeWith(disposableRegistration);
 
             _ = this.OneWayBind(

--- a/src/examples/Extensions.Hosting.ReactiveWpf.Example/NugetDetailsViewModel.cs
+++ b/src/examples/Extensions.Hosting.ReactiveWpf.Example/NugetDetailsViewModel.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
@@ -25,11 +25,8 @@ public class NugetDetailsViewModel : ReactiveObject
         _metadata = metadata;
         _defaultUrl = new("https://git.io/fAlfh");
 
-        var startInfo = new ProcessStartInfo(ProjectUrl?.ToString() ?? _defaultUrl.ToString())
-        {
-            UseShellExecute = true
-        };
-        OpenPage = ReactiveCommand.Create(() => OpenPackagePage(startInfo));
+        var projectUrl = ProjectUrl ?? _defaultUrl;
+        OpenPage = ReactiveCommand.Create(() => OpenPackagePage(projectUrl));
     }
 
     /// <summary>Gets the icon URL.</summary>
@@ -63,6 +60,16 @@ public class NugetDetailsViewModel : ReactiveObject
     public ReactiveCommand<Unit, Unit> OpenPage { get; }
 
     /// <summary>Opens the package page in the default system browser.</summary>
-    /// <param name="startInfo">The process start information.</param>
-    private static void OpenPackagePage(ProcessStartInfo startInfo) => _ = Process.Start(startInfo);
+    /// <param name="projectUrl">The package project URL.</param>
+    private static void OpenPackagePage(Uri projectUrl)
+    {
+        if (!string.Equals(projectUrl.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(projectUrl.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo("explorer.exe") { Arguments = projectUrl.AbsoluteUri, UseShellExecute = false };
+        _ = Process.Start(startInfo);
+    }
 }

--- a/src/examples/Extensions.Hosting.Wpf.Example/App.xaml.cs
+++ b/src/examples/Extensions.Hosting.Wpf.Example/App.xaml.cs
@@ -1,9 +1,10 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
 using System.IO;
+using System.Windows;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -18,23 +19,25 @@ public partial class App
 {
     /// <summary>Logs that another instance is already running.</summary>
     private static readonly Action<ILogger, string, Exception?> ApplicationAlreadyRunning =
-        LoggerMessage.Define<string>(LogLevel.Warning, new EventId(1, nameof(ApplicationAlreadyRunning)), "Application {ApplicationName} already running.");
+        LoggerMessage.Define<string>(LogLevel.Warning, new(1, nameof(ApplicationAlreadyRunning)), "Application {ApplicationName} already running.");
 
-    /// <summary>Initializes a new instance of the <see cref="App"/> class.</summary>
-    public App()
+    /// <inheritdoc />
+    protected override void OnStartup(StartupEventArgs e)
     {
+        base.OnStartup(e);
+
         // Replace the namespace with the namespace of your plugins
         const string nameSpace = "ReactiveMarbles.Plugin";
         var executableLocation = Path.GetDirectoryName(GetType().Assembly.Location);
         var host = Host.CreateDefaultBuilder()
             .ConfigureLogging()
             .ConfigureConfiguration(Environment.GetCommandLineArgs())
-            .ConfigureSingleInstance(builder =>
+            .ConfigureSingleInstance(static builder =>
             {
                 builder.MutexId = "{11D78650-4E8A-4D4E-95DC-B06047271CD3}";
 
                 // This is called when an instance was already started, this is in the second instance
-                builder.WhenNotFirstInstance = (hostingEnvironment, logger) =>
+                builder.WhenNotFirstInstance = static (hostingEnvironment, logger) =>
                     ApplicationAlreadyRunning(logger, hostingEnvironment.ApplicationName, null);
             })
             .ConfigurePlugins(pluginBuilder =>
@@ -51,7 +54,7 @@ public partial class App
                 var runtime = Path.GetFileName(executableLocation);
                 pluginBuilder?.IncludePlugins(@$"\Plugins\{runtime}\{nameSpace}*.dll");
             })
-            .ConfigureServices(serviceCollection => serviceCollection.AddTransient<SecondWindow>())
+            .ConfigureServices(static serviceCollection => serviceCollection.AddTransient<SecondWindow>())
             .ConfigureWpf(wpfBuilder => wpfBuilder.UseCurrentApplication(this).UseWindow<MainWindow>())
             .UseWpfLifetime()
             .UseConsoleLifetime()

--- a/src/examples/Extensions.Hosting.Wpf.Example/AppMixins.cs
+++ b/src/examples/Extensions.Hosting.Wpf.Example/AppMixins.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -28,7 +28,7 @@ public static class AppMixins
         /// <summary>Configures logging for the sample host.</summary>
         /// <returns>The configured host builder.</returns>
         internal IHostBuilder ConfigureLogging() =>
-            hostBuilder.ConfigureLogging((hostContext, configLogging) =>
+            hostBuilder.ConfigureLogging(static (hostContext, configLogging) =>
                 configLogging
                     .AddConfiguration(hostContext.Configuration.GetSection("Logging"))
                     .AddConsole()
@@ -44,7 +44,7 @@ public static class AppMixins
                 .AddCommandLine(args))
                 .ConfigureAppConfiguration((hostContext, configApp) =>
                 {
-                    _ = configApp.AddJsonFile(AppSettingsFilePrefix + ".json", optional: true);
+                    _ = configApp.AddJsonFile($"{AppSettingsFilePrefix}.json", optional: true);
                     if (!string.IsNullOrEmpty(hostContext.HostingEnvironment.EnvironmentName))
                     {
                         _ = configApp.AddJsonFile(AppSettingsFilePrefix + $".{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true);

--- a/src/examples/Extensions.Hosting.Wpf.Example/AssemblyInfo.cs
+++ b/src/examples/Extensions.Hosting.Wpf.Example/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows;

--- a/src/examples/Extensions.Hosting.Wpf.Example/MainWindow.xaml.cs
+++ b/src/examples/Extensions.Hosting.Wpf.Example/MainWindow.xaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -13,7 +13,7 @@ public partial class MainWindow : IWpfShell
 {
     /// <summary>Logs that the second window is opening.</summary>
     private static readonly Action<ILogger, Exception?> OpeningSecondWindow =
-        LoggerMessage.Define(LogLevel.Information, new EventId(1, nameof(OpenSecondWindow)), "Opening Second Window");
+        LoggerMessage.Define(LogLevel.Information, new(1, nameof(OpenSecondWindow)), "Opening Second Window");
 
     /// <summary>Stores the logger value.</summary>
     private readonly ILogger<MainWindow>? _logger;

--- a/src/examples/Extensions.Hosting.Wpf.Example/SecondWindow.xaml.cs
+++ b/src/examples/Extensions.Hosting.Wpf.Example/SecondWindow.xaml.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace Extensions.Hosting.Wpf.Example;

--- a/src/testconfig.json
+++ b/src/testconfig.json
@@ -4,24 +4,25 @@
             "parallel": false
         }
     },
-    "extensions": [
-        {
-            "extensionId": "Microsoft.Testing.Extensions.CodeCoverage",
-            "settings": {
-                "format": "cobertura",
-                "skipAutoProperties": true,
-                "modulePaths": {
-                    "include": [
-                        "^Extensions\\.Hosting\\..*$"
-                    ],
-                    "exclude": [
-                        ".*Tests.*",
-                        ".*TestRunner.*",
-                        "^Extensions\\.Hosting\\..*\\.Example$",
-                        "^Extensions\\.Logging\\..*"
+    "codeCoverage": {
+        "Configuration": {
+            "Format": "cobertura",
+            "IncludeTestAssembly": false,
+            "CodeCoverage": {
+                "ModulePaths": {
+                    "Exclude": [
+                        "(^|.*[/\\\\])[^/\\\\]*Tests[^/\\\\]*\\.(dll|exe)$",
+                        "(^|.*[/\\\\])[^/\\\\]*TestRunner[^/\\\\]*\\.(dll|exe)$",
+                        "(^|.*[/\\\\])[^/\\\\]*Benchmarks[^/\\\\]*\\.(dll|exe)$",
+                        "(^|.*[/\\\\])[^/\\\\]*\\.Example[^/\\\\]*\\.(dll|exe)$"
+                    ]
+                },
+                "Sources": {
+                    "Exclude": [
+                        ".*[/\\\\]obj[/\\\\].*"
                     ]
                 }
             }
         }
-    ]
+    }
 }

--- a/src/tests/Extensions.Hosting.Avalonia.Lifecycle.Tests/Extensions.Hosting.Avalonia.Lifecycle.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Avalonia.Lifecycle.Tests/Extensions.Hosting.Avalonia.Lifecycle.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.Avalonia.Lifecycle.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.Avalonia\Extensions.Hosting.Avalonia.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.Avalonia.Tests\AvaloniaHostedServiceTests.cs" Link="AvaloniaHostedServiceTests.cs" />
+    <Compile Include="..\Extensions.Hosting.Avalonia.Tests\LifecycleSignals.cs" Link="LifecycleSignals.cs" />
+    <Compile Include="..\Extensions.Hosting.Avalonia.Tests\RecordingAvaloniaService.cs" Link="RecordingAvaloniaService.cs" />
+    <Compile Include="..\Extensions.Hosting.Avalonia.Tests\TestApplication.cs" Link="TestApplication.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Avalonia.MultipleWindow.Tests/Extensions.Hosting.Avalonia.MultipleWindow.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Avalonia.MultipleWindow.Tests/Extensions.Hosting.Avalonia.MultipleWindow.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.Avalonia.MultipleWindow.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.Avalonia\Extensions.Hosting.Avalonia.csproj" />
+    <Compile Include="..\Extensions.Hosting.Avalonia.NativeWindow.Tests\NativeWindowLifecycleTests.cs" Link="NativeWindowLifecycleTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Avalonia.NativeWindow.Tests/NativeWindowLifecycleTests.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.NativeWindow.Tests/NativeWindowLifecycleTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Avalonia;
+
+namespace Extensions.Hosting.Avalonia.NativeWindow.Tests;
+
+/// <summary>Exercises native shell window paths in an isolated Avalonia test process.</summary>
+[NotInParallel]
+public sealed class NativeWindowLifecycleTests
+{
+    /// <summary>Gets the maximum duration allowed for a native window lifecycle.</summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+#if ONE_SHELL
+    /// <summary>Verifies a single configured shell is made the main window and shown.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task OneShellWindow_StartsAndShutsDownInDedicatedProcess()
+    {
+        var signals = new LifecycleSignals();
+        using var host = BuildHost(signals, static builder => builder.UseWindow<FirstShellWindow>());
+
+        await StartAndAwaitShutdown(host, signals);
+    }
+#else
+    /// <summary>Verifies multiple configured shells use the multiple-window lifetime path.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MultipleShellWindows_StartAndShutDownInDedicatedProcess()
+    {
+        var signals = new LifecycleSignals();
+        using var host = BuildHost(signals, static builder =>
+        {
+            _ = builder.UseWindow<FirstShellWindow>();
+            _ = builder.UseWindow<SecondShellWindow>();
+        });
+
+        await StartAndAwaitShutdown(host, signals);
+    }
+#endif
+
+    /// <summary>Builds a host with a native Avalonia application.</summary>
+    /// <param name="signals">Signals set by the Avalonia service at startup.</param>
+    /// <param name="configureWindows">Registers the shell windows to exercise.</param>
+    /// <returns>The configured host.</returns>
+    private static IHost BuildHost(LifecycleSignals signals, Action<IAvaloniaBuilder> configureWindows)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        _ = builder.Services.AddSingleton(signals);
+        _ = builder.Services.AddSingleton<IAvaloniaService, RecordingAvaloniaService>();
+        _ = builder.ConfigureAvalonia(avaloniaBuilder =>
+        {
+            _ = avaloniaBuilder.UseApplication<ShutdownApplication>();
+            configureWindows(avaloniaBuilder);
+        });
+        _ = builder.UseAvaloniaLifetime();
+        return builder.Build();
+    }
+
+    /// <summary>Starts a host on STA and waits for its application-requested shutdown.</summary>
+    /// <param name="host">The host to start.</param>
+    /// <param name="signals">Signals recorded during Avalonia startup.</param>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    private static async Task StartAndAwaitShutdown(IHost host, LifecycleSignals signals)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() => StartHost(host, completion)) { IsBackground = true };
+        SetApartmentState(thread, ApartmentState.STA);
+        thread.Start();
+
+        await signals.Initialized.Task.WaitAsync(Timeout);
+        await GetAvaloniaHostedService(host).StopAsync(CancellationToken.None).WaitAsync(Timeout);
+        await completion.Task.WaitAsync(Timeout);
+        await host.StopAsync().WaitAsync(Timeout);
+
+        await Assert.That(host.Services.GetRequiredService<IAvaloniaContext>().IsRunning).IsFalse();
+    }
+
+    /// <summary>Gets the Avalonia hosted service from a configured host.</summary>
+    /// <param name="host">The host that owns the service.</param>
+    /// <returns>The registered Avalonia hosted service.</returns>
+    private static AvaloniaHostedService GetAvaloniaHostedService(IHost host)
+    {
+        foreach (var service in host.Services.GetServices<IHostedService>())
+        {
+            if (service is AvaloniaHostedService avaloniaHostedService)
+            {
+                return avaloniaHostedService;
+            }
+        }
+
+        throw new InvalidOperationException("The host did not register an Avalonia hosted service.");
+    }
+
+    /// <summary>Starts a host and completes the supplied source from its result.</summary>
+    /// <param name="host">The host to start.</param>
+    /// <param name="completion">The completion source to set.</param>
+    private static void StartHost(IHost host, TaskCompletionSource completion)
+    {
+        try
+        {
+            var start = host.StartAsync();
+            _ = start.ContinueWith(
+                static (task, state) => CompleteTask(task, (TaskCompletionSource)state!),
+                completion,
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+        catch (Exception exception)
+        {
+            _ = completion.TrySetException(exception);
+        }
+    }
+
+    /// <summary>Sets a thread apartment state on Windows.</summary>
+    /// <param name="thread">The thread to configure.</param>
+    /// <param name="apartmentState">The requested apartment state.</param>
+    private static void SetApartmentState(Thread thread, ApartmentState apartmentState)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        thread.SetApartmentState(apartmentState);
+    }
+
+    /// <summary>Completes a task completion source from an arbitrary task result.</summary>
+    /// <param name="task">The task to inspect.</param>
+    /// <param name="completion">The source to complete.</param>
+    private static void CompleteTask(Task task, TaskCompletionSource completion)
+    {
+        if (task.IsFaulted)
+        {
+            _ = completion.TrySetException(task.Exception!.InnerExceptions);
+            return;
+        }
+
+        if (task.IsCanceled)
+        {
+            _ = completion.TrySetCanceled();
+            return;
+        }
+
+        _ = completion.TrySetResult();
+    }
+
+    /// <summary>An Avalonia application used by native window tests.</summary>
+    public sealed class ShutdownApplication : Application;
+
+    /// <summary>A first shell window.</summary>
+    public sealed class FirstShellWindow : Window, IAvaloniaShell;
+
+    /// <summary>A second shell window.</summary>
+    public sealed class SecondShellWindow : Window, IAvaloniaShell;
+
+    /// <summary>Records Avalonia service initialization.</summary>
+    /// <param name="signals">The signal store to update.</param>
+    public sealed class RecordingAvaloniaService(LifecycleSignals signals) : IAvaloniaService
+    {
+        /// <inheritdoc />
+        public void Initialize(Application application) => _ = signals.Initialized.TrySetResult(application);
+    }
+
+    /// <summary>Stores the application startup signal.</summary>
+    public sealed class LifecycleSignals
+    {
+        /// <summary>Gets the completion source for Avalonia service initialization.</summary>
+        public TaskCompletionSource<Application> Initialized { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/src/tests/Extensions.Hosting.Avalonia.OneWindow.Tests/Extensions.Hosting.Avalonia.OneWindow.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Avalonia.OneWindow.Tests/Extensions.Hosting.Avalonia.OneWindow.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.Avalonia.OneWindow.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <DefineConstants>$(DefineConstants);ONE_SHELL</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.Avalonia\Extensions.Hosting.Avalonia.csproj" />
+    <Compile Include="..\Extensions.Hosting.Avalonia.NativeWindow.Tests\NativeWindowLifecycleTests.cs" Link="NativeWindowLifecycleTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Avalonia.Reactive.Tests/Extensions.Hosting.Avalonia.Reactive.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Avalonia.Reactive.Tests/Extensions.Hosting.Avalonia.Reactive.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.Avalonia.Reactive.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.ReactiveUI.Avalonia.Reactive\Extensions.Hosting.ReactiveUI.Avalonia.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Avalonia.Reactive.Tests/ReactiveUiAvaloniaReactiveExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.Reactive.Tests/ReactiveUiAvaloniaReactiveExtensionsTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+
+namespace Extensions.Hosting.Avalonia.Reactive.Tests;
+
+/// <summary>Verifies the reactive-shim ReactiveUI and Splat host integration.</summary>
+[NotInParallel]
+public sealed class ReactiveUiAvaloniaReactiveExtensionsTests
+{
+    /// <summary>Verifies a built host maps its service provider to Splat and returns itself.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MapSplatLocator_WithHost_MapsServicesAndReturnsHost()
+    {
+        using var host = Host.CreateApplicationBuilder().Build();
+        IServiceProvider? receivedProvider = null;
+
+        var result = host.MapSplatLocator(provider => receivedProvider = provider);
+
+        await Assert.That(result).IsSameReferenceAs(host);
+        await Assert.That(receivedProvider).IsSameReferenceAs(host.Services);
+    }
+
+    /// <summary>Verifies application host builder configuration returns its receiver.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_WithApplicationBuilder_ReturnsBuilder()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var result = builder.ConfigureSplatForMicrosoftDependencyResolver();
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>Verifies host builder configuration executes while building its service container.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_WithHostBuilder_BuildsHost()
+    {
+        var builder = Host.CreateDefaultBuilder().ConfigureSplatForMicrosoftDependencyResolver();
+
+        using var host = builder.Build();
+
+        await Assert.That(host).IsNotNull();
+    }
+}

--- a/src/tests/Extensions.Hosting.Avalonia.Tests/AvaloniaBuilderExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.Tests/AvaloniaBuilderExtensionsTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using ReactiveMarbles.Extensions.Hosting.Avalonia;
+
+namespace Extensions.Hosting.Avalonia.Tests;
+
+/// <summary>Verifies configuration of <see cref="IAvaloniaBuilder"/> instances.</summary>
+public sealed class AvaloniaBuilderExtensionsTests
+{
+    /// <summary>Verifies that all configuration extensions persist their supplied settings.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigurationExtensions_PersistSettingsAndReturnOriginalBuilder()
+    {
+        var builder = new TestAvaloniaBuilder();
+        var application = new TestApplication();
+        var contextConfigured = false;
+        var appBuilderConfigured = false;
+
+        var windowResult = builder.UseWindow<TestShellWindow>();
+        var applicationResult = builder.UseApplication<TestApplication>();
+        var currentApplicationResult = builder.UseCurrentApplication(application);
+        var contextResult = builder.ConfigureContext(_ => contextConfigured = true);
+        var appBuilderResult = builder.ConfigureAppBuilder(_ => appBuilderConfigured = true);
+
+        await Assert.That(windowResult).IsSameReferenceAs(builder);
+        await Assert.That(applicationResult).IsSameReferenceAs(builder);
+        await Assert.That(currentApplicationResult).IsSameReferenceAs(builder);
+        await Assert.That(contextResult).IsSameReferenceAs(builder);
+        await Assert.That(appBuilderResult).IsSameReferenceAs(builder);
+        await Assert.That(builder.WindowTypes).Contains(typeof(TestShellWindow));
+        await Assert.That(builder.ApplicationType).IsEqualTo(typeof(TestApplication));
+        await Assert.That(builder.Application).IsSameReferenceAs(application);
+        await Assert.That(builder.ConfigureContextAction).IsNotNull();
+        await Assert.That(builder.ConfigureAppBuilderAction).IsNotNull();
+
+        builder.ConfigureContextAction!(new TestAvaloniaContext());
+        builder.ConfigureAppBuilderAction!(AppBuilder.Configure<TestApplication>());
+
+        await Assert.That(contextConfigured).IsTrue();
+        await Assert.That(appBuilderConfigured).IsTrue();
+    }
+
+    /// <summary>Verifies that builder configuration extensions guard null receivers.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigurationExtensions_WithNullBuilder_ThrowArgumentNullException()
+    {
+        IAvaloniaBuilder? builder = null;
+
+        var useWindow = () => builder!.UseWindow<TestShellWindow>();
+        var useApplication = () => builder!.UseApplication<TestApplication>();
+        var useCurrentApplication = () => builder!.UseCurrentApplication(new TestApplication());
+        var configureContext = () => builder!.ConfigureContext(static _ => { });
+        var configureAppBuilder = () => builder!.ConfigureAppBuilder(static _ => { });
+
+        await Assert.That(useWindow).Throws<ArgumentNullException>();
+        await Assert.That(useApplication).Throws<ArgumentNullException>();
+        await Assert.That(useCurrentApplication).Throws<ArgumentNullException>();
+        await Assert.That(configureContext).Throws<ArgumentNullException>();
+        await Assert.That(configureAppBuilder).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>A test implementation of the Avalonia builder contract.</summary>
+    private sealed class TestAvaloniaBuilder : IAvaloniaBuilder
+    {
+        /// <inheritdoc />
+        public Type? ApplicationType { get; set; }
+
+        /// <inheritdoc />
+        public Application? Application { get; set; }
+
+        /// <inheritdoc />
+        public IList<Type> WindowTypes { get; } = new List<Type>();
+
+        /// <inheritdoc />
+        public Action<IAvaloniaContext>? ConfigureContextAction { get; set; }
+
+        /// <inheritdoc />
+        public Action<AppBuilder>? ConfigureAppBuilderAction { get; set; }
+    }
+
+    /// <summary>A test implementation of the Avalonia context contract.</summary>
+    private sealed class TestAvaloniaContext : IAvaloniaContext
+    {
+        /// <inheritdoc />
+        public global::Avalonia.Controls.ShutdownMode ShutdownMode { get; set; }
+
+        /// <inheritdoc />
+        public bool IsLifetimeLinked { get; set; }
+
+        /// <inheritdoc />
+        public bool IsRunning { get; set; }
+
+        /// <inheritdoc />
+        public Application? AvaloniaApplication { get; set; }
+
+        /// <inheritdoc />
+        public global::Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime? ApplicationLifetime { get; set; }
+
+        /// <inheritdoc />
+        public global::Avalonia.Threading.Dispatcher Dispatcher => global::Avalonia.Threading.Dispatcher.UIThread;
+    }
+}

--- a/src/tests/Extensions.Hosting.Avalonia.Tests/AvaloniaHostedServiceTests.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.Tests/AvaloniaHostedServiceTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Avalonia;
+
+namespace Extensions.Hosting.Avalonia.Tests;
+
+/// <summary>Verifies the bounded hosted Avalonia application lifecycle.</summary>
+[NotInParallel]
+public sealed class AvaloniaHostedServiceTests
+{
+    /// <summary>Gets the maximum duration for a desktop lifecycle test.</summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>Verifies a desktop application starts on an STA thread and is shut down through the hosted service.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HostedAvaloniaApplication_StartsInitializesServicesAndStops()
+    {
+        var signals = new LifecycleSignals();
+        var host = BuildHost(signals, configureAppBuilder: true);
+        var service = GetHostedService(host);
+        var context = host.Services.GetRequiredService<IAvaloniaContext>();
+        await service.StartAsync(new(canceled: true));
+        await Assert.That(context.IsRunning).IsFalse();
+
+        var startupException = await StartOnMtaThread(service);
+        await Assert.That(startupException).IsTypeOf<InvalidOperationException>();
+
+        var start = StartHostOnStaThread(host);
+        try
+        {
+            var application = await signals.Initialized.Task.WaitAsync(Timeout);
+
+            await Assert.That(signals.AppBuilderConfigured).IsTrue();
+            await Assert.That(context.IsRunning).IsTrue();
+            await Assert.That(context.AvaloniaApplication).IsSameReferenceAs(application);
+
+            await service.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+            await start.WaitAsync(Timeout);
+        }
+        finally
+        {
+            if (start.IsCompleted)
+            {
+                await host.StopAsync().WaitAsync(Timeout);
+            }
+            else
+            {
+                await service.StopAsync(CancellationToken.None).WaitAsync(Timeout);
+                await start.WaitAsync(Timeout);
+                await host.StopAsync().WaitAsync(Timeout);
+            }
+
+            host.Dispose();
+        }
+
+        await Assert.That(context.IsRunning).IsFalse();
+    }
+
+    /// <summary>Creates a host configured with a non-visible Avalonia application.</summary>
+    /// <param name="signals">Lifecycle signals to register with the host.</param>
+    /// <param name="configureAppBuilder">Whether to configure the Avalonia application builder.</param>
+    /// <returns>The configured host.</returns>
+    private static IHost BuildHost(LifecycleSignals signals, bool configureAppBuilder = false)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        _ = builder.Services.AddSingleton(signals);
+        _ = builder.Services.AddSingleton<IAvaloniaService, RecordingAvaloniaService>();
+        Action<IAvaloniaBuilder>? configureAppBuilderAction = configureAppBuilder
+            ? avaloniaBuilder => avaloniaBuilder.ConfigureAppBuilder(_ => signals.AppBuilderConfigured = true)
+            : null;
+        _ = builder.ConfigureAvalonia(avaloniaBuilder =>
+        {
+            _ = avaloniaBuilder.UseApplication<TestApplication>();
+            configureAppBuilderAction?.Invoke(avaloniaBuilder);
+        });
+
+        return builder.Build();
+    }
+
+    /// <summary>Gets the Avalonia hosted service registered by a host.</summary>
+    /// <param name="host">The configured host.</param>
+    /// <returns>The registered Avalonia hosted service.</returns>
+    private static AvaloniaHostedService GetHostedService(IHost host)
+    {
+        foreach (var service in host.Services.GetServices<IHostedService>())
+        {
+            if (service is AvaloniaHostedService avaloniaHostedService)
+            {
+                return avaloniaHostedService;
+            }
+        }
+
+        throw new InvalidOperationException("The host did not register an Avalonia hosted service.");
+    }
+
+    /// <summary>Starts a host synchronously from a background STA thread.</summary>
+    /// <param name="host">The host to start.</param>
+    /// <returns>A task which completes when the Avalonia message loop stops.</returns>
+    private static Task StartHostOnStaThread(IHost host)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var start = host.StartAsync();
+                _ = start.ContinueWith(
+                    static (task, state) => CompleteTask(task, (TaskCompletionSource)state!),
+                    completion,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+            catch (Exception exception)
+            {
+                completion.SetException(exception);
+            }
+        }) { IsBackground = true };
+        SetApartmentState(thread, ApartmentState.STA);
+        thread.Start();
+        return completion.Task;
+    }
+
+    /// <summary>Sets a thread apartment state on Windows.</summary>
+    /// <param name="thread">The thread to configure.</param>
+    /// <param name="apartmentState">The requested apartment state.</param>
+    private static void SetApartmentState(Thread thread, ApartmentState apartmentState)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        thread.SetApartmentState(apartmentState);
+    }
+
+    /// <summary>Completes a task completion source from an arbitrary task result.</summary>
+    /// <param name="task">The task to inspect.</param>
+    /// <param name="completion">The source to complete.</param>
+    private static void CompleteTask(Task task, TaskCompletionSource completion)
+    {
+        if (task.IsFaulted)
+        {
+            _ = completion.TrySetException(task.Exception!.InnerExceptions);
+            return;
+        }
+
+        if (task.IsCanceled)
+        {
+            _ = completion.TrySetCanceled();
+            return;
+        }
+
+        _ = completion.TrySetResult();
+    }
+
+    /// <summary>Invokes Avalonia startup on an MTA thread.</summary>
+    /// <param name="service">The hosted service to start.</param>
+    /// <returns>A task containing the startup exception, if any.</returns>
+    private static Task<Exception?> StartOnMtaThread(AvaloniaHostedService service)
+    {
+        var completion = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                _ = service.StartAsync(CancellationToken.None);
+                _ = completion.TrySetResult(null);
+            }
+            catch (Exception exception)
+            {
+                _ = completion.TrySetResult(exception);
+            }
+        }) { IsBackground = true };
+        SetApartmentState(thread, ApartmentState.MTA);
+        thread.Start();
+        return completion.Task;
+    }
+}

--- a/src/tests/Extensions.Hosting.Avalonia.Tests/AvaloniaHostingExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.Tests/AvaloniaHostingExtensionsTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Avalonia;
+
+namespace Extensions.Hosting.Avalonia.Tests;
+
+/// <summary>Verifies host configuration for Avalonia.</summary>
+public sealed class AvaloniaHostingExtensionsTests
+{
+    /// <summary>Verifies service registration and context configuration through an application host builder.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureAvalonia_WithApplicationBuilder_RegistersConfiguredServices()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        var contextConfigured = false;
+        _ = builder.ConfigureAvalonia(avaloniaBuilder =>
+        {
+            _ = avaloniaBuilder.UseApplication<TestApplication>();
+            _ = avaloniaBuilder.UseWindow<TestShellWindow>();
+            _ = avaloniaBuilder.UseWindow<Window>();
+            _ = avaloniaBuilder.ConfigureContext(context =>
+            {
+                context.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+                contextConfigured = true;
+            });
+        });
+
+        using var host = builder.Build();
+        var context = host.Services.GetRequiredService<IAvaloniaContext>();
+        var application = host.Services.GetRequiredService<Application>();
+        var typedApplication = host.Services.GetRequiredService<TestApplication>();
+        var hostedServices = host.Services.GetServices<IHostedService>();
+
+        await Assert.That(contextConfigured).IsTrue();
+        await Assert.That(context.ShutdownMode).IsEqualTo(ShutdownMode.OnExplicitShutdown);
+        await Assert.That(application).IsSameReferenceAs(typedApplication);
+        await Assert.That(CountAvaloniaHostedServices(hostedServices)).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies repeated configuration shares the context and avoids duplicate hosting services.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureAvalonia_RepeatedApplicationBuilderCalls_ReusesContext()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        _ = builder.ConfigureAvalonia();
+        _ = builder.ConfigureAvalonia(static avaloniaBuilder => avaloniaBuilder.UseApplication<Application>());
+
+        using var host = builder.Build();
+        var hostedServices = host.Services.GetServices<IHostedService>();
+
+        await Assert.That(host.Services.GetRequiredService<IAvaloniaContext>()).IsNotNull();
+        await Assert.That(host.Services.GetRequiredService<Application>()).IsNotNull();
+        await Assert.That(CountAvaloniaHostedServices(hostedServices)).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies an existing Avalonia application is preserved during service registration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureAvalonia_WithCurrentApplication_RegistersProvidedInstance()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        var application = new TestApplication();
+        _ = builder.ConfigureAvalonia(avaloniaBuilder => avaloniaBuilder.UseCurrentApplication(application));
+
+        using var host = builder.Build();
+
+        await Assert.That(host.Services.GetRequiredService<TestApplication>()).IsSameReferenceAs(application);
+        await Assert.That(host.Services.GetRequiredService<Application>()).IsSameReferenceAs(application);
+    }
+
+    /// <summary>Verifies invalid application types fail when the host is built.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureAvalonia_WithInvalidApplicationType_ThrowsArgumentException()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        var configure = () => builder.ConfigureAvalonia(static avaloniaBuilder => avaloniaBuilder.ApplicationType = typeof(string));
+
+        await Assert.That(configure).Throws<ArgumentException>();
+    }
+
+    /// <summary>Verifies lifecycle configuration requires Avalonia configuration first.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseAvaloniaLifetime_BeforeConfigureAvalonia_ThrowsNotSupportedException()
+    {
+        var applicationBuilder = Host.CreateApplicationBuilder();
+        var applicationBuilderAction = () => applicationBuilder.UseAvaloniaLifetime();
+        var hostBuilder = Host.CreateDefaultBuilder().UseAvaloniaLifetime();
+        var hostBuilderAction = () => hostBuilder.Build();
+
+        await Assert.That(applicationBuilderAction).Throws<NotSupportedException>();
+        await Assert.That(hostBuilderAction).Throws<NotSupportedException>();
+    }
+
+    /// <summary>Verifies default and explicit lifetime configuration update the shared Avalonia context.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseAvaloniaLifetime_AfterConfigureAvalonia_UpdatesContext()
+    {
+        var applicationBuilder = Host.CreateApplicationBuilder();
+        _ = applicationBuilder.ConfigureAvalonia();
+        _ = applicationBuilder.UseAvaloniaLifetime(ShutdownMode.OnExplicitShutdown);
+
+        using var applicationHost = applicationBuilder.Build();
+        var applicationContext = applicationHost.Services.GetRequiredService<IAvaloniaContext>();
+
+        var hostBuilder = Host.CreateDefaultBuilder().ConfigureAvalonia().UseAvaloniaLifetime();
+        using var host = hostBuilder.Build();
+        var context = host.Services.GetRequiredService<IAvaloniaContext>();
+
+        await Assert.That(applicationContext.IsLifetimeLinked).IsTrue();
+        await Assert.That(applicationContext.ShutdownMode).IsEqualTo(ShutdownMode.OnExplicitShutdown);
+        await Assert.That(context.IsLifetimeLinked).IsTrue();
+        await Assert.That(context.ShutdownMode).IsEqualTo(ShutdownMode.OnLastWindowClose);
+    }
+
+    /// <summary>Verifies host-builder configuration registers Avalonia application services.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureAvalonia_WithHostBuilder_RegistersApplication()
+    {
+        var hostBuilder = Host.CreateDefaultBuilder().ConfigureAvalonia(static avaloniaBuilder => avaloniaBuilder.UseApplication<TestApplication>());
+
+        using var host = hostBuilder.Build();
+
+        await Assert.That(host.Services.GetRequiredService<Application>()).IsTypeOf<TestApplication>();
+    }
+
+    /// <summary>Verifies host builder extensions guard null receivers.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HostBuilderExtensions_WithNullBuilder_ThrowArgumentNullException()
+    {
+        IHostBuilder? builder = null;
+        var configure = () => builder!.ConfigureAvalonia(static _ => { });
+        var lifetime = () => builder!.UseAvaloniaLifetime(ShutdownMode.OnMainWindowClose);
+
+        await Assert.That(configure).Throws<ArgumentNullException>();
+        await Assert.That(lifetime).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies application host builder lifetime extensions guard null receivers.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HostApplicationBuilderLifetimeExtensions_WithNullBuilder_ThrowArgumentNullException()
+    {
+        IHostApplicationBuilder? builder = null;
+        var lifetime = () => builder!.UseAvaloniaLifetime(ShutdownMode.OnMainWindowClose);
+
+        await Assert.That(lifetime).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Counts Avalonia hosted services in a collection.</summary>
+    /// <param name="services">The service collection to inspect.</param>
+    /// <returns>The number of Avalonia hosted services.</returns>
+    private static int CountAvaloniaHostedServices(IEnumerable<IHostedService> services)
+    {
+        var count = 0;
+        foreach (var service in services)
+        {
+            if (service is AvaloniaHostedService)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/src/tests/Extensions.Hosting.Avalonia.Tests/Extensions.Hosting.Avalonia.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Avalonia.Tests/Extensions.Hosting.Avalonia.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.Avalonia.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.Avalonia\Extensions.Hosting.Avalonia.csproj" />
+    <ProjectReference Include="..\..\Extensions.Hosting.ReactiveUI.Avalonia\Extensions.Hosting.ReactiveUI.Avalonia.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="AvaloniaHostedServiceTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Avalonia.Tests/LifecycleSignals.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.Tests/LifecycleSignals.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+
+namespace Extensions.Hosting.Avalonia.Tests;
+
+/// <summary>Captures bounded Avalonia application lifecycle events.</summary>
+public sealed class LifecycleSignals
+{
+    /// <summary>Gets the application initialization completion source.</summary>
+    public TaskCompletionSource<Application> Initialized { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Gets or sets a value indicating whether the app builder was configured.</summary>
+    public bool AppBuilderConfigured { get; set; }
+}

--- a/src/tests/Extensions.Hosting.Avalonia.Tests/ReactiveUiAvaloniaExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.Tests/ReactiveUiAvaloniaExtensionsTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+
+namespace Extensions.Hosting.Avalonia.Tests;
+
+/// <summary>Verifies ReactiveUI and Splat host integration.</summary>
+[NotInParallel]
+public sealed class ReactiveUiAvaloniaExtensionsTests
+{
+    /// <summary>Verifies a built host maps its service provider to Splat and returns itself.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MapSplatLocator_WithHost_MapsServicesAndReturnsHost()
+    {
+        using var host = Host.CreateApplicationBuilder().Build();
+        IServiceProvider? receivedProvider = null;
+
+        var result = host.MapSplatLocator(provider => receivedProvider = provider);
+
+        await Assert.That(result).IsSameReferenceAs(host);
+        await Assert.That(receivedProvider).IsSameReferenceAs(host.Services);
+    }
+
+    /// <summary>Verifies mapping tolerates a null host and invokes the callback with null.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MapSplatLocator_WithNullHost_InvokesCallbackWithNull()
+    {
+        IHost host = null!;
+        IServiceProvider? receivedProvider = null;
+
+        var result = host.MapSplatLocator(provider => receivedProvider = provider);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(receivedProvider).IsNull();
+    }
+
+    /// <summary>Verifies application host builder configuration returns its receiver.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_WithApplicationBuilder_ReturnsBuilder()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var result = builder.ConfigureSplatForMicrosoftDependencyResolver();
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>Verifies host builder configuration executes while building its service container.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_WithHostBuilder_BuildsHost()
+    {
+        var builder = Host.CreateDefaultBuilder().ConfigureSplatForMicrosoftDependencyResolver();
+
+        using var host = builder.Build();
+
+        await Assert.That(host).IsNotNull();
+    }
+}

--- a/src/tests/Extensions.Hosting.Avalonia.Tests/RecordingAvaloniaService.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.Tests/RecordingAvaloniaService.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using ReactiveMarbles.Extensions.Hosting.Avalonia;
+
+namespace Extensions.Hosting.Avalonia.Tests;
+
+/// <summary>Signals application service initialization without opening a window.</summary>
+/// <param name="signals">The signal store updated on application initialization.</param>
+public sealed class RecordingAvaloniaService(LifecycleSignals signals) : IAvaloniaService
+{
+    /// <inheritdoc />
+    public void Initialize(Application application) => _ = signals.Initialized.TrySetResult(application);
+}

--- a/src/tests/Extensions.Hosting.Avalonia.Tests/TestApplication.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.Tests/TestApplication.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+
+namespace Extensions.Hosting.Avalonia.Tests;
+
+/// <summary>An Avalonia application used by hosting tests.</summary>
+public sealed class TestApplication : Application;

--- a/src/tests/Extensions.Hosting.Avalonia.Tests/TestShellWindow.cs
+++ b/src/tests/Extensions.Hosting.Avalonia.Tests/TestShellWindow.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia.Controls;
+using ReactiveMarbles.Extensions.Hosting.Avalonia;
+
+namespace Extensions.Hosting.Avalonia.Tests;
+
+/// <summary>A shell window used to verify shell registration.</summary>
+public sealed class TestShellWindow : Window, IAvaloniaShell;

--- a/src/tests/Extensions.Hosting.DataLogging.Tests/EntityFrameworkCoreExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.DataLogging.Tests/EntityFrameworkCoreExtensionsTests.cs
@@ -1,0 +1,495 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+extern alias Sqlite;
+extern alias SqlServer;
+using SqlServerExtensions = SqlServer::ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore.HostBuilderEntityFrameworkCoreExtensions;
+using SqliteExtensions = Sqlite::ReactiveMarbles.Extensions.Hosting.Identity.EntityFrameworkCore.HostBuilderEntityFrameworkCoreExtensions;
+
+namespace Extensions.Hosting.DataLogging.Tests;
+
+/// <summary>Contains Entity Framework Core extension coverage tests.</summary>
+public class EntityFrameworkCoreExtensionsTests
+{
+    /// <summary>Names the configured connection string.</summary>
+    private const string DatabaseConnectionName = "Database";
+
+    /// <summary>Names an absent connection string.</summary>
+    private const string MissingConnectionName = "Missing";
+
+    /// <summary>Provides an in-memory SQLite connection string.</summary>
+    private const string SqliteMemoryConnectionString = "Data Source=:memory:";
+
+    /// <summary>Provides a non-secret SQL Server connection-string value for options registration tests.</summary>
+    private const string SqlServerConnectionString = "Server=(localdb)\\MSSQLLocalDB;Database=ExtensionHostingTests;Trusted_Connection=True;";
+
+    /// <summary>Names the SQL Server Entity Framework Core provider.</summary>
+    private const string SqlServerProviderName = "Microsoft.EntityFrameworkCore.SqlServer";
+
+    /// <summary>Names the SQLite Entity Framework Core provider.</summary>
+    private const string SqliteProviderName = "Microsoft.EntityFrameworkCore.Sqlite";
+
+    /// <summary>Provides an ephemeral loopback URL for web-host tests.</summary>
+    private const string EphemeralWebHostUrl = "http://127.0.0.1:0";
+
+    /// <summary>Provides requests to the ephemeral web hosts.</summary>
+    private static readonly HttpClient _httpClient = new();
+
+    /// <summary>Verifies SQL Server application-builder registrations.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task SqlServerConfigurationExtensions_ValidateAndRetrieveConnectionStrings()
+    {
+        var configuration = CreateConfiguration();
+
+        await Assert.That(SqlServerExtensions.HasConnectionString(configuration, DatabaseConnectionName)).IsTrue();
+        await Assert.That(SqlServerExtensions.HasConnectionString(configuration, MissingConnectionName)).IsFalse();
+        await Assert.That(SqlServerExtensions.HasConnectionString(configuration, " ")).IsFalse();
+        await Assert.That(SqlServerExtensions.GetRequiredConnectionString(configuration, DatabaseConnectionName)).IsEqualTo(SqlServerConnectionString);
+
+        var missing = () => SqlServerExtensions.GetRequiredConnectionString(configuration, MissingConnectionName);
+        var whitespace = () => SqlServerExtensions.GetRequiredConnectionString(configuration, " ");
+        await Assert.That(missing).Throws<InvalidOperationException>();
+        await Assert.That(whitespace).Throws<ArgumentException>();
+    }
+
+    /// <summary>Verifies SQL Server application-builder validation.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task SqlServerApplicationBuilderRegistrations_RegisterAllOverloads()
+    {
+        var databaseBuilder = CreateApplicationBuilder();
+        var databaseResult = SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(databaseBuilder, DatabaseConnectionName);
+        await Assert.That(databaseResult).IsEqualTo(databaseBuilder);
+        await Assert.That(ContainsService<SqlServerContext>(databaseBuilder.Services)).IsTrue();
+        await Assert.That(GetProviderName<SqlServerContext>(databaseBuilder.Services)).IsEqualTo(SqlServerProviderName);
+
+        var databaseLifetimeBuilder = CreateApplicationBuilder();
+        var databaseLifetimeResult = SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(databaseLifetimeBuilder, DatabaseConnectionName, ServiceLifetime.Singleton);
+        await Assert.That(databaseLifetimeResult).IsEqualTo(databaseLifetimeBuilder);
+
+        var userIdentityBuilder = CreateApplicationBuilder();
+        var userIdentityResult = SqlServerExtensions.AddSqlServerWithIdentity<SqlServerIdentityContext, TestUser>(userIdentityBuilder, DatabaseConnectionName);
+        await Assert.That(userIdentityResult).IsEqualTo(userIdentityBuilder);
+        await Assert.That(ContainsService<SqlServerIdentityContext>(userIdentityBuilder.Services)).IsTrue();
+        await Assert.That(GetProviderName<SqlServerIdentityContext>(userIdentityBuilder.Services)).IsEqualTo(SqlServerProviderName);
+
+        var userIdentityLifetimeBuilder = CreateApplicationBuilder();
+        var userIdentityLifetimeResult = SqlServerExtensions.AddSqlServerWithIdentity<SqlServerIdentityContext, TestUser>(
+            userIdentityLifetimeBuilder,
+            DatabaseConnectionName,
+            ServiceLifetime.Singleton);
+        await Assert.That(userIdentityLifetimeResult).IsEqualTo(userIdentityLifetimeBuilder);
+
+        var roleIdentityBuilder = CreateApplicationBuilder();
+        var roleIdentityResult = SqlServerExtensions.AddSqlServerWithIdentity<SqlServerIdentityContext, TestUser, TestRole>(roleIdentityBuilder, DatabaseConnectionName);
+        await Assert.That(roleIdentityResult).IsEqualTo(roleIdentityBuilder);
+        await Assert.That(ContainsService<SqlServerIdentityContext>(roleIdentityBuilder.Services)).IsTrue();
+        await Assert.That(GetProviderName<SqlServerIdentityContext>(roleIdentityBuilder.Services)).IsEqualTo(SqlServerProviderName);
+
+        var roleIdentityLifetimeBuilder = CreateApplicationBuilder();
+        var roleIdentityLifetimeResult = SqlServerExtensions.AddSqlServerWithIdentity<SqlServerIdentityContext, TestUser, TestRole>(
+            roleIdentityLifetimeBuilder,
+            DatabaseConnectionName,
+            ServiceLifetime.Singleton);
+        await Assert.That(roleIdentityLifetimeResult).IsEqualTo(roleIdentityLifetimeBuilder);
+    }
+
+    /// <summary>Verifies SQL Server service-collection registrations.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task SqlServerApplicationBuilderRegistrations_ValidateArgumentsAndMissingConnections()
+    {
+        IHostApplicationBuilder? nullBuilder = null;
+        var nullBuilderAction = () => SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(nullBuilder!, DatabaseConnectionName, ServiceLifetime.Scoped);
+        await Assert.That(nullBuilderAction).Throws<ArgumentNullException>();
+
+        var builder = CreateApplicationBuilder();
+        var whitespace = () => SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(builder, " ", ServiceLifetime.Scoped);
+        await Assert.That(whitespace).Throws<ArgumentException>();
+
+        var missingBuilder = Host.CreateApplicationBuilder();
+        _ = SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(missingBuilder, MissingConnectionName, ServiceLifetime.Scoped);
+        await using var provider = missingBuilder.Services.BuildServiceProvider();
+        var missing = () => provider.GetRequiredService<SqlServerContext>();
+        await Assert.That(missing).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies SQL Server service-collection validation.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task SqlServerServiceCollectionRegistrations_RegisterAllOverloadsAndProviders()
+    {
+        var configuration = CreateConfiguration();
+        var context = new WebHostBuilderContext { Configuration = configuration };
+
+        var databaseServices = new ServiceCollection();
+        var databaseResult = SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(databaseServices, configuration, DatabaseConnectionName);
+        await Assert.That(databaseResult).IsEqualTo(databaseServices);
+        await Assert.That(GetProviderName<SqlServerContext>(databaseServices)).IsEqualTo(SqlServerProviderName);
+
+        var databaseLifetimeServices = new ServiceCollection();
+        var databaseLifetimeResult = SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(databaseLifetimeServices, configuration, DatabaseConnectionName, ServiceLifetime.Singleton);
+        await Assert.That(databaseLifetimeResult).IsEqualTo(databaseLifetimeServices);
+
+        var connectionStringServices = new ServiceCollection();
+        var connectionStringResult = SqlServerExtensions.AddSqlServerDbContextWithConnectionString<SqlServerContext>(connectionStringServices, SqlServerConnectionString);
+        await Assert.That(connectionStringResult).IsEqualTo(connectionStringServices);
+        await Assert.That(GetProviderName<SqlServerContext>(connectionStringServices)).IsEqualTo(SqlServerProviderName);
+
+        var connectionStringLifetimeServices = new ServiceCollection();
+        var connectionStringLifetimeResult = SqlServerExtensions.AddSqlServerDbContextWithConnectionString<SqlServerContext>(
+            connectionStringLifetimeServices,
+            SqlServerConnectionString,
+            ServiceLifetime.Singleton);
+        await Assert.That(connectionStringLifetimeResult).IsEqualTo(connectionStringLifetimeServices);
+
+        var userServices = new ServiceCollection();
+        var userResult = SqlServerExtensions.UseEntityFrameworkCoreSqlServer<SqlServerIdentityContext, TestUser>(userServices, context, DatabaseConnectionName);
+        await Assert.That(userResult).IsEqualTo(userServices);
+        await Assert.That(ContainsService<SqlServerIdentityContext>(userServices)).IsTrue();
+
+        var userLifetimeServices = new ServiceCollection();
+        var userLifetimeResult = SqlServerExtensions.UseEntityFrameworkCoreSqlServer<SqlServerIdentityContext, TestUser>(
+            userLifetimeServices,
+            context,
+            DatabaseConnectionName,
+            ServiceLifetime.Singleton);
+        await Assert.That(userLifetimeResult).IsEqualTo(userLifetimeServices);
+
+        var roleServices = new ServiceCollection();
+        var roleResult = SqlServerExtensions.UseEntityFrameworkCoreSqlServer<SqlServerIdentityContext, TestUser, TestRole>(roleServices, context, DatabaseConnectionName);
+        await Assert.That(roleResult).IsEqualTo(roleServices);
+        await Assert.That(ContainsService<SqlServerIdentityContext>(roleServices)).IsTrue();
+
+        var roleLifetimeServices = new ServiceCollection();
+        var roleLifetimeResult = SqlServerExtensions.UseEntityFrameworkCoreSqlServer<SqlServerIdentityContext, TestUser, TestRole>(
+            roleLifetimeServices,
+            context,
+            DatabaseConnectionName,
+            ServiceLifetime.Singleton);
+        await Assert.That(roleLifetimeResult).IsEqualTo(roleLifetimeServices);
+        await Assert.That(GetProviderName<SqlServerIdentityContext>(userServices)).IsEqualTo(SqlServerProviderName);
+        await Assert.That(GetProviderName<SqlServerIdentityContext>(roleServices)).IsEqualTo(SqlServerProviderName);
+    }
+
+    /// <summary>Verifies SQLite application-builder and service registrations.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task SqlServerServiceCollectionRegistrations_ValidateArguments()
+    {
+        var configuration = CreateConfiguration();
+        var context = new WebHostBuilderContext { Configuration = configuration };
+        IServiceCollection? nullServices = null;
+        var nullServicesAction = () => SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(nullServices!, configuration, DatabaseConnectionName, ServiceLifetime.Scoped);
+        await Assert.That(nullServicesAction).Throws<ArgumentNullException>();
+
+        var services = new ServiceCollection();
+        IConfiguration? nullConfiguration = null;
+        var nullConfigurationAction = () => SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(services, nullConfiguration!, DatabaseConnectionName, ServiceLifetime.Scoped);
+        var nullContextAction = () => SqlServerExtensions.UseEntityFrameworkCoreSqlServer<SqlServerIdentityContext, TestUser>(services, null!, DatabaseConnectionName, ServiceLifetime.Scoped);
+        var whitespace = () => SqlServerExtensions.AddSqlServerDbContextWithConnectionString<SqlServerContext>(services, " ", ServiceLifetime.Scoped);
+        await Assert.That(nullConfigurationAction).Throws<ArgumentNullException>();
+        await Assert.That(nullContextAction).Throws<ArgumentNullException>();
+        await Assert.That(whitespace).Throws<ArgumentException>();
+
+        var missingServices = new ServiceCollection();
+        _ = SqlServerExtensions.AddSqlServerDbContext<SqlServerContext>(missingServices, configuration, MissingConnectionName, ServiceLifetime.Scoped);
+        await using var provider = missingServices.BuildServiceProvider();
+        var missing = () => provider.GetRequiredService<SqlServerContext>();
+        await Assert.That(missing).Throws<InvalidOperationException>();
+
+        await Assert.That(context.Configuration).IsEqualTo(configuration);
+    }
+
+    /// <summary>Verifies SQLite helpers and validation behavior.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task SqliteApplicationBuilderAndServiceCollectionRegistrations_RegisterAllOverloads()
+    {
+        var builder = CreateApplicationBuilder();
+        await Assert.That(SqliteExtensions.AddSqliteDbContext<SqliteContext>(builder, DatabaseConnectionName)).IsEqualTo(builder);
+        await Assert.That(GetProviderName<SqliteContext>(builder.Services)).IsEqualTo(SqliteProviderName);
+        await Assert.That(SqliteExtensions.AddSqliteDbContext<SqliteContext>(builder, DatabaseConnectionName, ServiceLifetime.Singleton)).IsEqualTo(builder);
+
+        var userBuilder = CreateApplicationBuilder();
+        await Assert.That(SqliteExtensions.AddSqliteWithIdentity<SqliteIdentityContext, TestUser>(userBuilder, DatabaseConnectionName)).IsEqualTo(userBuilder);
+        await Assert.That(GetProviderName<SqliteIdentityContext>(userBuilder.Services)).IsEqualTo(SqliteProviderName);
+        await Assert.That(SqliteExtensions.AddSqliteWithIdentity<SqliteIdentityContext, TestUser>(userBuilder, DatabaseConnectionName, ServiceLifetime.Singleton)).IsEqualTo(userBuilder);
+
+        var roleBuilder = CreateApplicationBuilder();
+        await Assert.That(SqliteExtensions.AddSqliteWithIdentity<SqliteIdentityContext, TestUser, TestRole>(roleBuilder, DatabaseConnectionName)).IsEqualTo(roleBuilder);
+        await Assert.That(GetProviderName<SqliteIdentityContext>(roleBuilder.Services)).IsEqualTo(SqliteProviderName);
+        await Assert.That(SqliteExtensions.AddSqliteWithIdentity<SqliteIdentityContext, TestUser, TestRole>(roleBuilder, DatabaseConnectionName, ServiceLifetime.Singleton)).IsEqualTo(roleBuilder);
+
+        var configuration = CreateConfiguration();
+        var context = new WebHostBuilderContext { Configuration = configuration };
+        var services = new ServiceCollection();
+        await Assert.That(SqliteExtensions.AddSqliteDbContext<SqliteContext>(services, configuration, DatabaseConnectionName)).IsEqualTo(services);
+        await Assert.That(GetProviderName<SqliteContext>(services)).IsEqualTo(SqliteProviderName);
+        await Assert.That(SqliteExtensions.AddSqliteDbContext<SqliteContext>(services, configuration, DatabaseConnectionName, ServiceLifetime.Singleton)).IsEqualTo(services);
+        await Assert.That(SqliteExtensions.AddSqliteDbContextWithConnectionString<SqliteContext>(services, SqliteMemoryConnectionString)).IsEqualTo(services);
+        await Assert.That(SqliteExtensions.AddSqliteDbContextWithConnectionString<SqliteContext>(services, SqliteMemoryConnectionString, ServiceLifetime.Singleton)).IsEqualTo(services);
+        await Assert.That(SqliteExtensions.UseEntityFrameworkCoreSqlite<SqliteIdentityContext, TestUser>(services, context, DatabaseConnectionName)).IsEqualTo(services);
+        await Assert.That(SqliteExtensions.UseEntityFrameworkCoreSqlite<SqliteIdentityContext, TestUser>(services, context, DatabaseConnectionName, ServiceLifetime.Singleton)).IsEqualTo(services);
+        await Assert.That(SqliteExtensions.UseEntityFrameworkCoreSqlite<SqliteIdentityContext, TestUser, TestRole>(services, context, DatabaseConnectionName)).IsEqualTo(services);
+        await Assert.That(SqliteExtensions.UseEntityFrameworkCoreSqlite<SqliteIdentityContext, TestUser, TestRole>(
+            services,
+            context,
+            DatabaseConnectionName,
+            ServiceLifetime.Singleton)).IsEqualTo(services);
+        await Assert.That(GetProviderName<SqliteContext>(services)).IsEqualTo(SqliteProviderName);
+        await Assert.That(GetProviderName<SqliteIdentityContext>(services)).IsEqualTo(SqliteProviderName);
+    }
+
+    /// <summary>Verifies SQL Server web-host service overloads.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task SqliteExtensions_CreateConnectionStringsAndValidateArguments()
+    {
+        var memoryConnection = SqliteExtensions.CreateInMemoryConnectionString();
+        var namedMemoryConnection = SqliteExtensions.CreateInMemoryConnectionString("database");
+        var nullMemoryConnection = SqliteExtensions.CreateInMemoryConnectionString(null);
+        await Assert.That(memoryConnection).IsEqualTo("DataSource=:memory:");
+        await Assert.That(namedMemoryConnection).IsEqualTo("DataSource=database;Mode=Memory;Cache=Shared");
+        await Assert.That(nullMemoryConnection).IsEqualTo("DataSource=:memory:");
+        await Assert.That(SqliteExtensions.CreateFileConnectionString("database.db")).IsEqualTo("DataSource=database.db");
+
+        var builder = CreateApplicationBuilder();
+        var whitespace = () => SqliteExtensions.AddSqliteDbContext<SqliteContext>(builder, " ", ServiceLifetime.Scoped);
+        await Assert.That(whitespace).Throws<ArgumentException>();
+
+        var services = new ServiceCollection();
+        var nullServices = static () => SqliteExtensions.AddSqliteDbContextWithConnectionString<SqliteContext>(null!, SqliteMemoryConnectionString, ServiceLifetime.Scoped);
+        var nullConfiguration = () => SqliteExtensions.AddSqliteDbContext<SqliteContext>(services, null!, DatabaseConnectionName, ServiceLifetime.Scoped);
+        var emptyConnectionString = () => SqliteExtensions.AddSqliteDbContextWithConnectionString<SqliteContext>(services, " ", ServiceLifetime.Scoped);
+        await Assert.That(nullServices).Throws<ArgumentNullException>();
+        await Assert.That(nullConfiguration).Throws<ArgumentNullException>();
+        await Assert.That(emptyConnectionString).Throws<ArgumentException>();
+    }
+
+    /// <summary>Verifies SQLite web-host service overloads.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task WebHostServiceOverloads_ReturnBuildersAndRunConfiguration()
+    {
+        var serviceConfigured = false;
+        var webHostConfigured = false;
+        var appConfigured = false;
+
+        var first = CreateWebHostBuilder();
+        await Assert.That(SqlServerExtensions.UseWebHostServices(first, (context, services) =>
+        {
+            _ = context;
+            serviceConfigured = true;
+            _ = services.AddSingleton(new WebHostMarker());
+        })).IsEqualTo(first);
+        using var firstHost = first.Build();
+        await firstHost.StartAsync();
+        await Assert.That(await SendRequestAsync(firstHost)).IsTrue();
+        await firstHost.StopAsync();
+
+        var second = CreateWebHostBuilder();
+        await Assert.That(SqlServerExtensions.UseWebHostServices(second, static (_, _) => { }, true)).IsEqualTo(second);
+        using var secondHost = second.Build();
+        await secondHost.StartAsync();
+        await secondHost.StopAsync();
+
+        var third = CreateWebHostBuilder();
+        await Assert.That(SqlServerExtensions.UseWebHostServices(third, static (_, _) => { }, builder =>
+        {
+            webHostConfigured = true;
+            return builder;
+        })).IsEqualTo(third);
+        using var thirdHost = third.Build();
+        await thirdHost.StartAsync();
+        await Assert.That(await SendRequestAsync(thirdHost)).IsTrue();
+        await thirdHost.StopAsync();
+
+        var fourth = CreateWebHostBuilder();
+        await Assert.That(SqlServerExtensions.UseWebHostServices(fourth, static (_, _) => { }, static builder => builder, true)).IsEqualTo(fourth);
+        using var fourthHost = fourth.Build();
+        await fourthHost.StartAsync();
+        await fourthHost.StopAsync();
+
+        var fifth = CreateWebHostBuilder();
+        await Assert.That(SqlServerExtensions.UseWebHostServices(fifth, static (_, _) => { }, static builder => builder.UseUrls(EphemeralWebHostUrl), app =>
+        {
+            appConfigured = true;
+            return app;
+        })).IsEqualTo(fifth);
+        using var fifthHost = fifth.Build();
+        await fifthHost.StartAsync();
+        await Assert.That(await SendRequestAsync(fifthHost)).IsTrue();
+        await fifthHost.StopAsync();
+
+        var sixth = CreateWebHostBuilder();
+        await Assert.That(SqlServerExtensions.UseWebHostServices(sixth, static (_, _) => { }, static builder => builder, static app => app, true)).IsEqualTo(sixth);
+        using var sixthHost = sixth.Build();
+        await sixthHost.StartAsync();
+        await sixthHost.StopAsync();
+
+        IHostBuilder? nullBuilder = null;
+        var nullBuilderAction = () => SqlServerExtensions.UseWebHostServices(nullBuilder!, static (_, _) => { }, true);
+        await Assert.That(nullBuilderAction).Throws<ArgumentNullException>();
+        await Assert.That(serviceConfigured).IsTrue();
+        await Assert.That(webHostConfigured).IsTrue();
+        await Assert.That(appConfigured).IsTrue();
+    }
+
+    /// <summary>Verifies SQLite web-host service overloads.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task SqliteWebHostServiceOverloads_ReturnBuildersAndRunConfiguration()
+    {
+        var serviceConfigured = false;
+        var webHostConfigured = false;
+        var appConfigured = false;
+
+        var first = CreateWebHostBuilder();
+        await Assert.That(SqliteExtensions.UseWebHostServices(first, (_, _) => serviceConfigured = true)).IsEqualTo(first);
+        using var firstHost = first.Build();
+        await firstHost.StartAsync();
+        await Assert.That(await SendRequestAsync(firstHost)).IsTrue();
+        await firstHost.StopAsync();
+
+        var second = CreateWebHostBuilder();
+        await Assert.That(SqliteExtensions.UseWebHostServices(second, static (_, _) => { }, true)).IsEqualTo(second);
+        using var secondHost = second.Build();
+
+        var third = CreateWebHostBuilder();
+        await Assert.That(SqliteExtensions.UseWebHostServices(third, static (_, _) => { }, builder =>
+        {
+            webHostConfigured = true;
+            return builder;
+        })).IsEqualTo(third);
+        using var thirdHost = third.Build();
+        await thirdHost.StartAsync();
+        await Assert.That(await SendRequestAsync(thirdHost)).IsTrue();
+        await thirdHost.StopAsync();
+
+        var fourth = CreateWebHostBuilder();
+        await Assert.That(SqliteExtensions.UseWebHostServices(fourth, static (_, _) => { }, static builder => builder, true)).IsEqualTo(fourth);
+        using var fourthHost = fourth.Build();
+
+        var fifth = CreateWebHostBuilder();
+        await Assert.That(SqliteExtensions.UseWebHostServices(fifth, static (_, _) => { }, static builder => builder.UseUrls(EphemeralWebHostUrl), app =>
+        {
+            appConfigured = true;
+            return app;
+        })).IsEqualTo(fifth);
+        using var fifthHost = fifth.Build();
+        await fifthHost.StartAsync();
+        await Assert.That(await SendRequestAsync(fifthHost)).IsTrue();
+        await fifthHost.StopAsync();
+
+        var sixth = CreateWebHostBuilder();
+        await Assert.That(SqliteExtensions.UseWebHostServices(sixth, static (_, _) => { }, static builder => builder, static app => app, true)).IsEqualTo(sixth);
+        using var sixthHost = sixth.Build();
+
+        IHostBuilder? nullBuilder = null;
+        var nullBuilderAction = () => SqliteExtensions.UseWebHostServices(nullBuilder!, static (_, _) => { }, true);
+        await Assert.That(nullBuilderAction).Throws<ArgumentNullException>();
+        await Assert.That(serviceConfigured).IsTrue();
+        await Assert.That(webHostConfigured).IsTrue();
+        await Assert.That(appConfigured).IsTrue();
+    }
+
+    /// <summary>Creates configuration containing the test connection string.</summary>
+    /// <returns>The configuration.</returns>
+    private static IConfiguration CreateConfiguration() => new ConfigurationBuilder()
+        .AddInMemoryCollection(
+        [
+            new KeyValuePair<string, string?>("ConnectionStrings:Database", SqlServerConnectionString),
+        ])
+        .Build();
+
+    /// <summary>Creates an application builder containing the test connection string.</summary>
+    /// <returns>The application builder.</returns>
+    private static HostApplicationBuilder CreateApplicationBuilder()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        _ = builder.Configuration.AddInMemoryCollection(
+        [
+            new KeyValuePair<string, string?>("ConnectionStrings:Database", SqlServerConnectionString),
+        ]);
+        return builder;
+    }
+
+    /// <summary>Creates a web-host builder that selects an ephemeral local port.</summary>
+    /// <returns>The configured host builder.</returns>
+    private static IHostBuilder CreateWebHostBuilder() => Host.CreateDefaultBuilder()
+        .ConfigureWebHostDefaults(static builder => builder.UseUrls(EphemeralWebHostUrl));
+
+    /// <summary>Sends a request to the active web host.</summary>
+    /// <param name="host">The started host.</param>
+    /// <returns>true when the host successfully responds.</returns>
+    private static async Task<bool> SendRequestAsync(IHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        var server = host.Services.GetRequiredService<IServer>();
+        var addresses = server.Features.Get<IServerAddressesFeature>()?.Addresses;
+        var address = addresses?.Single() ?? throw new InvalidOperationException("The web host did not expose a listening address.");
+        using var response = await _httpClient.GetAsync(new Uri(address, UriKind.Absolute));
+        return response.IsSuccessStatusCode;
+    }
+
+    /// <summary>Resolves a context and returns its configured provider name.</summary>
+    /// <typeparam name="TContext">The context type.</typeparam>
+    /// <param name="services">The registered services.</param>
+    /// <returns>The provider name.</returns>
+    private static string? GetProviderName<TContext>(IServiceCollection services)
+        where TContext : DbContext
+    {
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<TContext>().Database.ProviderName;
+    }
+
+    /// <summary>Determines whether a service is registered.</summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <param name="services">The services to inspect.</param>
+    /// <returns>true when the service is registered.</returns>
+    private static bool ContainsService<TService>(IServiceCollection services)
+    {
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType == typeof(TService))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Provides a SQL Server context test double.</summary>
+    /// <param name="options">The context options.</param>
+    public sealed class SqlServerContext(DbContextOptions<SqlServerContext> options) : DbContext(options);
+
+    /// <summary>Provides a SQLite context test double.</summary>
+    /// <param name="options">The context options.</param>
+    public sealed class SqliteContext(DbContextOptions<SqliteContext> options) : DbContext(options);
+
+    /// <summary>Provides a SQL Server identity context test double.</summary>
+    /// <param name="options">The context options.</param>
+    public sealed class SqlServerIdentityContext(DbContextOptions<SqlServerIdentityContext> options) : IdentityDbContext<TestUser, TestRole, string>(options);
+
+    /// <summary>Provides a SQLite identity context test double.</summary>
+    /// <param name="options">The context options.</param>
+    public sealed class SqliteIdentityContext(DbContextOptions<SqliteIdentityContext> options) : IdentityDbContext<TestUser, TestRole, string>(options);
+
+    /// <summary>Provides an identity user test double.</summary>
+    public sealed class TestUser : IdentityUser;
+
+    /// <summary>Provides an identity role test double.</summary>
+    public sealed class TestRole : IdentityRole;
+
+    /// <summary>Marks web-host service registration.</summary>
+    public sealed class WebHostMarker
+    {
+        /// <summary>Gets a marker value.</summary>
+        public bool IsRegistered => true;
+    }
+}

--- a/src/tests/Extensions.Hosting.DataLogging.Tests/Extensions.Hosting.DataLogging.Tests.csproj
+++ b/src/tests/Extensions.Hosting.DataLogging.Tests/Extensions.Hosting.DataLogging.Tests.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Extensions.Hosting.DataLogging.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.Identity.EntityFrameworkCore\Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj" Aliases="SqlServer" />
+    <ProjectReference Include="..\..\Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite\Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj" Aliases="Sqlite" />
+    <ProjectReference Include="..\..\Extensions.Logging.Log4Net\Extensions.Logging.Log4Net.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="log4net.config" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.AspNetCore.Hosting" />
+    <Using Include="Microsoft.AspNetCore.Hosting.Server" />
+    <Using Include="Microsoft.AspNetCore.Hosting.Server.Features" />
+    <Using Include="Microsoft.AspNetCore.Identity" />
+    <Using Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <Using Include="Microsoft.EntityFrameworkCore" />
+    <Using Include="Microsoft.Extensions.Configuration" />
+    <Using Include="Microsoft.Extensions.Configuration.Memory" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="Microsoft.Extensions.Hosting" />
+    <Using Include="Microsoft.Extensions.Logging" />
+    <Using Include="ReactiveMarbles.Extensions.Logging" />
+    <Using Include="ReactiveMarbles.Extensions.Logging.Log4Net.Entities" />
+    <Using Include="ReactiveMarbles.Extensions.Logging.Log4Net.Extensions" />
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.IO" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Net.Http" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.DataLogging.Tests/Log4NetTests.cs
+++ b/src/tests/Extensions.Hosting.DataLogging.Tests/Log4NetTests.cs
@@ -1,0 +1,437 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using log4net;
+using CoreLevel = log4net.Core.Level;
+using LoggingEvent = log4net.Core.LoggingEvent;
+
+namespace Extensions.Hosting.DataLogging.Tests;
+
+/// <summary>Contains Log4Net adapter coverage tests.</summary>
+public class Log4NetTests
+{
+    /// <summary>Provides the debug level name.</summary>
+    private const string DebugLevelName = "DEBUG";
+
+    /// <summary>Provides a log message.</summary>
+    private const string MessageText = "message";
+
+    /// <summary>Provides a candidate state value.</summary>
+    private const string StateText = "state";
+
+    /// <summary>Provides a generic value.</summary>
+    private const string ValueText = "value";
+
+    /// <summary>Provides a logging scope key and value.</summary>
+    private const string ScopeText = "scope";
+
+    /// <summary>Provides a test event identifier.</summary>
+    private const int EventIdentifier = 3;
+
+    /// <summary>Provides an invalid log-level value.</summary>
+    private const int InvalidLogLevelValue = 999;
+
+    /// <summary>Provides a numeric scope value.</summary>
+    private const int NumericScopeValue = 7;
+
+    /// <summary>Provides a numeric object scope value.</summary>
+    private const int ObjectScopeValue = 5;
+
+    /// <summary>Provides a candidate event identifier.</summary>
+    private const int CandidateEventIdentifier = 42;
+
+    /// <summary>Provides the expected provider registration count.</summary>
+    private const int ExpectedProviderCount = 3;
+
+    /// <summary>Verifies provider options and message-candidate values.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task ProviderOptionsAndMessageCandidate_PreserveSuppliedValues()
+    {
+        var defaults = new Log4NetProviderOptions();
+        var singleArgument = new Log4NetProviderOptions("custom.config");
+        var options = new Log4NetProviderOptions("watched.config", true)
+        {
+            Name = "test-name",
+            LoggerRepository = "test-repository",
+            OverrideCriticalLevelWith = "Critical",
+            ExternalConfigurationSetup = true,
+            UseWebOrAppConfig = true,
+            ConfigurationAssembly = typeof(Log4NetTests).Assembly,
+        };
+        var exception = new InvalidOperationException("failure");
+        var candidate = new MessageCandidate<string>(LogLevel.Warning, new EventId(CandidateEventIdentifier, "test"), StateText, exception, static (state, _) => state);
+
+        await Assert.That(defaults.Log4NetConfigFileName).IsEqualTo("log4net.config");
+        await Assert.That(singleArgument.Watch).IsFalse();
+        await Assert.That(options.Watch).IsTrue();
+        await Assert.That(options.Name).IsEqualTo("test-name");
+        await Assert.That(options.PropertyOverrides.Count).IsEqualTo(0);
+        await Assert.That(candidate.LogLevel).IsEqualTo(LogLevel.Warning);
+        await Assert.That(candidate.EventId.Id).IsEqualTo(CandidateEventIdentifier);
+        await Assert.That(candidate.State).IsEqualTo(StateText);
+        await Assert.That(candidate.Exception).IsEqualTo(exception);
+        await Assert.That(candidate.Formatter(candidate.State, candidate.Exception)).IsEqualTo(StateText);
+    }
+
+    /// <summary>Verifies log-level translation.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task LogLevelTranslator_TranslatesEveryLevelAndCriticalOverride()
+    {
+        var translator = new Log4NetLogLevelTranslator();
+        var normalOptions = new Log4NetProviderOptions();
+        var criticalOptions = new Log4NetProviderOptions { OverrideCriticalLevelWith = "critical" };
+
+        await Assert.That(translator.TranslateLogLevel(LogLevel.Trace, normalOptions)).IsEqualTo(CoreLevel.Trace);
+        await Assert.That(translator.TranslateLogLevel(LogLevel.Debug, normalOptions)).IsEqualTo(CoreLevel.Debug);
+        await Assert.That(translator.TranslateLogLevel(LogLevel.Information, normalOptions)).IsEqualTo(CoreLevel.Info);
+        await Assert.That(translator.TranslateLogLevel(LogLevel.Warning, normalOptions)).IsEqualTo(CoreLevel.Warn);
+        await Assert.That(translator.TranslateLogLevel(LogLevel.Error, normalOptions)).IsEqualTo(CoreLevel.Error);
+        await Assert.That(translator.TranslateLogLevel(LogLevel.Critical, normalOptions)).IsEqualTo(CoreLevel.Fatal);
+        await Assert.That(translator.TranslateLogLevel(LogLevel.Critical, criticalOptions)).IsEqualTo(CoreLevel.Critical);
+        await Assert.That(translator.TranslateLogLevel(LogLevel.None, normalOptions)).IsNull();
+        await Assert.That(translator.TranslateLogLevel((LogLevel)InvalidLogLevelValue, normalOptions)).IsNull();
+
+        var nullOptions = () => translator.TranslateLogLevel(LogLevel.Critical, null!);
+        await Assert.That(nullOptions).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies logging-event creation and scope enrichment.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task LoggingEventFactory_CreatesEventsAndEnrichesAllPublicScopeShapes()
+    {
+        using var provider = CreateExternalProvider();
+        var logger = provider.CreateLogger("scope-category") as Log4NetLogger;
+        var scopes = new LoggerExternalScopeProvider();
+        using var stringScope = scopes.Push("one");
+        using var enumerableScope = scopes.Push(new List<KeyValuePair<string, object>> { new("object", ObjectScopeValue), new("eventId", "overridden"), });
+        using var stringEnumerableScope = scopes.Push(new List<KeyValuePair<string, string>> { new("text", ValueText), });
+        using var tupleScope = scopes.Push(("tuple", NumericScopeValue));
+        using var arbitraryScope = scopes.Push(new ScopeValue(ValueText));
+        var factory = new Log4NetLoggingEventFactory();
+        var options = new Log4NetProviderOptions { LogLevelTranslator = new Log4NetLogLevelTranslator(), };
+        var candidate = new MessageCandidate<string>(LogLevel.Information, new EventId(EventIdentifier, "event"), MessageText, null, static (state, _) => state);
+
+        var loggingEvent = factory.CreateLoggingEvent(in candidate, GetCoreLogger(logger!), options, scopes);
+
+        await Assert.That(loggingEvent).IsNotNull();
+        await Assert.That(loggingEvent!.RenderedMessage).IsEqualTo(MessageText);
+        await Assert.That(loggingEvent.Properties[ScopeText]).IsEqualTo("one value");
+        await Assert.That(loggingEvent.Properties["object"]).IsEqualTo(ObjectScopeValue.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        await Assert.That(loggingEvent.Properties["text"]).IsEqualTo(ValueText);
+        await Assert.That(loggingEvent.Properties["tuple"]).IsEqualTo(NumericScopeValue.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        await Assert.That(loggingEvent.Properties["eventId"]).IsEqualTo(new EventId(EventIdentifier, "event"));
+    }
+
+    /// <summary>Verifies logging-event empty and invalid paths.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task LoggingEventFactory_ReturnsNullForUntranslatableOrEmptyMessagesAndValidatesArguments()
+    {
+        using var provider = CreateExternalProvider();
+        var logger = provider.CreateLogger("factory-category") as Log4NetLogger;
+        var factory = new Log4NetLoggingEventFactory();
+        var options = new Log4NetProviderOptions { LogLevelTranslator = new Log4NetLogLevelTranslator() };
+        var noneCandidate = new MessageCandidate<string>(LogLevel.None, default, MessageText, null, static (state, _) => state);
+        var emptyCandidate = new MessageCandidate<string>(LogLevel.Information, default, string.Empty, null, static (state, _) => state);
+
+        await Assert.That(factory.CreateLoggingEvent(in noneCandidate, GetCoreLogger(logger!), options, new LoggerExternalScopeProvider())).IsNull();
+        await Assert.That(factory.CreateLoggingEvent(in emptyCandidate, GetCoreLogger(logger!), options, new LoggerExternalScopeProvider())).IsNull();
+
+        var nullOptions = () => factory.CreateLoggingEvent(in noneCandidate, GetCoreLogger(logger!), null!, new LoggerExternalScopeProvider());
+        var nullLogger = () => factory.CreateLoggingEvent(in noneCandidate, null!, options, new LoggerExternalScopeProvider());
+        await Assert.That(nullOptions).Throws<ArgumentNullException>();
+        await Assert.That(nullLogger).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies provider logger and scope behavior.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task Provider_CreatesAndCachesLoggersAndManagesScopes()
+    {
+        using var provider = CreateExternalProvider();
+        var first = provider.CreateLogger("category");
+        var second = provider.CreateLogger("category");
+        var defaultLogger = provider.CreateLogger();
+        var nullScopeLogger = provider.CreateLogger("null-scope") as Log4NetLogger;
+        using var nullScope = nullScopeLogger!.BeginScope(ScopeText);
+        nullScopeLogger.Log(LogLevel.None, default, MessageText, null, static (state, _) => state);
+        var scopeProvider = new LoggerExternalScopeProvider();
+
+        provider.SetScopeProvider(scopeProvider);
+        var scopedLogger = provider.CreateLogger("scoped-category") as Log4NetLogger;
+        using var scope = scopedLogger!.BeginScope(ScopeText);
+
+        await Assert.That(first).IsEqualTo(second);
+        await Assert.That(defaultLogger).IsNotNull();
+        await Assert.That(scopedLogger.Name).IsEqualTo("scoped-category");
+        await Assert.That(scope).IsNotNull();
+    }
+
+    /// <summary>Verifies provider options, files, repositories, and overrides.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task Provider_ValidatesOptionsAndCanConfigureFilesRepositoriesAndOverrides()
+    {
+        var configPath = CreateConfigurationFile();
+        var invalidOptions = new Log4NetProviderOptions(configPath, true);
+        invalidOptions.PropertyOverrides.Add(new NodeInfo { XPath = "/log4net/root/level", NodeContent = DebugLevelName });
+        var invalid = () => new Log4NetProvider(invalidOptions);
+        await Assert.That(invalid).Throws<NotSupportedException>();
+
+        using var configured = new Log4NetProvider(new Log4NetProviderOptions(configPath));
+        await Assert.That(configured.CreateLogger(nameof(configured))).IsNotNull();
+
+        var overrideOptions = new Log4NetProviderOptions(configPath) { LoggerRepository = $"override-{Guid.NewGuid():N}", };
+        var overridingNode = new NodeInfo { XPath = "/log4net/root/level", NodeContent = DebugLevelName, };
+        overridingNode.Attributes[ValueText] = DebugLevelName;
+        overridingNode.Attributes["newAttribute"] = "added";
+        overrideOptions.PropertyOverrides.Add(overridingNode);
+        using var overridden = new Log4NetProvider(overrideOptions);
+        await Assert.That(overridden.CreateLogger(nameof(overridden))).IsNotNull();
+
+        var repositoryName = $"existing-{Guid.NewGuid():N}";
+        using var firstRepository = new Log4NetProvider(new Log4NetProviderOptions { LoggerRepository = repositoryName, ExternalConfigurationSetup = true, });
+        using var existingRepository = new Log4NetProvider(new Log4NetProviderOptions { LoggerRepository = repositoryName, ExternalConfigurationSetup = true, });
+        await Assert.That(existingRepository.CreateLogger("existing")).IsNotNull();
+    }
+
+    /// <summary>Verifies web configuration, watch, and disposal behavior.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task Provider_HandlesWebConfigurationWatchAndDisposal()
+    {
+        var configPath = CreateConfigurationFile();
+        using var webConfiguration = new Log4NetProvider(new Log4NetProviderOptions { UseWebOrAppConfig = true, });
+        await Assert.That(webConfiguration.CreateLogger("web-config")).IsNotNull();
+
+        using var watched = new Log4NetProvider(new Log4NetProviderOptions(configPath, true));
+        await Assert.That(watched.CreateLogger(nameof(watched))).IsNotNull();
+
+        var disposable = CreateExternalProvider();
+        disposable.Dispose();
+        disposable.Dispose();
+        await Assert.That(disposable.CreateLogger("disposed")).IsNotNull();
+    }
+
+    /// <summary>Verifies logger factories, enabled checks, and formatter validation.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task Logger_UsesFactoriesSupportsAllEnabledChecksAndValidatesFormatter()
+    {
+        var factory = new CountingLoggingEventFactory();
+        using var provider = new Log4NetProvider(new Log4NetProviderOptions(CreateConfigurationFile())
+        {
+            LoggerRepository = $"logger-{Guid.NewGuid():N}",
+            LoggingEventFactory = factory,
+            LogLevelTranslator = new Log4NetLogLevelTranslator(),
+        });
+        var logger = provider.CreateLogger(nameof(Log4NetLogger)) as Log4NetLogger;
+
+        await Assert.That(logger!.IsEnabled(LogLevel.None)).IsFalse();
+        var unsupportedLevel = () => logger.IsEnabled((LogLevel)InvalidLogLevelValue);
+        await Assert.That(unsupportedLevel).Throws<ArgumentOutOfRangeException>();
+        logger.Log(LogLevel.Information, new(EventIdentifier), MessageText, null, static (state, _) => state);
+        await Assert.That(factory.CallCount).IsEqualTo(1);
+
+        using var configuredProvider = new Log4NetProvider(new Log4NetProviderOptions(CreateConfigurationFile()) { LoggerRepository = $"event-{Guid.NewGuid():N}", });
+        var configuredLogger = configuredProvider.CreateLogger(nameof(Log4NetProvider)) as Log4NetLogger;
+        configuredLogger!.Log(LogLevel.Information, new(EventIdentifier), MessageText, null, static (state, _) => state);
+
+        var nullFormatter = () => logger.Log(LogLevel.Information, default, MessageText, null, null!);
+        await Assert.That(nullFormatter).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies factory extensions and provider-type validation.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task Extensions_AddProvidersAndValidateProviderTypes()
+    {
+        var configPath = CreateConfigurationFile();
+        using var factory = LoggerFactory.Create(static _ => { });
+        await Assert.That(factory.AddLog4Net(new Log4NetProviderOptions(configPath))).IsEqualTo(factory);
+        await Assert.That(factory.AddLog4Net(configPath)).IsEqualTo(factory);
+        await Assert.That(factory.AddLog4Net(configPath, false)).IsEqualTo(factory);
+
+        using var defaultProvider = new Log4NetProvider();
+        using var namedProvider = new Log4NetProvider(configPath);
+        await Assert.That(defaultProvider.CreateLogger("default-provider")).IsNotNull();
+        await Assert.That(namedProvider.CreateLogger("named-provider")).IsNotNull();
+
+        await Assert.That(factory.AddLog4Net()).IsEqualTo(factory);
+        var missingFactory = () => factory.AddLog4Net("missing-log4net.config");
+        await Assert.That(missingFactory).Throws<FileNotFoundException>();
+
+        ILoggerFactory? nullFactory = null;
+        var nullFactoryAction = () => nullFactory!.AddLog4Net(new Log4NetProviderOptions(configPath));
+        await Assert.That(nullFactoryAction).Throws<ArgumentNullException>();
+
+        using var provider = CreateExternalProvider();
+        await Assert.That(((ILoggerProvider)provider).CreateLogger(typeof(Log4NetTests))).IsNotNull();
+        var nullProvider = static () => ((ILoggerProvider)null!).CreateLogger(typeof(Log4NetTests));
+        var nullType = () => ((ILoggerProvider)provider).CreateLogger(null!);
+        var wrongProvider = static () => ((ILoggerProvider)new EmptyProvider()).CreateLogger(typeof(Log4NetTests));
+        await Assert.That(nullProvider).Throws<ArgumentNullException>();
+        await Assert.That(nullType).Throws<ArgumentNullException>();
+        await Assert.That(wrongProvider).Throws<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>Verifies logging-builder extensions.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task LoggingBuilderExtensions_RegisterProvidersAndValidateBuilder()
+    {
+        var configPath = CreateConfigurationFile();
+        var services = new ServiceCollection();
+        var builder = new TestLoggingBuilder(services);
+        await Assert.That(builder.AddLog4Net(new Log4NetProviderOptions(configPath))).IsEqualTo(builder);
+        await Assert.That(builder.AddLog4Net(configPath)).IsEqualTo(builder);
+        await Assert.That(builder.AddLog4Net(configPath, false)).IsEqualTo(builder);
+        await Assert.That(builder.AddLog4Net()).IsEqualTo(builder);
+        await Assert.That(CountServices<ILoggerProvider>(services)).IsEqualTo(ExpectedProviderCount + 1);
+
+        ILoggingBuilder? nullBuilder = null;
+        var nullBuilderAction = () => nullBuilder!.AddLog4Net(new Log4NetProviderOptions(configPath));
+        await Assert.That(nullBuilderAction).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies direct critical and trace log extensions.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task LogExtensions_AcceptCriticalAndTraceMessages()
+    {
+        var log = LogManager.GetLogger($"extensions-{Guid.NewGuid():N}");
+        var exception = new InvalidOperationException("failure");
+
+        log.Critical("critical", exception);
+        log.Trace("trace", exception);
+
+        await Assert.That(log).IsNotNull();
+    }
+
+    /// <summary>Creates an externally configured provider.</summary>
+    /// <param name="loggingEventFactory">An optional event factory.</param>
+    /// <returns>The provider.</returns>
+    private static Log4NetProvider CreateExternalProvider(ILog4NetLoggingEventFactory? loggingEventFactory = null) =>
+        new(new Log4NetProviderOptions
+        {
+            ExternalConfigurationSetup = true,
+            LoggerRepository = $"provider-{Guid.NewGuid():N}",
+            LoggingEventFactory = loggingEventFactory,
+            LogLevelTranslator = new Log4NetLogLevelTranslator(),
+        });
+
+    /// <summary>Gets a core logger for event-factory tests.</summary>
+    /// <param name="logger">The adapter logger.</param>
+    /// <returns>The core logger.</returns>
+    private static log4net.Core.ILogger GetCoreLogger(Log4NetLogger logger) =>
+        LogManager.GetLogger(logger.Name).Logger;
+
+    /// <summary>Creates a temporary Log4Net configuration file.</summary>
+    /// <returns>The configuration path.</returns>
+    private static string CreateConfigurationFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"log4net-{Guid.NewGuid():N}.config");
+        const string configuration = "<log4net><root><level value=\"ALL\" /><appender-ref ref=\"MemoryAppender\" /></root>"
+            + "<appender name=\"MemoryAppender\" type=\"log4net.Appender.MemoryAppender\" /></log4net>";
+        File.WriteAllText(path, configuration);
+        return path;
+    }
+
+    /// <summary>Counts services of a specified type.</summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <param name="services">The services to inspect.</param>
+    /// <returns>The number of matching services.</returns>
+    private static int CountServices<TService>(IServiceCollection services)
+    {
+        var count = 0;
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType == typeof(TService))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Counts calls made by a logger.</summary>
+    private sealed class CountingLoggingEventFactory : ILog4NetLoggingEventFactory
+    {
+        /// <summary>Gets the number of factory calls.</summary>
+        public int CallCount { get; private set; }
+
+        /// <summary>Counts an event creation request.</summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <param name="messageCandidate">The candidate message.</param>
+        /// <param name="logger">The core logger.</param>
+        /// <param name="options">The provider options.</param>
+        /// <param name="scopeProvider">The scope provider.</param>
+        /// <returns>No event.</returns>
+        public LoggingEvent? CreateLoggingEvent<TState>(in MessageCandidate<TState> messageCandidate, log4net.Core.ILogger logger, Log4NetProviderOptions options, IExternalScopeProvider scopeProvider)
+        {
+            CallCount++;
+            return null;
+        }
+    }
+
+    /// <summary>Provides a non-Log4Net provider test double.</summary>
+    private sealed class EmptyProvider : ILoggerProvider
+    {
+        /// <summary>Creates an empty logger.</summary>
+        /// <param name="categoryName">The category name.</param>
+        /// <returns>An empty logger.</returns>
+        public ILogger CreateLogger(string categoryName) => new EmptyLogger();
+
+        /// <summary>Disposes the provider.</summary>
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>Provides a no-op logger test double.</summary>
+    private sealed class EmptyLogger : ILogger
+    {
+        /// <summary>Does not create a scope.</summary>
+        /// <typeparam name="TState">The scope state type.</typeparam>
+        /// <param name="state">The scope state.</param>
+        /// <returns>No scope.</returns>
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        /// <summary>Reports logging as disabled.</summary>
+        /// <param name="logLevel">The log level.</param>
+        /// <returns>false.</returns>
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        /// <summary>Does not log.</summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <param name="logLevel">The log level.</param>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="state">The state.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="formatter">The formatter.</param>
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+        }
+    }
+
+    /// <summary>Provides a scope string representation.</summary>
+    /// <param name="value">The value to render.</param>
+    private sealed class ScopeValue(string value)
+    {
+        public override string ToString() => value;
+    }
+
+    /// <summary>Provides an in-memory logging builder.</summary>
+    /// <param name="services">The services to expose.</param>
+    private sealed class TestLoggingBuilder(IServiceCollection services) : ILoggingBuilder
+    {
+        /// <summary>Gets registered services.</summary>
+        public IServiceCollection Services { get; } = services;
+    }
+}

--- a/src/tests/Extensions.Hosting.DataLogging.Tests/log4net.config
+++ b/src/tests/Extensions.Hosting.DataLogging.Tests/log4net.config
@@ -1,0 +1,7 @@
+<log4net>
+  <root>
+    <level value="ALL" />
+    <appender-ref ref="MemoryAppender" />
+  </root>
+  <appender name="MemoryAppender" type="log4net.Appender.MemoryAppender" />
+</log4net>

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.Maui.Platform.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.Maui.Platform.Tests.csproj
@@ -4,7 +4,7 @@
     <UseMaui>true</UseMaui>
     <WindowsPackageType>None</WindowsPackageType>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
     <IsTestProject>true</IsTestProject>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.Maui.Platform.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.Maui.Platform.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <UseMaui>true</UseMaui>
+    <WindowsPackageType>None</WindowsPackageType>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Extensions.Hosting.Maui.Platform.Tests</RootNamespace>
+    <SolutionDir>$(MSBuildThisFileDirectory)..\..\..\</SolutionDir>
+    <SolutionName>Extensions.Hosting</SolutionName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Extensions.Hosting.Maui\Extensions.Hosting.Maui.csproj" />
+    <ProjectReference Include="..\..\..\Extensions.Hosting.ReactiveUI.Maui\Extensions.Hosting.ReactiveUI.Maui.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="10.0.90" />
+    <PackageReference Include="Microsoft.Maui.Core" VersionOverride="10.0.90" />
+    <PackageReference Include="Microsoft.Maui.Essentials" VersionOverride="10.0.90" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.ReactiveUI.Maui.Reactive.Platform.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.ReactiveUI.Maui.Reactive.Platform.Tests.csproj
@@ -4,7 +4,7 @@
     <UseMaui>true</UseMaui>
     <WindowsPackageType>None</WindowsPackageType>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
     <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
     <IsTestProject>true</IsTestProject>

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.ReactiveUI.Maui.Reactive.Platform.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/Extensions.Hosting.ReactiveUI.Maui.Reactive.Platform.Tests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <UseMaui>true</UseMaui>
+    <WindowsPackageType>None</WindowsPackageType>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <OutputType>Exe</OutputType>
+    <SolutionDir>$(MSBuildThisFileDirectory)..\..\..\</SolutionDir>
+    <SolutionName>Extensions.Hosting</SolutionName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Extensions.Hosting.ReactiveUI.Maui.Reactive\Extensions.Hosting.ReactiveUI.Maui.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="10.0.90" />
+    <PackageReference Include="Microsoft.Maui.Core" VersionOverride="10.0.90" />
+    <PackageReference Include="Microsoft.Maui.Essentials" VersionOverride="10.0.90" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="MauiHostedServiceTests.cs" />
+    <Compile Remove="MauiHostingRegistrationTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiBuilderExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiBuilderExtensionsTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Maui.Controls;
+using ReactiveMarbles.Extensions.Hosting.Maui;
+using ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+
+namespace Extensions.Hosting.Maui.Platform.Tests;
+
+/// <summary>Tests MAUI builder extension configuration without starting a MAUI UI loop.</summary>
+public class MauiBuilderExtensionsTests
+{
+    /// <summary>Verifies page registration preserves the builder and accepts a null builder.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task AddSingletonPage_RegistersPageAndPreservesNullBuilder()
+    {
+        var builder = new MauiBuilder(static _ => { });
+
+        var result = builder.AddSingletonPage<ContentPage>();
+        var nullResult = ((IMauiBuilder)null!).AddSingletonPage<ContentPage>();
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(builder.PageTypes).Contains(typeof(ContentPage));
+        await Assert.That(nullResult).IsNull();
+    }
+
+    /// <summary>Verifies application-type configuration assigns the type and invokes its optional customization.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseMauiApp_WithApplicationType_ConfiguresBuilder()
+    {
+        var builder = new MauiBuilder(static _ => { });
+        var result = builder.UseMauiApp<TestMauiApplication>(static _ => { });
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(builder.ApplicationType).IsEqualTo(typeof(TestMauiApplication));
+    }
+
+    /// <summary>Verifies application-parameter configuration assigns the application and supports the convenience overload.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseMauiApp_WithApplicationParameter_ConfiguresBuilder()
+    {
+        var builder = new MauiBuilder(static _ => { });
+
+        var result = builder.UseMauiApp((TestMauiApplication)null!);
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(builder.Application).IsNull();
+        await Assert.That(builder.ApplicationType).IsEqualTo(typeof(TestMauiApplication));
+    }
+
+    /// <summary>Verifies context configuration stores the provided action.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureContext_StoresAction()
+    {
+        var builder = new MauiBuilder();
+        var configured = false;
+
+        var result = builder.ConfigureContext(_ => configured = true);
+        builder.ConfigureContextAction!(new MauiContext());
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(configured).IsTrue();
+    }
+
+    /// <summary>Verifies null builders are rejected by operations that require builder state.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task RequiredBuilderOperations_WithNullBuilder_ThrowArgumentNullException()
+    {
+        IMauiBuilder? builder = null;
+        await Assert.That(() => builder!.UseMauiApp<TestMauiApplication>()).Throws<ArgumentNullException>();
+        await Assert.That(() => builder!.UseMauiApp((TestMauiApplication)null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => builder!.ConfigureContext(static _ => { })).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Represents an application type used exclusively for builder registration tests.</summary>
+    public sealed class TestMauiApplication : Application;
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiHostedServiceTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiHostedServiceTests.cs
@@ -1,0 +1,220 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Dispatching;
+using ReactiveMarbles.Extensions.Hosting.Maui;
+using ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+
+namespace Extensions.Hosting.Maui.Platform.Tests;
+
+/// <summary>Tests MAUI hosted-service orchestration without a device UI loop.</summary>
+public class MauiHostedServiceTests
+{
+    /// <summary>Verifies that starting a non-cancelled host starts its composed UI-thread starter.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StartAsync_WhenNotCancelled_StartsComposedThreadStarter()
+    {
+        var starts = 0;
+        var service = new MauiHostedService(
+            NullLogger<MauiHostedService>.Instance,
+            new MauiThreadStarter(() => starts++),
+            new TestMauiContext());
+
+        await service.StartAsync(CancellationToken.None);
+
+        await Assert.That(starts).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that starting a cancelled host does not start its composed UI-thread starter.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StartAsync_WhenCancelled_DoesNotStartComposedThreadStarter()
+    {
+        var starts = 0;
+        var service = new MauiHostedService(
+            NullLogger<MauiHostedService>.Instance,
+            new MauiThreadStarter(() => starts++),
+            new TestMauiContext());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        await service.StartAsync(cancellationTokenSource.Token);
+
+        await Assert.That(starts).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that stopping an inactive host completes without requesting UI shutdown.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenNotRunning_Completes()
+    {
+        var service = new MauiHostedService(
+            NullLogger<MauiHostedService>.Instance,
+            new MauiThreadStarter(static () => { }),
+            new TestMauiContext());
+
+        var completed = false;
+        await service.StopAsync(CancellationToken.None);
+        completed = true;
+
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that stopping a running host without a dispatcher fails immediately.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenRunningWithoutDispatcher_ThrowsInvalidOperationException()
+    {
+        var service = CreateRunningService(new());
+
+        await Assert.That(() => service.StopAsync(CancellationToken.None)).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies that an already-cancelled stop request does not dispatch a UI shutdown callback.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenCancelledBeforeDispatch_DoesNotDispatch()
+    {
+        var dispatchCount = 0;
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+        var service = CreateRunningService(new(), callback =>
+        {
+            dispatchCount++;
+            callback();
+            return true;
+        });
+
+        await Assert.That(() => service.StopAsync(cancellationTokenSource.Token)).Throws<OperationCanceledException>();
+        await Assert.That(dispatchCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that a dispatcher which rejects the shutdown callback fails immediately.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenDispatcherRejectsCallback_ThrowsInvalidOperationException()
+    {
+        var service = CreateRunningService(new(), static _ => false);
+
+        await Assert.That(() => service.StopAsync(CancellationToken.None)).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies that stopping a running host honours cancellation while its accepted callback remains pending.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenCancelledWhileCallbackIsPending_ThrowsOperationCanceledException()
+    {
+        Action? callback = null;
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var service = CreateRunningService(new(), dispatchedCallback =>
+        {
+            callback = dispatchedCallback;
+            return true;
+        });
+
+        var stopTask = service.StopAsync(cancellationTokenSource.Token);
+        await cancellationTokenSource.CancelAsync();
+
+        await Assert.That(() => stopTask).Throws<OperationCanceledException>();
+        await Assert.That(callback is not null).IsTrue();
+    }
+
+    /// <summary>Verifies that an accepted dispatcher callback completes application shutdown.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenDispatcherAcceptsCallback_Completes()
+    {
+        var dispatchCount = 0;
+        var service = CreateRunningService(new(), callback =>
+        {
+            dispatchCount++;
+            callback();
+            return true;
+        });
+
+        await service.StopAsync(CancellationToken.None);
+
+        await Assert.That(dispatchCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that the thread-starter adapter validates its supplied start action.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MauiThreadStarter_WithNullAction_ThrowsArgumentNullException() =>
+        await Assert.That(static () => new MauiThreadStarter((Action)null!)).Throws<ArgumentNullException>();
+
+    /// <summary>Verifies that the public constructor continues to compose the MAUI thread implementation.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Constructor_WithMauiThread_ComposesPublicThreadStarter()
+    {
+        var context = new TestMauiContext();
+        var services = new ServiceCollection().AddSingleton<IMauiContext>(context);
+        await using var serviceProvider = services.BuildServiceProvider();
+        using var mauiThread = new MauiThread(serviceProvider);
+
+        var service = new MauiHostedService(NullLogger<MauiHostedService>.Instance, mauiThread, context);
+
+        await Assert.That(service).IsNotNull();
+    }
+
+    /// <summary>Creates a hosted service whose context reports an active MAUI application.</summary>
+    /// <param name="context">The context to provide to the hosted service.</param>
+    /// <param name="dispatch">The callback used to schedule shutdown work.</param>
+    /// <returns>A hosted service configured for shutdown testing.</returns>
+    private static MauiHostedService CreateRunningService(TestMauiContext context, Func<Action, bool>? dispatch = null)
+    {
+        context.IsRunning = true;
+        context.Dispatcher = dispatch is null ? null : new TestDispatcher(dispatch);
+        return new(NullLogger<MauiHostedService>.Instance, new MauiThreadStarter(static () => { }), context);
+    }
+
+    /// <summary>Provides a dispatcher-free context for lifecycle orchestration tests.</summary>
+    private sealed class TestMauiContext : IMauiContext
+    {
+        /// <inheritdoc />
+        public bool IsLifetimeLinked { get; set; }
+
+        /// <inheritdoc />
+        public bool IsRunning { get; set; }
+
+        /// <inheritdoc />
+        public Application? MauiApplication { get; set; }
+
+        /// <inheritdoc />
+        public IDispatcher? Dispatcher { get; set; }
+    }
+
+    /// <summary>Provides controllable dispatch behavior for hosted-service tests.</summary>
+    private sealed class TestDispatcher : IDispatcher
+    {
+        /// <summary>Stores the configured dispatch behavior.</summary>
+        private readonly Func<Action, bool> _dispatch;
+
+        /// <summary>Initializes a new instance of the <see cref="TestDispatcher"/> class.</summary>
+        /// <param name="dispatch">The callback used to implement dispatch behavior.</param>
+        public TestDispatcher(Func<Action, bool> dispatch) =>
+            _dispatch = dispatch ?? throw new ArgumentNullException(nameof(dispatch));
+
+        /// <inheritdoc />
+        public bool IsDispatchRequired => true;
+
+        /// <inheritdoc />
+        public bool Dispatch(Action action) =>
+            _dispatch(action);
+
+        /// <inheritdoc />
+        public bool DispatchDelayed(TimeSpan delay, Action action) =>
+            throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public IDispatcherTimer CreateTimer() =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiHostingRegistrationTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiHostingRegistrationTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Maui.Controls;
+using ReactiveMarbles.Extensions.Hosting.Maui;
+using ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+
+namespace Extensions.Hosting.Maui.Platform.Tests;
+
+/// <summary>Tests MAUI hosting registration behavior that does not require a running UI loop.</summary>
+public class MauiHostingRegistrationTests
+{
+    /// <summary>Verifies that configuring the MAUI lifetime preserves the host builder.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseMauiLifetime_ReturnsConfiguredApplicationBuilder()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var result = builder.UseMauiLifetime();
+
+        await Assert.That(ReferenceEquals(result, builder)).IsTrue();
+    }
+
+    /// <summary>Verifies that MAUI configuration registers its lifetime and hosted service once.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureMaui_RegistersCoreServicesOnlyOnce()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        _ = builder.ConfigureMaui();
+        _ = builder.ConfigureMaui();
+
+        await Assert.That(CountRegistrations(builder.Services, typeof(IMauiContext), null)).IsEqualTo(1);
+        await Assert.That(CountRegistrations(builder.Services, typeof(IHostedService), null)).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that null application builders are rejected.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureMaui_WithNullApplicationBuilder_ThrowsArgumentNullException()
+    {
+        static IHostApplicationBuilder? GetNullBuilder() => null;
+
+        await Assert.That(static () => GetNullBuilder()!.ConfigureMaui()).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies application-builder configuration registers application, page, shell, and context services.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureMaui_WithApplicationAndShell_RegistersConfiguredServices()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var result = builder.ConfigureMaui(static maui =>
+        {
+            maui.ApplicationType = typeof(TestMauiApplication);
+            _ = maui.AddSingletonPage<TestMauiShell>();
+            _ = maui.AddSingletonPage<ContentPage>();
+            _ = maui.ConfigureContext(static context => context.IsLifetimeLinked = true);
+        });
+        await using var serviceProvider = builder.Services.BuildServiceProvider();
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(serviceProvider.GetRequiredService<IMauiContext>().IsLifetimeLinked).IsTrue();
+        await Assert.That(CountRegistrations(builder.Services, typeof(TestMauiApplication), null)).IsEqualTo(1);
+        await Assert.That(CountRegistrations(builder.Services, typeof(IMauiShell), null)).IsEqualTo(1);
+        await Assert.That(CountRegistrations(builder.Services, typeof(ContentPage), null)).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies the application-builder shell and base-application convenience paths register their services.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureMauiShell_WithApplicationBuilder_RegistersShellAndBaseApplication()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var shellResult = builder.ConfigureMauiShell<TestMauiShell>();
+        var applicationResult = builder.ConfigureMaui(static maui => maui.ApplicationType = typeof(Application));
+        await using var serviceProvider = builder.Services.BuildServiceProvider();
+        using var mauiThread = serviceProvider.GetRequiredService<MauiThread>();
+
+        await Assert.That(shellResult).IsSameReferenceAs(builder);
+        await Assert.That(applicationResult).IsSameReferenceAs(builder);
+        await Assert.That(CountRegistrations(builder.Services, typeof(Application), null)).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies invalid application types are rejected by application-builder configuration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureMaui_WithInvalidApplicationType_ThrowsArgumentException()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        await Assert.That(() => builder.ConfigureMaui(static maui => maui.ApplicationType = typeof(string))).Throws<ArgumentException>();
+    }
+
+    /// <summary>Verifies legacy host-builder configuration is materialized during host construction.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureMaui_WithLegacyHostBuilder_RegistersConfiguredServices()
+    {
+        var builder = Host.CreateDefaultBuilder();
+
+        var lifetimeResult = builder.UseMauiLifetime();
+        var configurationResult = builder.ConfigureMaui(static maui =>
+        {
+            maui.ApplicationType = typeof(TestMauiApplication);
+            _ = maui.AddSingletonPage<TestMauiShell>();
+            _ = maui.ConfigureContext(static context => context.IsLifetimeLinked = true);
+        });
+        using var host = builder.Build();
+
+        await Assert.That(lifetimeResult).IsSameReferenceAs(builder);
+        await Assert.That(configurationResult).IsSameReferenceAs(builder);
+        await Assert.That(host.Services).IsNotNull();
+    }
+
+    /// <summary>Verifies the legacy convenience overload preserves its builder.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureMaui_WithoutCustomization_ReturnsLegacyHostBuilder()
+    {
+        var builder = Host.CreateDefaultBuilder();
+
+        var result = builder.ConfigureMaui();
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>Verifies legacy shell configuration and null legacy builders preserve their documented behavior.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureMauiShell_WithLegacyHostBuilder_RegistersShellAndNullReturnsNull()
+    {
+        var builder = Host.CreateDefaultBuilder();
+        IHostBuilder? nullBuilder = null;
+
+        var result = builder.ConfigureMauiShell<TestMauiShell>();
+        using var host = builder.Build();
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(host.Services.GetRequiredService<IMauiContext>()).IsNotNull();
+        await Assert.That(nullBuilder!.UseMauiLifetime()).IsNull();
+        await Assert.That(nullBuilder!.ConfigureMauiShell<TestMauiShell>()).IsNull();
+    }
+
+    /// <summary>Counts registrations with matching types.</summary>
+    /// <param name="services">The service registrations to inspect.</param>
+    /// <param name="serviceType">The optional expected service type.</param>
+    /// <param name="implementationType">The optional expected implementation type.</param>
+    /// <returns>The matching registration count.</returns>
+    private static int CountRegistrations(IEnumerable<ServiceDescriptor> services, Type? serviceType, Type? implementationType)
+    {
+        var count = 0;
+        foreach (var descriptor in services)
+        {
+            if ((serviceType is null || descriptor.ServiceType == serviceType) && (implementationType is null || descriptor.ImplementationType == implementationType))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Represents an application type used exclusively for hosting registration tests.</summary>
+    public sealed class TestMauiApplication : Application;
+
+    /// <summary>Represents a shell type used exclusively for hosting registration tests.</summary>
+    public sealed class TestMauiShell : ContentPage, IMauiShell;
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiNativeRuntimeTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiNativeRuntimeTests.cs
@@ -1,0 +1,198 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Hosting;
+using Microsoft.UI.Xaml;
+using ReactiveMarbles.Extensions.Hosting.Maui;
+using ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+using MauiApplication = Microsoft.Maui.Controls.Application;
+using WinUIApplication = Microsoft.UI.Xaml.Application;
+
+namespace Extensions.Hosting.Maui.Platform.Tests;
+
+/// <summary>Tests native Windows MAUI registration paths inside an initialized WinUI application loop.</summary>
+public class MauiNativeRuntimeTests
+{
+    /// <summary>Defines the maximum time to await native application-loop completion.</summary>
+    private static readonly TimeSpan NativeLoopTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>Verifies native MAUI builder, application-instance, capture, and starter paths.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    [NotInParallel]
+    public async Task NativeRegistrationPaths_RunInsideWinUIApplication()
+    {
+        var completion = new TaskCompletionSource<(Exception? Exception, NativeResults? Results)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() => RunNativeApplication(completion));
+        thread.IsBackground = true;
+        thread.SetApartmentState(ApartmentState.STA);
+
+        thread.Start();
+        var outcome = await completion.Task.WaitAsync(NativeLoopTimeout);
+
+        await Assert.That(outcome.Exception).IsNull();
+        await Assert.That(outcome.Results).IsNotNull();
+        await Assert.That(outcome.Results!.InternalBuilderConfigured).IsTrue();
+        await Assert.That(outcome.Results.ExternalTypeBuilderConfigured).IsTrue();
+        await Assert.That(outcome.Results.ExternalInstanceBuilderConfigured).IsTrue();
+        await Assert.That(outcome.Results.RegisteredApplicationPreserved).IsTrue();
+        await Assert.That(outcome.Results.CurrentApplicationCaptured).IsTrue();
+        await Assert.That(outcome.Results.MismatchedApplicationIgnored).IsTrue();
+        await Assert.That(outcome.Results.ExplicitApplicationPreserved).IsTrue();
+        await Assert.That(outcome.Results.StarterResolvedApplication).IsTrue();
+        await Assert.That(outcome.Results.StarterCreatedFallback).IsTrue();
+        await Assert.That(outcome.Results.ShellMappingResolved).IsTrue();
+        await Assert.That(outcome.Results.ApplicationExitObserved).IsTrue();
+    }
+
+    /// <summary>Runs native MAUI verification within a WinUI application loop.</summary>
+    /// <param name="completion">The completion source that receives verification results.</param>
+    private static void RunNativeApplication(TaskCompletionSource<(Exception? Exception, NativeResults? Results)> completion)
+    {
+        Exception? capturedException = null;
+        NativeResults? results = null;
+
+        try
+        {
+            WinUIApplication.Start(_ =>
+            {
+                var winUIApplication = new RuntimeTestWinUIApplication();
+                try
+                {
+                    results = ExecuteNativePaths();
+                }
+                catch (Exception exception)
+                {
+                    capturedException = exception;
+                }
+                finally
+                {
+                    winUIApplication.Exit();
+                }
+            });
+        }
+        catch (Exception exception)
+        {
+            capturedException = exception;
+        }
+
+        completion.SetResult((capturedException, results));
+    }
+
+    /// <summary>Executes the native MAUI paths after the Windows XAML runtime has initialized.</summary>
+    /// <returns>The observed native-path results.</returns>
+    private static NativeResults ExecuteNativePaths()
+    {
+        var application = new TestMauiApplication();
+        var internalBuilder = new MauiBuilder();
+        var internalNativeResult = internalBuilder.UseMauiApp<TestMauiApplication>();
+        var internalExtensionResult = ((IMauiBuilder)internalBuilder).UseMauiApp<TestMauiApplication>(static _ => { });
+        var externalTypeBuilder = new ExternalMauiBuilder();
+        var externalTypeResult = externalTypeBuilder.UseMauiApp<TestMauiApplication>();
+        var externalInstanceBuilder = new ExternalMauiBuilder();
+        var externalInstanceResult = externalInstanceBuilder.UseMauiApp(application);
+
+        var hostBuilder = Host.CreateApplicationBuilder();
+        _ = hostBuilder.ConfigureMaui(maui =>
+        {
+            maui.ApplicationType = typeof(TestMauiApplication);
+            maui.Application = application;
+            _ = maui.AddSingletonPage<TestMauiShell>();
+        });
+        using var hostServices = hostBuilder.Services.BuildServiceProvider();
+
+        var matchingBuilder = new MauiBuilder(static _ => { }) { ApplicationType = typeof(TestMauiApplication) };
+        var mismatchedBuilder = new MauiBuilder(static _ => { }) { ApplicationType = typeof(MauiApplication) };
+        var configuredBuilder = new MauiBuilder(static _ => { }) { ApplicationType = typeof(TestMauiApplication), Application = application };
+        MauiApplicationCapture.Capture(matchingBuilder, application);
+        MauiApplicationCapture.Capture(mismatchedBuilder, application);
+        MauiApplicationCapture.Capture(configuredBuilder, new TestMauiApplication());
+
+        var registeredServices = new ServiceCollection().AddSingleton<MauiApplication>(application);
+        using var registeredProvider = registeredServices.BuildServiceProvider();
+        using var emptyProvider = new ServiceCollection().BuildServiceProvider();
+        var starter = new MauiApplicationStarter();
+        var resolvedApplication = starter.Create(registeredProvider);
+        var fallbackApplication = starter.Create(emptyProvider);
+        var applicationExitObserved = false;
+        starter.RegisterApplicationExit(fallbackApplication, () => applicationExitObserved = true);
+        MauiApplicationStarter.RegisterApplicationExit(
+            handler => handler(fallbackApplication, new(new ContentPage())),
+            () => applicationExitObserved = true);
+
+        return new(
+            ReferenceEquals(internalNativeResult, internalBuilder.MauiAppBuilder)
+                && ReferenceEquals(internalExtensionResult, internalBuilder)
+                && internalBuilder.ApplicationType == typeof(TestMauiApplication),
+            ReferenceEquals(externalTypeResult, externalTypeBuilder) && externalTypeBuilder.ApplicationType == typeof(TestMauiApplication),
+            ReferenceEquals(externalInstanceResult, externalInstanceBuilder) && ReferenceEquals(externalInstanceBuilder.Application, application),
+            ReferenceEquals(hostServices.GetRequiredService<TestMauiApplication>(), application)
+                && ReferenceEquals(hostServices.GetRequiredService<MauiApplication>(), application),
+            ReferenceEquals(matchingBuilder.Application, application),
+            mismatchedBuilder.Application is null,
+            ReferenceEquals(configuredBuilder.Application, application),
+            ReferenceEquals(resolvedApplication, application),
+            fallbackApplication is not null,
+            hostServices.GetRequiredService<IMauiShell>() is TestMauiShell,
+            applicationExitObserved);
+    }
+
+    /// <summary>Provides a MAUI shell for native registration tests.</summary>
+    public sealed class TestMauiShell : ContentPage, IMauiShell;
+
+    /// <summary>Provides a MAUI application for native registration tests.</summary>
+    private sealed class TestMauiApplication : MauiApplication;
+
+    /// <summary>Provides a WinUI application that owns the native test loop.</summary>
+    private sealed class RuntimeTestWinUIApplication : WinUIApplication;
+
+    /// <summary>Represents a public-interface MAUI builder implementation used to verify extension fallback behavior.</summary>
+    private sealed class ExternalMauiBuilder : IMauiBuilder
+    {
+        /// <inheritdoc />
+        public Type? ApplicationType { get; set; }
+
+        /// <inheritdoc />
+        public MauiApplication? Application { get; set; }
+
+        /// <inheritdoc />
+        public IList<Type> PageTypes { get; } = [];
+
+        /// <inheritdoc />
+        public Action<IMauiContext>? ConfigureContextAction { get; set; }
+
+        /// <inheritdoc />
+        public MauiAppBuilder MauiAppBuilder { get; } = MauiApp.CreateBuilder();
+    }
+
+    /// <summary>Stores results observed inside the native application loop.</summary>
+    /// <param name="InternalBuilderConfigured">Whether the internal builder used MAUI defaults.</param>
+    /// <param name="ExternalTypeBuilderConfigured">Whether an external builder configured an application type.</param>
+    /// <param name="ExternalInstanceBuilderConfigured">Whether an external builder configured an application instance.</param>
+    /// <param name="RegisteredApplicationPreserved">Whether host registration preserved the configured application.</param>
+    /// <param name="CurrentApplicationCaptured">Whether compatible current-application capture succeeded.</param>
+    /// <param name="MismatchedApplicationIgnored">Whether incompatible current-application capture was ignored.</param>
+    /// <param name="ExplicitApplicationPreserved">Whether capture preserved explicit application configuration.</param>
+    /// <param name="StarterResolvedApplication">Whether the application starter resolved the registered application.</param>
+    /// <param name="StarterCreatedFallback">Whether the application starter created its fallback application.</param>
+    /// <param name="ShellMappingResolved">Whether the configured shell mapping resolved the registered shell page.</param>
+    /// <param name="ApplicationExitObserved">Whether the registered application-exit callback observed a modal-pop event.</param>
+    private sealed record NativeResults(
+        bool InternalBuilderConfigured,
+        bool ExternalTypeBuilderConfigured,
+        bool ExternalInstanceBuilderConfigured,
+        bool RegisteredApplicationPreserved,
+        bool CurrentApplicationCaptured,
+        bool MismatchedApplicationIgnored,
+        bool ExplicitApplicationPreserved,
+        bool StarterResolvedApplication,
+        bool StarterCreatedFallback,
+        bool ShellMappingResolved,
+        bool ApplicationExitObserved);
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiThreadTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/MauiThreadTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Dispatching;
+using ReactiveMarbles.Extensions.Hosting.Maui;
+using ReactiveMarbles.Extensions.Hosting.Maui.Internals;
+
+namespace Extensions.Hosting.Maui.Platform.Tests;
+
+/// <summary>Tests MAUI thread initialization through a deterministic dispatcher.</summary>
+public class MauiThreadTests
+{
+    /// <summary>Defines the maximum time to await deterministic UI-thread initialization.</summary>
+    private static readonly TimeSpan InitializationTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies the UI-thread callback creates an application and initializes registered MAUI services.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Start_InitializesApplicationAndRegisteredMauiServices()
+    {
+        var context = new TestMauiContext(new ImmediateDispatcher());
+        var initialized = new TaskCompletionSource<Application?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var services = new ServiceCollection()
+            .AddSingleton<IMauiContext>(context)
+            .AddSingleton<IMauiService>(new TestMauiService(initialized));
+        await using var serviceProvider = services.BuildServiceProvider();
+        using var mauiThread = new MauiThread(serviceProvider, new TestMauiApplicationStarter(), useDedicatedUiThread: false);
+
+        mauiThread.Start();
+
+        _ = await initialized.Task.WaitAsync(InitializationTimeout);
+        await Assert.That(context.MauiApplication).IsNull();
+        await Assert.That(context.IsRunning).IsTrue();
+    }
+
+    /// <summary>Verifies the concrete MAUI context tolerates the absence of a current application.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MauiContext_WithoutCurrentApplication_HasNoDispatcher()
+    {
+        var context = new MauiContext();
+
+        await Assert.That(context.Dispatcher).IsNull();
+    }
+
+    /// <summary>Provides an MAUI context backed by a deterministic dispatcher.</summary>
+    /// <param name="dispatcher">The dispatcher used by the context.</param>
+    private sealed class TestMauiContext(IDispatcher dispatcher) : IMauiContext
+    {
+        /// <inheritdoc />
+        public bool IsLifetimeLinked { get; set; }
+
+        /// <inheritdoc />
+        public bool IsRunning { get; set; }
+
+        /// <inheritdoc />
+        public Application? MauiApplication { get; set; }
+
+        /// <inheritdoc />
+        public IDispatcher? Dispatcher { get; } = dispatcher;
+    }
+
+    /// <summary>Completes a task when the MAUI application service is initialized.</summary>
+    /// <param name="initialized">The completion source for the initialized application.</param>
+    private sealed class TestMauiService(TaskCompletionSource<Application?> initialized) : IMauiService
+    {
+        /// <inheritdoc />
+        public void Initialize(Application application) =>
+            initialized.SetResult(application);
+    }
+
+    /// <summary>Provides an uninitialized application instance without starting a platform UI runtime.</summary>
+    private sealed class TestMauiApplicationStarter : IMauiApplicationStarter
+    {
+        /// <inheritdoc />
+        public Application Create(IServiceProvider serviceProvider) =>
+            null!;
+
+        /// <inheritdoc />
+        public void RegisterApplicationExit(Application mauiApplication, Action onApplicationExit)
+        {
+        }
+    }
+
+    /// <summary>Dispatches callbacks synchronously for deterministic tests.</summary>
+    private sealed class ImmediateDispatcher : IDispatcher
+    {
+        /// <inheritdoc />
+        public bool IsDispatchRequired => false;
+
+        /// <inheritdoc />
+        public bool Dispatch(Action action)
+        {
+            action();
+            return true;
+        }
+
+        /// <inheritdoc />
+        public bool DispatchDelayed(TimeSpan delay, Action action) =>
+            Dispatch(action);
+
+        /// <inheritdoc />
+        public IDispatcherTimer CreateTimer() =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/Maui/ReactiveMauiHostingTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/Maui/ReactiveMauiHostingTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Hosting;
+#if REACTIVE_SHIM
+using ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
+
+namespace Extensions.Hosting.Maui.Platform.Tests;
+
+/// <summary>Tests ReactiveUI MAUI hosting configuration without starting a MAUI application.</summary>
+public class ReactiveMauiHostingTests
+{
+    /// <summary>Verifies that application-builder configuration preserves the original builder.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_ReturnsApplicationBuilder()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var result = builder.ConfigureSplatForMicrosoftDependencyResolver();
+
+        await Assert.That(ReferenceEquals(result, builder)).IsTrue();
+    }
+
+    /// <summary>Verifies that legacy host-builder configuration is applied while the host is built.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_WithHostBuilder_ReturnsConfiguredBuilder()
+    {
+        var hostBuilder = Host.CreateDefaultBuilder();
+
+        var configuredBuilder = hostBuilder.ConfigureSplatForMicrosoftDependencyResolver();
+        using var host = hostBuilder.Build();
+
+        await Assert.That(configuredBuilder).IsSameReferenceAs(hostBuilder);
+        await Assert.That(host.Services).IsNotNull();
+    }
+
+    /// <summary>Verifies that mapping a null host invokes the supplied factory with a null provider.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MapSplatLocator_WithNullHost_InvokesFactoryWithNullProvider()
+    {
+        IServiceProvider? factoryProvider = new object() as IServiceProvider;
+
+        var result = ((IHost)null!).MapSplatLocator(provider => factoryProvider = provider);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(factoryProvider).IsNull();
+    }
+
+    /// <summary>Verifies that null application builders are rejected before any ReactiveUI registration occurs.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_WithNullApplicationBuilder_ThrowsArgumentNullException()
+    {
+        IHostApplicationBuilder? builder = null;
+
+        await Assert.That(() => builder!.ConfigureSplatForMicrosoftDependencyResolver()).Throws<ArgumentNullException>();
+    }
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/PluginService/Extensions.Hosting.PluginService.Platform.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Platform.Tests/PluginService/Extensions.Hosting.PluginService.Platform.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Extensions.Hosting.PluginService.Platform.Tests</RootNamespace>
+    <SolutionDir>$(MSBuildThisFileDirectory)..\..\..\</SolutionDir>
+    <SolutionName>Extensions.Hosting</SolutionName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Extensions.Hosting.PluginService\Extensions.Hosting.PluginService.csproj" />
+    <ProjectReference Include="..\..\..\Extensions.Hosting.Plugins\Extensions.Hosting.Plugins.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\Extensions.Hosting.PluginService\log4net.config" Link="log4net.config" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Platform.Tests/PluginService/Extensions.Hosting.PluginService.Reactive.Platform.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Platform.Tests/PluginService/Extensions.Hosting.PluginService.Reactive.Platform.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <OutputType>Exe</OutputType>
+    <SolutionDir>$(MSBuildThisFileDirectory)..\..\..\</SolutionDir>
+    <SolutionName>Extensions.Hosting</SolutionName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Extensions.Hosting.PluginService.Reactive\Extensions.Hosting.PluginService.Reactive.csproj" />
+    <ProjectReference Include="..\..\..\Extensions.Hosting.Plugins.Reactive\Extensions.Hosting.Plugins.Reactive.csproj" />
+    <None Include="..\..\..\Extensions.Hosting.PluginService\log4net.config" Link="log4net.config" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Platform.Tests/PluginService/PluginServiceTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/PluginService/PluginServiceTests.cs
@@ -1,0 +1,422 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.ServiceProcess;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+#if REACTIVE_SHIM
+using ReactiveMarbles.Extensions.Hosting.Reactive.PluginService;
+#else
+using ReactiveMarbles.Extensions.Hosting.PluginService;
+#endif
+
+namespace Extensions.Hosting.PluginService.Platform.Tests;
+
+/// <summary>Tests safe PluginService registration and guard behavior.</summary>
+public class PluginServiceTests
+{
+    /// <summary>Stores the expected number of host and service operations in two-operation tests.</summary>
+    private const int ExpectedSixOperations = 6;
+
+    /// <summary>Stores the expected number of service stop operations.</summary>
+    private const int ExpectedTwoOperations = 2;
+
+    /// <summary>Stores the console switch used to select console host lifetime.</summary>
+    private const string ConsoleSwitch = "--console";
+
+    /// <summary>Stores the namespace used to configure test plugin discovery.</summary>
+    private const string TestPluginNamespace = "Extensions.Hosting";
+
+    /// <summary>Stores the target runtime supplied to host factory tests.</summary>
+    private const string TestRuntime = "test-runtime";
+
+    /// <summary>Verifies that the default logger retains the supplied logger instance.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task DefaultLogger_ExposesInjectedLogger()
+    {
+        ILogger<DefaultLogger> logger = NullLogger<DefaultLogger>.Instance;
+
+        var defaultLogger = new DefaultLogger(logger);
+
+        await Assert.That(ReferenceEquals(defaultLogger.Logger, logger)).IsTrue();
+    }
+
+    /// <summary>Verifies that service lifetime registration preserves the application builder.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseServiceBaseLifetime_RegistersServiceLifetime()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var result = builder.UseServiceBaseLifetime();
+
+        await Assert.That(ReferenceEquals(result, builder)).IsTrue();
+        await Assert.That(ContainsRegistration(builder.Services, typeof(IHostLifetime), typeof(ServiceBaseLifetime))).IsTrue();
+    }
+
+    /// <summary>Verifies that console lifetime registration preserves the application builder.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseConsoleLifetime_RegistersConsoleLifetime()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var result = builder.UseConsoleLifetime();
+
+        await Assert.That(ReferenceEquals(result, builder)).IsTrue();
+        await Assert.That(ContainsRegistration(builder.Services, typeof(IHostLifetime), typeof(ConsoleLifetime))).IsTrue();
+    }
+
+    /// <summary>Verifies that a null application builder is rejected for service lifetime registration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseServiceBaseLifetime_WithNullApplicationBuilder_ThrowsArgumentNullException()
+    {
+        static IHostApplicationBuilder? GetNullBuilder() => null;
+
+        await Assert.That(static () => GetNullBuilder()!.UseServiceBaseLifetime()).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that a null entry type is rejected before a plugin host is created.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Create_WithNullEntryType_ThrowsArgumentNullException()
+    {
+        static Task Act() => ServiceHost.Create(null!, []);
+
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that a null entry type is rejected before an application host is created.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task CreateApplication_WithNullEntryType_ThrowsArgumentNullException()
+    {
+        static Task Act() => ServiceHost.CreateApplication(null!, []);
+
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that service lifetimes require a host application lifetime.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ServiceBaseLifetime_WithNullApplicationLifetime_ThrowsArgumentNullException()
+    {
+        static ServiceBaseLifetime Act() => new(null!);
+
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that both public host factories build and pass their hosts to the composed runtime.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ServiceHost_CreateMethods_UseConfiguredRuntimeAndBuildHosts()
+    {
+        using var runtime = new TestServiceHostRuntime();
+        var configureHostCallCount = 0;
+
+        using (ServiceHost.UseRuntime(runtime))
+        {
+            await ServiceHost.Create(
+                typeof(PluginServiceTests),
+                [ConsoleSwitch],
+                static builder => builder,
+                _ => configureHostCallCount++,
+                TestPluginNamespace,
+                TestRuntime);
+            await ServiceHost.CreateApplication(
+                typeof(PluginServiceTests),
+                [ConsoleSwitch],
+                static builder => builder,
+                _ => configureHostCallCount++,
+                TestPluginNamespace,
+                TestRuntime);
+
+            var originalDirectory = Directory.GetCurrentDirectory();
+            try
+            {
+                await ServiceHost.Create(
+                    typeof(PluginServiceTests),
+                    [],
+                    null,
+                    null,
+                    TestPluginNamespace,
+                    TestRuntime);
+                await ServiceHost.CreateApplication(
+                    typeof(PluginServiceTests),
+                    [],
+                    null,
+                    null,
+                    TestPluginNamespace,
+                    TestRuntime);
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDirectory);
+            }
+
+            var runner = new ServiceHostRunner(runtime);
+            await runner.Create(typeof(PluginServiceTests), [ConsoleSwitch]);
+            await runner.CreateApplication(typeof(PluginServiceTests), [ConsoleSwitch]);
+        }
+
+        await Assert.That(runtime.RunAsyncCallCount).IsEqualTo(ExpectedSixOperations);
+        await Assert.That(configureHostCallCount).IsEqualTo(ExpectedTwoOperations);
+        await Assert.That(ServiceHost.Logger).IsNotNull();
+    }
+
+    /// <summary>Verifies that the runner configuration helpers exercise both selection and null-safe paths.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ServiceHostRunner_ConfigurationHelpers_ConfigureExpectedPaths()
+    {
+        var serviceLifetimeCallCount = 0;
+        var consoleLifetimeCallCount = 0;
+        var applicationBuilder = Host.CreateApplicationBuilder();
+        var hostBuilder = Host.CreateDefaultBuilder();
+
+        ServiceHostRunner.Configuration.ConfigureLifetime(true, () => serviceLifetimeCallCount++, () => consoleLifetimeCallCount++);
+        ServiceHostRunner.Configuration.ConfigureLifetime(false, () => serviceLifetimeCallCount++, () => consoleLifetimeCallCount++);
+        _ = ServiceHostRunner.Configuration.ConfigureApplicationLogging(applicationBuilder);
+        _ = ServiceHostRunner.Configuration.ConfigureApplicationConfiguration(applicationBuilder, ["--key", "value"]);
+        _ = ServiceHostRunner.Configuration.UseContentRoot(applicationBuilder, Directory.GetCurrentDirectory());
+        _ = ServiceHostRunner.Configuration.ConfigureHostLogging(hostBuilder);
+        _ = ServiceHostRunner.Configuration.ConfigureHostConfiguration(hostBuilder, ["--key", "value"]);
+
+        var configuredBuilder = ServiceHostRunner.Configuration.ConfigureExternal(applicationBuilder, static builder => builder);
+        var nullConfiguredBuilder = ServiceHostRunner.Configuration.ConfigureExternal<IHostApplicationBuilder>(null, null);
+
+        ServiceHostRunner.Configuration.ConfigurePluginScanning(null, null, null, TestPluginNamespace);
+
+        await Assert.That(serviceLifetimeCallCount).IsEqualTo(1);
+        await Assert.That(consoleLifetimeCallCount).IsEqualTo(1);
+        await Assert.That(ReferenceEquals(configuredBuilder, applicationBuilder)).IsTrue();
+        await Assert.That(nullConfiguredBuilder).IsNull();
+        await Assert.That(ServiceHostRunner.Configuration.ConfigureApplicationLogging(null)).IsNull();
+        await Assert.That(ServiceHostRunner.Configuration.ConfigureApplicationConfiguration(null, [])).IsNull();
+        await Assert.That(ServiceHostRunner.Configuration.ConfigureHostLogging(null)).IsNull();
+        await Assert.That(ServiceHostRunner.Configuration.ConfigureHostConfiguration(null, [])).IsNull();
+        await Assert.That(() => ServiceHostRunner.Configuration.UseContentRoot(applicationBuilder, string.Empty)).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that the composed service runtime drives service start, stop, cancellation, and fault outcomes.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ServiceBaseLifetime_UsesComposedRuntimeForServiceControl()
+    {
+        using var applicationLifetime = new TestHostApplicationLifetime();
+        using var runtime = new TestServiceHostRuntime();
+        using var serviceLifetime = new TestServiceBaseLifetime(applicationLifetime, runtime);
+
+        var startTask = serviceLifetime.WaitForStartAsync(CancellationToken.None);
+        serviceLifetime.Start([]);
+        await startTask;
+        await serviceLifetime.StopAsync(CancellationToken.None);
+        serviceLifetime.StopFromServiceControlManager();
+        applicationLifetime.TriggerStopping();
+        runtime.ReleaseServiceRun();
+
+        await Assert.That(runtime.RunServiceCallCount).IsEqualTo(1);
+        await Assert.That(runtime.StopServiceCallCount).IsEqualTo(ExpectedTwoOperations);
+        await Assert.That(applicationLifetime.StopApplicationCallCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that service lifetime startup cancellation and run failures complete its startup task.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ServiceBaseLifetime_StartupCancellationAndFailure_AreReported()
+    {
+        using var cancellationLifetime = new TestHostApplicationLifetime();
+        using var cancellationRuntime = new TestServiceHostRuntime();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var cancellationServiceLifetime = new TestServiceBaseLifetime(cancellationLifetime, cancellationRuntime);
+
+        var cancellationStartTask = cancellationServiceLifetime.WaitForStartAsync(cancellationTokenSource.Token);
+        await cancellationTokenSource.CancelAsync();
+        await Task.WhenAny(cancellationStartTask, Task.Delay(TimeSpan.FromSeconds(1)));
+        cancellationRuntime.ReleaseServiceRun();
+
+        using var failureLifetime = new TestHostApplicationLifetime();
+        using var failureRuntime = new TestServiceHostRuntime { RunServiceException = new InvalidOperationException() };
+        using var failureServiceLifetime = new TestServiceBaseLifetime(failureLifetime, failureRuntime);
+        var failureStartTask = failureServiceLifetime.WaitForStartAsync(CancellationToken.None);
+        await Task.WhenAny(failureStartTask, Task.Delay(TimeSpan.FromSeconds(1)));
+
+        await Assert.That(cancellationStartTask.IsCanceled).IsTrue();
+        await Assert.That(failureStartTask.IsFaulted).IsTrue();
+    }
+
+    /// <summary>Verifies that the production runtime forwards host and service operations to their framework implementations.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ServiceHostRuntime_ForwardsFrameworkOperations()
+    {
+        var runtime = new ServiceHostRuntime();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var host = Host.CreateApplicationBuilder().Build();
+        using var service = new TestServiceBase();
+
+        await cancellationTokenSource.CancelAsync();
+        await Assert.That(() => runtime.RunAsync(host, cancellationTokenSource.Token)).Throws<OperationCanceledException>();
+        runtime.StopService(service);
+
+        await Assert.That(() => runtime.RunService(null!)).Throws<ArgumentException>();
+    }
+
+    /// <summary>Verifies that service-host extension run methods use the composed host runtime instead of directly running hosts.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task RunAsServiceAsync_UsesConfiguredRuntime()
+    {
+        using var runtime = new TestServiceHostRuntime();
+
+        using (ServiceHost.UseRuntime(runtime))
+        {
+            var applicationBuilder = Host.CreateApplicationBuilder();
+            await applicationBuilder.RunAsServiceAsync();
+
+            var hostBuilder = Host.CreateDefaultBuilder();
+            await hostBuilder.RunAsServiceAsync();
+        }
+
+        await Assert.That(runtime.RunAsyncCallCount).IsEqualTo(ExpectedTwoOperations);
+    }
+
+    /// <summary>Determines whether a collection contains a service registration of the expected types.</summary>
+    /// <param name="services">The service registrations to inspect.</param>
+    /// <param name="serviceType">The expected service type.</param>
+    /// <param name="implementationType">The expected implementation type.</param>
+    /// <returns>true when the expected registration exists; otherwise, false.</returns>
+    private static bool ContainsRegistration(IEnumerable<ServiceDescriptor> services, Type serviceType, Type implementationType)
+    {
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType == serviceType && descriptor.ImplementationType == implementationType)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Exposes protected service callbacks for deterministic lifetime tests.</summary>
+    private sealed class TestServiceBaseLifetime : ServiceBaseLifetime
+    {
+        /// <summary>Initializes a new instance of the <see cref="TestServiceBaseLifetime"/> class.</summary>
+        /// <param name="applicationLifetime">The controllable application lifetime.</param>
+        /// <param name="runtime">The deterministic service runtime.</param>
+        public TestServiceBaseLifetime(IHostApplicationLifetime applicationLifetime, IServiceHostRuntime runtime)
+            : base(applicationLifetime, runtime)
+        {
+        }
+
+        /// <summary>Signals that the service control manager started this service.</summary>
+        /// <param name="args">The service start arguments.</param>
+        public void Start(string[] args) => OnStart(args);
+
+        /// <summary>Signals that the service control manager stopped this service.</summary>
+        public void StopFromServiceControlManager() => OnStop();
+    }
+
+    /// <summary>Provides a deterministic replacement for host execution and service-control-manager operations.</summary>
+    private sealed class TestServiceHostRuntime : IServiceHostRuntime, IDisposable
+    {
+        /// <summary>Stores the service-run completion source.</summary>
+        private readonly ManualResetEventSlim _serviceRunRelease = new(false);
+
+        /// <summary>Gets the number of calls to <see cref="RunAsync"/>.</summary>
+        public int RunAsyncCallCount { get; private set; }
+
+        /// <summary>Gets the number of calls to <see cref="RunService"/>.</summary>
+        public int RunServiceCallCount { get; private set; }
+
+        /// <summary>Gets the number of calls to <see cref="StopService"/>.</summary>
+        public int StopServiceCallCount { get; private set; }
+
+        /// <summary>Gets or sets an exception to throw when the simulated service begins running.</summary>
+        public Exception? RunServiceException { get; init; }
+
+        /// <inheritdoc/>
+        public Task RunAsync(IHost host, CancellationToken cancellationToken)
+        {
+            RunAsyncCallCount++;
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public void RunService(ServiceBase service)
+        {
+            RunServiceCallCount++;
+            if (RunServiceException is not null)
+            {
+                throw RunServiceException;
+            }
+
+            _serviceRunRelease.Wait();
+        }
+
+        /// <inheritdoc/>
+        public void StopService(ServiceBase service) => StopServiceCallCount++;
+
+        /// <summary>Releases an in-progress simulated service run.</summary>
+        public void ReleaseServiceRun() => _serviceRunRelease.Set();
+
+        /// <inheritdoc />
+        public void Dispose() => _serviceRunRelease.Dispose();
+    }
+
+    /// <summary>Provides a concrete service base instance for runtime forwarding tests.</summary>
+    private sealed class TestServiceBase : ServiceBase;
+
+    /// <summary>Provides a controllable application lifetime for service lifetime tests.</summary>
+    private sealed class TestHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+    {
+        /// <summary>Stores the application-started token source.</summary>
+        private readonly CancellationTokenSource _applicationStarted = new();
+
+        /// <summary>Stores the application-stopping token source.</summary>
+        private readonly CancellationTokenSource _applicationStopping = new();
+
+        /// <summary>Stores the application-stopped token source.</summary>
+        private readonly CancellationTokenSource _applicationStopped = new();
+
+        /// <inheritdoc />
+        public CancellationToken ApplicationStarted => _applicationStarted.Token;
+
+        /// <inheritdoc />
+        public CancellationToken ApplicationStopping => _applicationStopping.Token;
+
+        /// <inheritdoc />
+        public CancellationToken ApplicationStopped => _applicationStopped.Token;
+
+        /// <summary>Gets the number of calls to <see cref="StopApplication"/>.</summary>
+        public int StopApplicationCallCount { get; private set; }
+
+        /// <summary>Triggers the application-stopping token.</summary>
+        public void TriggerStopping() => _applicationStopping.Cancel();
+
+        /// <inheritdoc />
+        public void StopApplication()
+        {
+            StopApplicationCallCount++;
+            TriggerStopping();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _applicationStarted.Dispose();
+            _applicationStopping.Dispose();
+            _applicationStopped.Dispose();
+        }
+    }
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/WinUI/Extensions.Hosting.ReactiveUI.WinUI.Reactive.Platform.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Platform.Tests/WinUI/Extensions.Hosting.ReactiveUI.WinUI.Reactive.Platform.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <UseWinUI>true</UseWinUI>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <OutputType>Exe</OutputType>
+    <SolutionDir>$(MSBuildThisFileDirectory)..\..\..\</SolutionDir>
+    <SolutionName>Extensions.Hosting</SolutionName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Extensions.Hosting.ReactiveUI.WinUI.Reactive\Extensions.Hosting.ReactiveUI.WinUI.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="WinUIHostedServiceTests.cs" />
+    <Compile Remove="WinUIHostingRegistrationTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Platform.Tests/WinUI/Extensions.Hosting.WinUI.Platform.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Platform.Tests/WinUI/Extensions.Hosting.WinUI.Platform.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <UseWinUI>true</UseWinUI>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Extensions.Hosting.WinUI.Platform.Tests</RootNamespace>
+    <SolutionDir>$(MSBuildThisFileDirectory)..\..\..\</SolutionDir>
+    <SolutionName>Extensions.Hosting</SolutionName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Extensions.Hosting.WinUI\Extensions.Hosting.WinUI.csproj" />
+    <ProjectReference Include="..\..\..\Extensions.Hosting.ReactiveUI.WinUI\Extensions.Hosting.ReactiveUI.WinUI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Platform.Tests/WinUI/ReactiveWinUIHostingTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/WinUI/ReactiveWinUIHostingTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.UI.Dispatching;
+#if REACTIVE_SHIM
+using ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
+
+namespace Extensions.Hosting.WinUI.Platform.Tests;
+
+/// <summary>Tests ReactiveUI WinUI hosting configuration without starting a WinUI application.</summary>
+public class ReactiveWinUIHostingTests
+{
+    /// <summary>Verifies that WinUI ReactiveUI configuration succeeds with an unpackaged dispatcher queue.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    [NotInParallel]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_WithDispatcherQueue_ReturnsApplicationBuilder()
+    {
+        var dispatcherQueueController = EnsureDispatcherQueue();
+        var builder = Host.CreateApplicationBuilder();
+
+        var result = builder.ConfigureSplatForMicrosoftDependencyResolver();
+
+        await Assert.That(DispatcherQueue.GetForCurrentThread()).IsNotNull();
+        await Assert.That(ReferenceEquals(result, builder)).IsTrue();
+        GC.KeepAlive(dispatcherQueueController);
+    }
+
+    /// <summary>Verifies that legacy host-builder configuration is applied while the host is built.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    [NotInParallel]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_WithHostBuilder_ReturnsConfiguredBuilder()
+    {
+        var dispatcherQueueController = EnsureDispatcherQueue();
+        var hostBuilder = Host.CreateDefaultBuilder();
+
+        var configuredBuilder = hostBuilder.ConfigureSplatForMicrosoftDependencyResolver();
+        using var host = hostBuilder.Build();
+
+        await Assert.That(DispatcherQueue.GetForCurrentThread()).IsNotNull();
+        await Assert.That(configuredBuilder).IsSameReferenceAs(hostBuilder);
+        await Assert.That(host.Services).IsNotNull();
+        GC.KeepAlive(dispatcherQueueController);
+    }
+
+    /// <summary>Verifies that mapping a null host invokes the supplied factory with a null provider.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MapSplatLocator_WithNullHost_InvokesFactoryWithNullProvider()
+    {
+        IServiceProvider? factoryProvider = new object() as IServiceProvider;
+
+        var result = ((IHost)null!).MapSplatLocator(provider => factoryProvider = provider);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(factoryProvider).IsNull();
+    }
+
+    /// <summary>Verifies that null application builders are rejected before any ReactiveUI registration occurs.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_WithNullApplicationBuilder_ThrowsArgumentNullException()
+    {
+        IHostApplicationBuilder? builder = null;
+
+        await Assert.That(() => builder!.ConfigureSplatForMicrosoftDependencyResolver()).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Creates a dispatcher queue for the current test thread when one is not already present.</summary>
+    /// <returns>The controller that owns a newly created queue, or <see langword="null"/> when the thread already has a queue.</returns>
+    private static DispatcherQueueController? EnsureDispatcherQueue() =>
+        DispatcherQueue.GetForCurrentThread() is null ? DispatcherQueueController.CreateOnCurrentThread() : null;
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/WinUI/WinUIHostedServiceTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/WinUI/WinUIHostedServiceTests.cs
@@ -1,0 +1,211 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using ReactiveMarbles.Extensions.Hosting.WinUI;
+using ReactiveMarbles.Extensions.Hosting.WinUI.Internals;
+
+namespace Extensions.Hosting.WinUI.Platform.Tests;
+
+/// <summary>Tests WinUI hosted-service orchestration without an App SDK UI loop.</summary>
+public class WinUIHostedServiceTests
+{
+    /// <summary>Verifies that starting a non-cancelled host starts its composed UI-thread starter.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StartAsync_WhenNotCancelled_StartsComposedThreadStarter()
+    {
+        var starts = 0;
+        var service = new WinUIHostedService(
+            NullLogger<WinUIHostedService>.Instance,
+            new WinUIThreadStarter(() => starts++),
+            new TestWinUIContext());
+
+        await service.StartAsync(CancellationToken.None);
+
+        await Assert.That(starts).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that starting a cancelled host does not start its composed UI-thread starter.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StartAsync_WhenCancelled_DoesNotStartComposedThreadStarter()
+    {
+        var starts = 0;
+        var service = new WinUIHostedService(
+            NullLogger<WinUIHostedService>.Instance,
+            new WinUIThreadStarter(() => starts++),
+            new TestWinUIContext());
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        await service.StartAsync(cancellationTokenSource.Token);
+
+        await Assert.That(starts).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that stopping an inactive host completes without requesting UI shutdown.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenNotRunning_Completes()
+    {
+        var service = new WinUIHostedService(
+            NullLogger<WinUIHostedService>.Instance,
+            new WinUIThreadStarter(static () => { }),
+            new TestWinUIContext());
+
+        var completed = false;
+        await service.StopAsync(CancellationToken.None);
+        completed = true;
+
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that stopping a running host without a dispatcher fails immediately.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenRunningWithoutDispatcher_ThrowsInvalidOperationException()
+    {
+        var service = CreateRunningService(new());
+
+        await Assert.That(() => service.StopAsync(CancellationToken.None)).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies that an already-cancelled stop request does not enqueue a UI shutdown callback.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenCancelledBeforeEnqueue_DoesNotEnqueue()
+    {
+        var enqueueCount = 0;
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+        var service = CreateRunningService(new(), callback =>
+        {
+            enqueueCount++;
+            callback();
+            return true;
+        });
+
+        await Assert.That(() => service.StopAsync(cancellationTokenSource.Token)).Throws<OperationCanceledException>();
+        await Assert.That(enqueueCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that a dispatcher which rejects the shutdown callback fails immediately.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenDispatcherRejectsCallback_ThrowsInvalidOperationException()
+    {
+        var service = CreateRunningService(new(), static _ => false);
+
+        await Assert.That(() => service.StopAsync(CancellationToken.None)).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies that stopping a running host honours cancellation while its accepted callback remains pending.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    [NotInParallel]
+    public async Task StopAsync_WhenCancelledWhileCallbackIsPending_ThrowsOperationCanceledException()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var dispatcherQueueController = EnsureDispatcherQueue();
+        var service = CreateRunningService(new() { Dispatcher = DispatcherQueue.GetForCurrentThread() });
+
+        var stopTask = service.StopAsync(cancellationTokenSource.Token);
+        await cancellationTokenSource.CancelAsync();
+
+        await Assert.That(() => stopTask).Throws<OperationCanceledException>();
+        GC.KeepAlive(dispatcherQueueController);
+    }
+
+    /// <summary>Verifies that an accepted dispatcher callback completes shutdown after requesting application exit.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StopAsync_WhenDispatcherAcceptsCallback_Completes()
+    {
+        var service = CreateRunningService(new(), static callback =>
+        {
+            callback();
+            return true;
+        });
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    /// <summary>Verifies that the thread-starter adapter validates its supplied start action.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task WinUIThreadStarter_WithNullAction_ThrowsArgumentNullException() =>
+        await Assert.That(static () => new WinUIThreadStarter((Action)null!)).Throws<ArgumentNullException>();
+
+    /// <summary>Verifies that the composed constructor rejects each required dependency.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Constructor_WithNullRequiredDependency_ThrowsArgumentNullException()
+    {
+        var starter = new WinUIThreadStarter(static () => { });
+        var context = new TestWinUIContext();
+
+        await Assert.That(() => new WinUIHostedService(null!, starter, context)).Throws<ArgumentNullException>();
+        await Assert.That(() => new WinUIHostedService(NullLogger<WinUIHostedService>.Instance, (IUiThreadStarter)null!, context)).Throws<ArgumentNullException>();
+        await Assert.That(() => new WinUIHostedService(NullLogger<WinUIHostedService>.Instance, starter, null!)).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that the public constructor continues to compose the WinUI thread implementation.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Constructor_WithWinUIThread_ComposesPublicThreadStarter()
+    {
+        var context = new TestWinUIContext();
+        var services = new ServiceCollection().AddSingleton<IWinUIContext>(context);
+        await using var serviceProvider = services.BuildServiceProvider();
+        using var winUIThread = new WinUIThread(serviceProvider);
+
+        var service = new WinUIHostedService(NullLogger<WinUIHostedService>.Instance, winUIThread, context);
+
+        await Assert.That(service).IsNotNull();
+    }
+
+    /// <summary>Creates a hosted service whose context reports an active WinUI application.</summary>
+    /// <param name="context">The context to provide to the hosted service.</param>
+    /// <param name="tryEnqueue">The callback used to schedule shutdown work.</param>
+    /// <returns>A hosted service configured for shutdown testing.</returns>
+    private static WinUIHostedService CreateRunningService(TestWinUIContext context, Func<Action, bool>? tryEnqueue = null)
+    {
+        context.IsRunning = true;
+        return tryEnqueue is null
+            ? new(NullLogger<WinUIHostedService>.Instance, new WinUIThreadStarter(static () => { }), context)
+            : new(NullLogger<WinUIHostedService>.Instance, new WinUIThreadStarter(static () => { }), context, tryEnqueue);
+    }
+
+    /// <summary>Creates a dispatcher queue for the current test thread when one is not already present.</summary>
+    /// <returns>The controller that owns a newly created queue, or <see langword="null"/> when the thread already has a queue.</returns>
+    private static DispatcherQueueController? EnsureDispatcherQueue() =>
+        DispatcherQueue.GetForCurrentThread() is null ? DispatcherQueueController.CreateOnCurrentThread() : null;
+
+    /// <summary>Provides a dispatcher-free context for lifecycle orchestration tests.</summary>
+    private sealed class TestWinUIContext : IWinUIContext
+    {
+        /// <inheritdoc />
+        public Window? AppWindow { get; set; }
+
+        /// <inheritdoc />
+        public Type? AppWindowType { get; set; }
+
+        /// <inheritdoc />
+        public DispatcherQueue? Dispatcher { get; set; }
+
+        /// <inheritdoc />
+        public bool IsLifetimeLinked { get; set; }
+
+        /// <inheritdoc />
+        public bool IsRunning { get; set; }
+
+        /// <inheritdoc />
+        public Application? WinUIApplication { get; set; }
+    }
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/WinUI/WinUIHostingRegistrationTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/WinUI/WinUIHostingRegistrationTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.UI.Xaml;
+using ReactiveMarbles.Extensions.Hosting.WinUI;
+using ReactiveMarbles.Extensions.Hosting.WinUI.Internals;
+
+namespace Extensions.Hosting.WinUI.Platform.Tests;
+
+/// <summary>Tests WinUI hosting registration behavior that does not start a WinUI application.</summary>
+public class WinUIHostingRegistrationTests
+{
+    /// <summary>Verifies that WinUI configuration registers core services and configured types.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinUI_RegistersCoreAndApplicationServices()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var result = builder.ConfigureWinUI<TestWinUIApplication, TestWinUIWindow>();
+
+        await Assert.That(ReferenceEquals(result, builder)).IsTrue();
+        await Assert.That(CountRegistrations(builder.Services, typeof(IWinUIContext), null)).IsEqualTo(1);
+        await Assert.That(HasRegistration(builder.Services, typeof(WinUIThread), null)).IsTrue();
+        await Assert.That(HasRegistration(builder.Services, typeof(IHostedService), null)).IsTrue();
+        await Assert.That(HasRegistration(builder.Services, typeof(TestWinUIApplication), null)).IsTrue();
+        await Assert.That(HasRegistration(builder.Services, typeof(Application), null)).IsTrue();
+    }
+
+    /// <summary>Verifies that repeated WinUI configuration reuses its registered context.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinUI_WhenCalledTwice_RegistersOneContext()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        _ = builder.ConfigureWinUI<TestWinUIApplication, TestWinUIWindow>();
+        _ = builder.ConfigureWinUI<TestWinUIApplication, TestWinUIWindow>();
+
+        await Assert.That(CountRegistrations(builder.Services, typeof(IWinUIContext), null)).IsEqualTo(1);
+        await Assert.That(CountRegistrations(builder.Services, typeof(IHostedService), null)).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that the generic host builder applies WinUI registrations when it is built.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinUI_WithLegacyHostBuilder_ConfiguresTheBuiltHost()
+    {
+        var builder = Host.CreateDefaultBuilder();
+
+        var result = builder.ConfigureWinUI<TestWinUIApplication, TestWinUIWindow>();
+
+        using var host = result!.Build();
+        var context = host.Services.GetRequiredService<IWinUIContext>();
+
+        await Assert.That(ReferenceEquals(result, builder)).IsTrue();
+        await Assert.That(context.AppWindowType).IsEqualTo(typeof(TestWinUIWindow));
+        await Assert.That(context.IsLifetimeLinked).IsTrue();
+    }
+
+    /// <summary>Verifies that configuring the base WinUI application type does not register a redundant application mapping.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinUI_WithBaseApplication_RegistersOneApplicationService()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        _ = builder.ConfigureWinUI<Application, TestWinUIWindow>();
+
+        await Assert.That(CountRegistrations(builder.Services, typeof(Application), null)).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that a null application host builder produces the documented argument exception.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinUI_WithNullApplicationHostBuilder_ThrowsArgumentNullException() =>
+        await Assert.That(static () => ((IHostApplicationBuilder)null!).ConfigureWinUI<TestWinUIApplication, TestWinUIWindow>())
+            .Throws<ArgumentNullException>();
+
+    /// <summary>Verifies that a null legacy host builder preserves the documented null result.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinUI_WithNullHostBuilder_ReturnsNull()
+    {
+        var result = ((IHostBuilder)null!).ConfigureWinUI<TestWinUIApplication, TestWinUIWindow>();
+
+        await Assert.That(result).IsNull();
+    }
+
+    /// <summary>Determines whether a collection contains a registration with matching types.</summary>
+    /// <param name="services">The service registrations to inspect.</param>
+    /// <param name="serviceType">The optional expected service type.</param>
+    /// <param name="implementationType">The optional expected implementation type.</param>
+    /// <returns>true when the matching registration exists; otherwise, false.</returns>
+    private static bool HasRegistration(IEnumerable<ServiceDescriptor> services, Type? serviceType, Type? implementationType) =>
+        CountRegistrations(services, serviceType, implementationType) > 0;
+
+    /// <summary>Counts registrations with matching types.</summary>
+    /// <param name="services">The service registrations to inspect.</param>
+    /// <param name="serviceType">The optional expected service type.</param>
+    /// <param name="implementationType">The optional expected implementation type.</param>
+    /// <returns>The matching registration count.</returns>
+    private static int CountRegistrations(IEnumerable<ServiceDescriptor> services, Type? serviceType, Type? implementationType)
+    {
+        var count = 0;
+        foreach (var descriptor in services)
+        {
+            if ((serviceType is null || descriptor.ServiceType == serviceType) && (implementationType is null || descriptor.ImplementationType == implementationType))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Provides a WinUI application type used solely for service registrations.</summary>
+    public sealed class TestWinUIApplication : Application;
+
+    /// <summary>Provides a WinUI window type used solely for service registrations.</summary>
+    public sealed class TestWinUIWindow : Window;
+}

--- a/src/tests/Extensions.Hosting.Platform.Tests/WinUI/WinUIThreadTests.cs
+++ b/src/tests/Extensions.Hosting.Platform.Tests/WinUI/WinUIThreadTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using ReactiveMarbles.Extensions.Hosting.WinUI;
+using ReactiveMarbles.Extensions.Hosting.WinUI.Internals;
+
+namespace Extensions.Hosting.WinUI.Platform.Tests;
+
+/// <summary>Tests the WinUI-thread startup flow without starting a native WinUI event loop.</summary>
+public class WinUIThreadTests
+{
+    /// <summary>Defines the maximum time to await native WinUI-loop completion.</summary>
+    private static readonly TimeSpan NativeLoopTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>Verifies that the UI-thread startup flow initializes WinUI services and activates the configured window.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Start_InitializesApplicationServicesAndMainWindow()
+    {
+        var context = new TestWinUIContext { AppWindowType = typeof(Window) };
+        var initializedApplications = new List<Application?>();
+        var runtime = new TestWinUIThreadRuntime();
+        var services = new ServiceCollection()
+            .AddSingleton<IWinUIContext>(context)
+            .AddSingleton<IWinUIService>(new TestWinUIService(initializedApplications));
+        await using var serviceProvider = services.BuildServiceProvider();
+        using var winUIThread = new WinUIThread(serviceProvider, runtime, useDedicatedUiThread: false);
+        var originalSynchronizationContext = SynchronizationContext.Current;
+
+        try
+        {
+            winUIThread.Start();
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(originalSynchronizationContext);
+        }
+
+        await Assert.That(runtime.InitializedComWrappers).IsTrue();
+        await Assert.That(runtime.Started).IsTrue();
+        await Assert.That(initializedApplications).Count().IsEqualTo(1);
+        await Assert.That(context.WinUIApplication).IsNull();
+        await Assert.That(context.AppWindow).IsNull();
+        await Assert.That(context.IsRunning).IsFalse();
+    }
+
+    /// <summary>Verifies the production WinUI runtime can own a complete native application-loop lifecycle.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    [NotInParallel]
+    public async Task WinUIThreadRuntime_StartsAndStopsNativeApplicationLoop()
+    {
+        var completion = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runtime = new WinUIThreadRuntime();
+        var configuredApplicationPreserved = false;
+        Task? stopTask = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                runtime.InitializeComWrappers();
+                runtime.Start((dispatcher, synchronizationContext) =>
+                {
+                    var application = new RuntimeTestApplication();
+                    var services = new ServiceCollection().AddSingleton<Application>(application);
+                    using var serviceProvider = services.BuildServiceProvider();
+                    var resolvedApplication = runtime.GetApplication(serviceProvider);
+                    var window = runtime.CreateWindow(serviceProvider, typeof(RuntimeTestWindow));
+                    var hostBuilder = Host.CreateApplicationBuilder();
+                    _ = hostBuilder.ConfigureWinUI<RuntimeTestApplication, RuntimeTestWindow>();
+                    _ = hostBuilder.Services.AddSingleton(application);
+                    using var hostServices = hostBuilder.Services.BuildServiceProvider();
+                    configuredApplicationPreserved = ReferenceEquals(
+                        hostServices.GetRequiredService<Application>(),
+                        application);
+
+                    runtime.ActivateWindow(window);
+                    window.Close();
+
+                    var context = new TestWinUIContext { Dispatcher = dispatcher, IsRunning = true, WinUIApplication = resolvedApplication };
+                    var hostedService = new WinUIHostedService(
+                        NullLogger<WinUIHostedService>.Instance,
+                        new TestUiThreadStarter(),
+                        context);
+                    stopTask = hostedService.StopAsync(CancellationToken.None);
+                });
+                completion.SetResult(null);
+            }
+            catch (Exception exception)
+            {
+                completion.SetResult(exception);
+            }
+        });
+        thread.IsBackground = true;
+        thread.SetApartmentState(ApartmentState.STA);
+
+        thread.Start();
+        var exception = await completion.Task.WaitAsync(NativeLoopTimeout);
+
+        await Assert.That(exception).IsNull();
+        await Assert.That(configuredApplicationPreserved).IsTrue();
+        await Assert.That(stopTask).IsNotNull();
+        await Assert.That(stopTask!.IsCompletedSuccessfully).IsTrue();
+    }
+
+    /// <summary>Provides a WinUI window for the production runtime lifecycle test.</summary>
+    public sealed class RuntimeTestWindow : Window;
+
+    /// <summary>Provides an in-memory WinUI application context for UI-thread tests.</summary>
+    private sealed class TestWinUIContext : IWinUIContext
+    {
+        /// <inheritdoc />
+        public Window? AppWindow { get; set; }
+
+        /// <inheritdoc />
+        public Type? AppWindowType { get; set; }
+
+        /// <inheritdoc />
+        public DispatcherQueue? Dispatcher { get; set; }
+
+        /// <inheritdoc />
+        public bool IsLifetimeLinked { get; set; }
+
+        /// <inheritdoc />
+        public bool IsRunning { get; set; }
+
+        /// <inheritdoc />
+        public Application? WinUIApplication { get; set; }
+    }
+
+    /// <summary>Provides a deterministic application-loop runtime for testing.</summary>
+    private sealed class TestWinUIThreadRuntime : IWinUIThreadRuntime
+    {
+        /// <summary>Gets a value indicating whether COM wrappers were initialized.</summary>
+        public bool InitializedComWrappers { get; private set; }
+
+        /// <summary>Gets a value indicating whether the application loop was started.</summary>
+        public bool Started { get; private set; }
+
+        /// <inheritdoc />
+        public void InitializeComWrappers() =>
+            InitializedComWrappers = true;
+
+        /// <inheritdoc />
+        public void Start(Action<DispatcherQueue?, SynchronizationContext> initialize)
+        {
+            Started = true;
+            initialize(null, new());
+        }
+
+        /// <inheritdoc />
+        public Application GetApplication(IServiceProvider serviceProvider) =>
+            GetNull<Application>();
+
+        /// <inheritdoc />
+        public Window CreateWindow(IServiceProvider serviceProvider, Type windowType) =>
+            GetNull<Window>();
+
+        /// <inheritdoc />
+        public void ActivateWindow(Window window)
+        {
+        }
+
+        /// <summary>Returns a null test double for a WinUI runtime component.</summary>
+        /// <typeparam name="T">The component type.</typeparam>
+        /// <returns>A null test double.</returns>
+        private static T GetNull<T>()
+            where T : class =>
+            null!;
+    }
+
+    /// <summary>Provides a no-op UI-thread starter for native shutdown verification.</summary>
+    private sealed class TestUiThreadStarter : IUiThreadStarter
+    {
+        /// <inheritdoc />
+        public void Start()
+        {
+        }
+    }
+
+    /// <summary>Provides a WinUI application for the production runtime lifecycle test.</summary>
+    private sealed class RuntimeTestApplication : Application;
+
+    /// <summary>Records initialized WinUI application instances.</summary>
+    /// <param name="initializedApplications">The collection that receives initialized applications.</param>
+    private sealed class TestWinUIService(List<Application?> initializedApplications) : IWinUIService
+    {
+        /// <inheritdoc />
+        public void Initialize(Application application) =>
+            initializedApplications.Add(application);
+    }
+}

--- a/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Reactive.Tests/Extensions.Hosting.ReactiveUI.Wpf.Reactive.Tests.csproj
+++ b/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Reactive.Tests/Extensions.Hosting.ReactiveUI.Wpf.Reactive.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.ReactiveUI.Wpf.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.ReactiveUI.Wpf.Tests\ReactiveWpfSchedulerTests.cs" Link="ReactiveWpfSchedulerTests.cs" />
+    <Compile Include="..\Extensions.Hosting.ReactiveUI.Wpf.Tests\TestApplication.cs" Link="TestApplication.cs" />
+    <Compile Include="..\Extensions.Hosting.ReactiveUI.Wpf.Tests\WpfHostingCoverageTests.cs" Link="WpfHostingCoverageTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.ReactiveUI.Wpf.Reactive\Extensions.Hosting.ReactiveUI.Wpf.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Tests/Extensions.Hosting.ReactiveUI.Wpf.Tests.csproj
+++ b/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Tests/Extensions.Hosting.ReactiveUI.Wpf.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.ReactiveUI.Wpf.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.ReactiveUI.Wpf\Extensions.Hosting.ReactiveUI.Wpf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Tests/ReactiveWpfSchedulerTests.cs
+++ b/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Tests/ReactiveWpfSchedulerTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+#if REACTIVE_SHIM
+using System.Reactive.Concurrency;
+using ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+using ReactiveUI.Primitives.Reactive.Concurrency;
+using ReactiveUI.Reactive;
+#else
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+using ReactiveUI;
+using ReactiveUI.Primitives.Concurrency;
+#endif
+
+namespace Extensions.Hosting.ReactiveUI.Wpf.Tests;
+
+/// <summary>Verifies that ReactiveUI uses the dispatcher created by the hosted WPF application.</summary>
+[NotInParallel]
+public sealed class ReactiveWpfSchedulerTests
+{
+    /// <summary>Gets the maximum duration allowed for an asynchronous test operation.</summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>Verifies scheduler binding to the hosted application dispatcher.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task
+        ConfigureSplatForMicrosoftDependencyResolver_BindsSchedulerToHostedApplicationDispatcher()
+    {
+        var originalScheduler = RxSchedulers.MainThreadScheduler;
+        using var host = await BuildHostOnBootstrapThread().WaitAsync(Timeout);
+
+        try
+        {
+            await host.StartAsync().WaitAsync(Timeout);
+            var applicationDispatcher = await TestApplication.Started.Task.WaitAsync(Timeout);
+            var scheduler = RxSchedulers.MainThreadScheduler;
+
+            await Assert.That(scheduler).IsTypeOf<DispatcherSequencer>();
+
+            var dispatcherScheduler = (DispatcherSequencer)scheduler;
+            await Assert.That(dispatcherScheduler.Dispatcher).IsSameReferenceAs(applicationDispatcher);
+
+            var scheduledThread = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+#if REACTIVE_SHIM
+            Func<IScheduler, TaskCompletionSource<int>, IDisposable> scheduleAction =
+                static (_, completion) =>
+                {
+                    completion.SetResult(Environment.CurrentManagedThreadId);
+                    return System.Reactive.Disposables.Disposable.Empty;
+                };
+            using var scheduledWork = ((IScheduler)scheduler).Schedule(
+                scheduledThread,
+                scheduleAction);
+#else
+            using var scheduledWork = scheduler.Schedule(
+                scheduledThread,
+                static completion => _ = completion.TrySetResult(Environment.CurrentManagedThreadId));
+#endif
+            var scheduledThreadId = await scheduledThread.Task.WaitAsync(Timeout);
+
+            await Assert.That(scheduledThreadId).IsEqualTo(applicationDispatcher.Thread.ManagedThreadId);
+        }
+        finally
+        {
+            await host.StopAsync().WaitAsync(Timeout);
+            RxSchedulers.MainThreadScheduler = originalScheduler;
+        }
+    }
+
+    /// <summary>Verifies that the scheduler service rejects an absent WPF application.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_SchedulerServiceRejectsNullApplication()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        _ = builder.ConfigureSplatForMicrosoftDependencyResolver();
+        using var host = builder.Build();
+        var schedulerService = host.Services.GetRequiredService<IWpfService>();
+
+        void Act() => schedulerService.Initialize(null!);
+
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Builds a host on a thread with a dispatcher that differs from the hosted WPF dispatcher.</summary>
+    /// <returns>A task that produces the configured host.</returns>
+    private static Task<IHost> BuildHostOnBootstrapThread()
+    {
+        var hostCompletion = new TaskCompletionSource<IHost>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var bootstrapThread = new Thread(() =>
+        {
+            try
+            {
+                var builder = Host.CreateApplicationBuilder();
+                _ = builder.ConfigureSplatForMicrosoftDependencyResolver();
+                _ = builder.ConfigureWpf(static wpfBuilder => wpfBuilder.UseApplication<TestApplication>());
+                _ = hostCompletion.TrySetResult(builder.Build());
+            }
+            catch (Exception exception)
+            {
+                _ = hostCompletion.TrySetException(exception);
+            }
+        }) { IsBackground = true };
+
+        bootstrapThread.SetApartmentState(ApartmentState.STA);
+        bootstrapThread.Start();
+        return hostCompletion.Task;
+    }
+}

--- a/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Tests/TestApplication.cs
+++ b/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Tests/TestApplication.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows;
+using System.Windows.Threading;
+
+namespace Extensions.Hosting.ReactiveUI.Wpf.Tests;
+
+/// <summary>Signals when the hosted WPF application has entered its startup lifecycle.</summary>
+public sealed class TestApplication : Application
+{
+    /// <summary>Gets the dispatcher reported by the hosted application at startup.</summary>
+    public static TaskCompletionSource<Dispatcher> Started { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <inheritdoc />
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        _ = Started.TrySetResult(Dispatcher);
+    }
+}

--- a/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Tests/WpfHostingCoverageTests.cs
+++ b/src/tests/Extensions.Hosting.ReactiveUI.Wpf.Tests/WpfHostingCoverageTests.cs
@@ -1,0 +1,262 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+#if REACTIVE_SHIM
+using ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+
+namespace Extensions.Hosting.ReactiveUI.Wpf.Tests;
+
+/// <summary>Verifies WPF host and ReactiveUI builder registrations without starting a WPF message loop.</summary>
+[NotInParallel]
+public sealed class WpfHostingCoverageTests
+{
+    /// <summary>Verifies application-builder WPF registration, context configuration, and lifetime configuration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWpf_ApplicationBuilderRegistersServicesAndConfiguresLifetime()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        IWpfContext? configuredContext = null;
+
+        var configuredBuilder = builder.ConfigureWpf(wpfBuilder =>
+        {
+            _ = wpfBuilder.UseApplication<TestApplication>();
+            _ = wpfBuilder.UseWindow<TestShellWindow>();
+            _ = wpfBuilder.ConfigureContext(context =>
+            {
+                configuredContext = context;
+                context.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+            });
+        });
+        var lifetimeBuilder = builder.UseWpfLifetime();
+        var explicitlyConfiguredLifetimeBuilder = builder.UseWpfLifetime(ShutdownMode.OnMainWindowClose);
+
+        await Assert.That(configuredBuilder).IsSameReferenceAs(builder);
+        await Assert.That(lifetimeBuilder).IsSameReferenceAs(builder);
+        await Assert.That(explicitlyConfiguredLifetimeBuilder).IsSameReferenceAs(builder);
+        await Assert.That(configuredContext).IsNotNull();
+        await Assert.That(configuredContext!.ShutdownMode).IsEqualTo(ShutdownMode.OnMainWindowClose);
+        await Assert.That(configuredContext.IsLifetimeLinked).IsTrue();
+        await Assert.That(HasRegistration(builder.Services, typeof(IWpfContext))).IsTrue();
+        await Assert.That(HasRegistration(builder.Services, typeof(IHostedService))).IsTrue();
+        await Assert.That(HasRegistration(builder.Services, typeof(TestApplication))).IsTrue();
+        await Assert.That(HasRegistration(builder.Services, typeof(TestShellWindow))).IsTrue();
+        await Assert.That(HasRegistration(builder.Services, typeof(IWpfShell))).IsTrue();
+
+        _ = builder.ConfigureWpf();
+
+        await Assert.That(CountRegistrations(builder.Services, typeof(IWpfContext))).IsEqualTo(1);
+        await Assert.That(CountRegistrations(builder.Services, typeof(IHostedService))).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies generic host-builder WPF registration and lifetime configuration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWpf_HostBuilderRegistersContextWhenBuilt()
+    {
+        var hostBuilder = new HostBuilder();
+        var configuredBuilder = hostBuilder.ConfigureWpf(static wpfBuilder =>
+        {
+            _ = wpfBuilder.UseApplication<TestApplication>();
+            _ = wpfBuilder.UseWindow<TestShellWindow>();
+        });
+        var lifetimeBuilder = hostBuilder.UseWpfLifetime(ShutdownMode.OnExplicitShutdown);
+
+        using var host = hostBuilder.Build();
+        var context = host.Services.GetRequiredService<IWpfContext>();
+
+        await Assert.That(configuredBuilder).IsSameReferenceAs(hostBuilder);
+        await Assert.That(lifetimeBuilder).IsSameReferenceAs(hostBuilder);
+        await Assert.That(context.ShutdownMode).IsEqualTo(ShutdownMode.OnExplicitShutdown);
+        await Assert.That(context.IsLifetimeLinked).IsTrue();
+    }
+
+    /// <summary>Verifies WPF lifetime configuration reports a missing WPF configuration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseWpfLifetime_WithoutWpfConfigurationThrowsNotSupportedException()
+    {
+        var applicationBuilder = Host.CreateApplicationBuilder();
+        var hostBuilder = new HostBuilder();
+
+        void ConfigureApplicationBuilderLifetime() => applicationBuilder.UseWpfLifetime();
+        void BuildHost() => hostBuilder.UseWpfLifetime().Build();
+
+        await Assert.That(ConfigureApplicationBuilderLifetime).Throws<NotSupportedException>();
+        await Assert.That(BuildHost).Throws<NotSupportedException>();
+    }
+
+    /// <summary>Verifies builder extensions configure all supported builder properties.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task WpfBuilderExtensions_ConfigureBuilderProperties()
+    {
+        var builder = new RecordingWpfBuilder();
+        _ = builder.UseApplication<TestApplication>();
+        _ = builder.UseCurrentApplication<TestApplication>(null!);
+        _ = builder.UseWindow<TestShellWindow>();
+        var configuredBuilder = builder.ConfigureContext(static context => context.IsLifetimeLinked = true);
+
+        await Assert.That(configuredBuilder).IsSameReferenceAs(builder);
+        await Assert.That(builder.ApplicationType).IsEqualTo(typeof(TestApplication));
+        await Assert.That(builder.Application).IsNull();
+        await Assert.That(builder.WindowTypes[0]).IsEqualTo(typeof(TestShellWindow));
+        await Assert.That(builder.ConfigureContextAction).IsNotNull();
+    }
+
+    /// <summary>Verifies invalid WPF application types are rejected during configuration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWpf_InvalidApplicationTypeThrowsArgumentException()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        void Act() => _ = builder.ConfigureWpf(static wpfBuilder => wpfBuilder.ApplicationType = typeof(string));
+
+        await Assert.That(Act).Throws<ArgumentException>();
+    }
+
+    /// <summary>Verifies ReactiveUI configuration registers the WPF scheduler service for application builders.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_ApplicationBuilderRegistersWpfService()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var configuredBuilder = builder.ConfigureSplatForMicrosoftDependencyResolver();
+
+        await Assert.That(configuredBuilder).IsSameReferenceAs(builder);
+        await Assert.That(CountRegistrations(builder.Services, typeof(IWpfService))).IsEqualTo(1);
+        await Assert.That(GetRegistration(builder.Services, typeof(IWpfService)).Lifetime).IsEqualTo(ServiceLifetime.Singleton);
+    }
+
+    /// <summary>Verifies ReactiveUI configuration registers the WPF scheduler service for generic host builders.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_HostBuilderRegistersWpfService()
+    {
+        var hostBuilder = new HostBuilder();
+
+        var configuredBuilder = hostBuilder.ConfigureSplatForMicrosoftDependencyResolver();
+        using var host = hostBuilder.Build();
+
+        await Assert.That(configuredBuilder).IsSameReferenceAs(hostBuilder);
+        await Assert.That(CountServices(host.Services.GetServices<IWpfService>())).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies mapping a host forwards its service provider to the supplied callback.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MapSplatLocator_HostInvokesContainerFactoryWithServiceProvider()
+    {
+        using var host = Host.CreateApplicationBuilder().Build();
+        IServiceProvider? receivedProvider = null;
+
+        var mappedHost = host.MapSplatLocator(provider => receivedProvider = provider);
+
+        await Assert.That(mappedHost).IsSameReferenceAs(host);
+        await Assert.That(receivedProvider).IsSameReferenceAs(host.Services);
+    }
+
+    /// <summary>Determines whether a service collection contains a registration for the specified service type.</summary>
+    /// <param name="services">The service collection to inspect.</param>
+    /// <param name="serviceType">The service type to locate.</param>
+    /// <returns><see langword="true"/> when a registration is present; otherwise, <see langword="false"/>.</returns>
+    private static bool HasRegistration(IServiceCollection services, Type serviceType)
+    {
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType == serviceType)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Counts registrations for the specified service type.</summary>
+    /// <param name="services">The service collection to inspect.</param>
+    /// <param name="serviceType">The service type to count.</param>
+    /// <returns>The number of matching service registrations.</returns>
+    private static int CountRegistrations(IServiceCollection services, Type serviceType)
+    {
+        var count = 0;
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType == serviceType)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Gets the service registration for the specified service type.</summary>
+    /// <param name="services">The service collection to inspect.</param>
+    /// <param name="serviceType">The service type to locate.</param>
+    /// <returns>The matching service registration.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no registration exists for the specified service type.</exception>
+    private static ServiceDescriptor GetRegistration(IServiceCollection services, Type serviceType)
+    {
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType == serviceType)
+            {
+                return descriptor;
+            }
+        }
+
+        throw new InvalidOperationException($"No registration found for {serviceType}.");
+    }
+
+    /// <summary>Counts values in the supplied service sequence.</summary>
+    /// <param name="services">The services to count.</param>
+    /// <returns>The number of supplied services.</returns>
+    private static int CountServices(IEnumerable<IWpfService> services)
+    {
+        var count = 0;
+        foreach (var service in services)
+        {
+            _ = service;
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>Provides a shell window type used only for service-registration coverage.</summary>
+    public sealed class TestShellWindow : Window, IWpfShell
+    {
+        /// <summary>Gets the shell window type registered by the WPF host builder.</summary>
+        public static Type RegistrationType => typeof(TestShellWindow);
+    }
+
+    /// <summary>Provides a writable test implementation of <see cref="IWpfBuilder"/>.</summary>
+    public sealed class RecordingWpfBuilder : IWpfBuilder
+    {
+        /// <inheritdoc />
+        public Type? ApplicationType { get; set; }
+
+        /// <inheritdoc />
+        public Application? Application { get; set; }
+
+        /// <inheritdoc />
+        public IList<Type> WindowTypes { get; } = [];
+
+        /// <inheritdoc />
+        public Action<IWpfContext>? ConfigureContextAction { get; set; }
+    }
+}

--- a/src/tests/Extensions.Hosting.Tests/AbstractTestPlugin.cs
+++ b/src/tests/Extensions.Hosting.Tests/AbstractTestPlugin.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -10,6 +10,18 @@ namespace Extensions.Hosting.Tests;
 /// <summary>An abstract plugin used to test that abstract classes are not discovered.</summary>
 public abstract class AbstractTestPlugin : IPlugin
 {
+    /// <summary>Gets a value indicating whether the plugin received host configuration.</summary>
+    public bool WasConfigured { get; private set; }
+
     /// <inheritdoc />
-    public abstract void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection);
+    public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
+    {
+        WasConfigured = true;
+        ConfigureHostCore(hostBuilderContext, serviceCollection);
+    }
+
+    /// <summary>Configures services for a concrete test plugin.</summary>
+    /// <param name="hostBuilderContext">The host builder context.</param>
+    /// <param name="serviceCollection">The service collection.</param>
+    protected abstract void ConfigureHostCore(object hostBuilderContext, IServiceCollection serviceCollection);
 }

--- a/src/tests/Extensions.Hosting.Tests/AssemblyLoadingTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/AssemblyLoadingTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -27,7 +27,7 @@ public class AssemblyLoadingTests
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
             var resolver = new PluginAssemblyDependencyResolver(pluginPath);
 
-            var resolvedPath = resolver.ResolveAssemblyToPath(new AssemblyName("Dependency"));
+            var resolvedPath = resolver.ResolveAssemblyToPath(new("Dependency"));
 
             await Assert.That(resolvedPath).IsEqualTo(dependencyPath);
         }
@@ -49,7 +49,7 @@ public class AssemblyLoadingTests
             await File.WriteAllTextAsync(pluginPath, string.Empty);
             var resolver = new PluginAssemblyDependencyResolver(pluginPath);
 
-            var resolvedPath = resolver.ResolveAssemblyToPath(new AssemblyName("Missing.Dependency"));
+            var resolvedPath = resolver.ResolveAssemblyToPath(new("Missing.Dependency"));
 
             await Assert.That(resolvedPath).IsNull();
         }
@@ -140,7 +140,7 @@ public class AssemblyLoadingTests
         var context = PluginAssemblyLoadContext.Default;
 
         await Assert.That(context.Name).IsEqualTo("default");
-        await Assert.That(PluginAssemblyLoadContext.Assemblies.Any()).IsTrue();
+        await Assert.That(TestEnumerable.ContainsAny(PluginAssemblyLoadContext.Assemblies)).IsTrue();
     }
 
     /// <summary>Verifies that loading from a null assembly name throws.</summary>
@@ -163,7 +163,7 @@ public class AssemblyLoadingTests
     {
         var context = new PluginAssemblyLoadContext("test");
 
-        Assembly? assembly = context.LoadFromAssemblyName(new AssemblyName("Missing.Assembly"));
+        Assembly? assembly = context.LoadFromAssemblyName(new("Missing.Assembly"));
 
         await Assert.That(assembly).IsNull();
     }
@@ -224,7 +224,7 @@ public class AssemblyLoadingTests
     {
         var context = PluginAssemblyLoadContext.Default;
 
-        var result = context.TryGetAssembly(new AssemblyName("Missing.Plugin.Assembly"), out var assembly);
+        var result = context.TryGetAssembly(new("Missing.Plugin.Assembly"), out var assembly);
 
         await Assert.That(result).IsFalse();
         await Assert.That(assembly).IsNull();
@@ -244,7 +244,7 @@ public class AssemblyLoadingTests
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
             var context = new PluginLoadContext(pluginPath, nameof(Plugin));
 
-            var resolvedPath = context.ResolveAssemblyPath(new AssemblyName("Dependency"));
+            var resolvedPath = context.ResolveAssemblyPath(new("Dependency"));
 
             await Assert.That(resolvedPath).IsEqualTo(dependencyPath);
         }
@@ -288,7 +288,7 @@ public class AssemblyLoadingTests
     {
         var context = new PluginLoadContext(typeof(AssemblyLoadingTests).Assembly.Location, nameof(Plugin));
 
-        Assembly? assembly = context.LoadFromAssemblyName(new AssemblyName("Missing.Plugin.Assembly"));
+        Assembly? assembly = context.LoadFromAssemblyName(new("Missing.Plugin.Assembly"));
 
         await Assert.That(assembly).IsNull();
     }
@@ -299,9 +299,8 @@ public class AssemblyLoadingTests
     public async Task PluginLoadContext_LoadUnmanagedDll_WithMissingLibrary_ReturnsZero()
     {
         var context = new PluginLoadContext(typeof(AssemblyLoadingTests).Assembly.Location, nameof(Plugin));
-        var method = typeof(PluginLoadContext).GetMethod("LoadUnmanagedDll", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        var result = (IntPtr)method!.Invoke(context, ["missing"])!;
+        var result = context.LoadUnmanagedLibrary("missing");
 
         await Assert.That(result).IsEqualTo(IntPtr.Zero);
     }
@@ -320,16 +319,21 @@ public class AssemblyLoadingTests
     private static string GetUnloadedAssemblyPath()
     {
         var assemblyDirectory = Path.GetDirectoryName(typeof(AssemblyLoadingTests).Assembly.Location)!;
-        var loadedAssemblyNames = AppDomain.CurrentDomain.GetAssemblies()
-            .Select(assembly => assembly.GetName().Name)
-            .Where(name => name is not null)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var loadedAssemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var loadedAssembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var loadedAssemblyName = loadedAssembly.GetName().Name;
+            if (loadedAssemblyName is not null)
+            {
+                _ = loadedAssemblyNames.Add(loadedAssemblyName);
+            }
+        }
 
         foreach (var assemblyPath in Directory.EnumerateFiles(assemblyDirectory, "*.dll"))
         {
             var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-            if (!loadedAssemblyNames.Contains(assemblyName) &&
-                !assemblyName.StartsWith("Extensions.Hosting", StringComparison.OrdinalIgnoreCase))
+            if (!loadedAssemblyNames.Contains(assemblyName)
+                && !assemblyName.StartsWith("Extensions.Hosting", StringComparison.OrdinalIgnoreCase))
             {
                 return assemblyPath;
             }

--- a/src/tests/Extensions.Hosting.Tests/BaseUiThreadCoverageTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/BaseUiThreadCoverageTests.cs
@@ -1,0 +1,304 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.UiThread;
+
+namespace Extensions.Hosting.Tests;
+
+/// <summary>Contains line-coverage tests for <see cref="BaseUiThread{T}"/>.</summary>
+public class BaseUiThreadCoverageTests
+{
+    /// <summary>The maximum duration to wait for a UI-thread test signal.</summary>
+    private static readonly TimeSpan _uiThreadSignalTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>The duration used to confirm that a disposed UI thread does not begin execution.</summary>
+    private static readonly TimeSpan _disposedUiThreadSignalTimeout = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>Verifies that the dedicated-thread constructor runs the complete startup sequence.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Start_WithDedicatedUiThread_RunsInitializationAndUiThread()
+    {
+        using var context = new TestUiContext();
+        await using var provider = CreateServiceProvider(context);
+        using var uiThread = new TestUiThread(provider);
+
+        await Assert.That(uiThread.PreUiThreadStarted.Wait(_uiThreadSignalTimeout)).IsTrue();
+
+        uiThread.Start();
+
+        await Assert.That(uiThread.UiThreadStarted.Wait(_uiThreadSignalTimeout)).IsTrue();
+        await Assert.That(context.IsRunning).IsTrue();
+    }
+
+    /// <summary>Verifies that the caller-thread startup mode completes synchronously.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Start_WithoutDedicatedUiThread_RunsInitializationAndUiThread()
+    {
+        using var context = new TestUiContext();
+        await using var provider = CreateServiceProvider(context);
+        using var uiThread = new TestUiThread(provider, useDedicatedUiThread: false);
+
+        uiThread.Start();
+
+        await Assert.That(uiThread.PreUiThreadStarted.IsSet).IsTrue();
+        await Assert.That(uiThread.UiThreadStarted.IsSet).IsTrue();
+        await Assert.That(context.IsRunning).IsTrue();
+    }
+
+    /// <summary>Verifies that disposing a waiting dedicated UI thread ends its startup safely.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_WhileDedicatedUiThreadWaitsForStart_EndsStartupSafely()
+    {
+        using var context = new TestUiContext { BlockPreUiThreadStart = true };
+        await using var provider = CreateServiceProvider(context);
+        var uiThread = new TestUiThread(provider);
+
+        await Assert.That(uiThread.PreUiThreadStarted.Wait(_uiThreadSignalTimeout)).IsTrue();
+
+        uiThread.Dispose();
+        context.ContinuePreUiThreadStart();
+
+        await Assert.That(uiThread.UiThreadStarted.Wait(_disposedUiThreadSignalTimeout)).IsFalse();
+    }
+
+    /// <summary>Verifies that constructing the thread without a service provider fails.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Constructor_WithNullServiceProvider_ThrowsArgumentNullException()
+    {
+        static TestUiThread Act() => new(null!, useDedicatedUiThread: false);
+
+        await Assert.That(Act).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that constructing the thread without its UI context registration fails.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Constructor_WithoutUiContextRegistration_ThrowsInvalidOperationException()
+    {
+        await using var provider = new ServiceCollection().BuildServiceProvider();
+        static TestUiThread Act(IServiceProvider serviceProvider) => new(serviceProvider, useDedicatedUiThread: false);
+
+        await Assert.That(() => Act(provider)).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies that application exit stops an active linked host lifetime.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HandleApplicationExit_WithActiveLinkedLifetime_StopsApplication()
+    {
+        using var context = new TestUiContext { IsLifetimeLinked = true, IsRunning = true };
+        using var lifetime = new TestHostApplicationLifetime();
+        await using var provider = CreateServiceProvider(context, lifetime);
+        using var uiThread = new TestUiThread(provider, useDedicatedUiThread: false);
+
+        uiThread.ExitApplication();
+
+        await Assert.That(context.IsRunning).IsFalse();
+        await Assert.That(lifetime.StopApplicationCallCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that application exit does not stop an unlinked or unavailable lifetime.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HandleApplicationExit_WithUnlinkedOrUnavailableLifetime_DoesNotStopApplication()
+    {
+        using var unlinkedContext = new TestUiContext { IsRunning = true };
+        await using var unlinkedProvider = CreateServiceProvider(unlinkedContext);
+        using var unlinkedUiThread = new TestUiThread(unlinkedProvider, useDedicatedUiThread: false);
+
+        unlinkedUiThread.ExitApplication();
+
+        await Assert.That(unlinkedContext.IsRunning).IsFalse();
+
+        using var linkedContext = new TestUiContext { IsLifetimeLinked = true, IsRunning = true };
+        await using var linkedProvider = CreateServiceProvider(linkedContext);
+        using var linkedUiThread = new TestUiThread(linkedProvider, useDedicatedUiThread: false);
+
+        linkedUiThread.ExitApplication();
+
+        await Assert.That(linkedContext.IsRunning).IsFalse();
+    }
+
+    /// <summary>Verifies that application exit does not stop a lifetime that is already stopping or stopped.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HandleApplicationExit_WithStoppingOrStoppedLifetime_DoesNotStopApplication()
+    {
+        using var stoppingLifetime = new TestHostApplicationLifetime();
+        stoppingLifetime.TriggerStopping();
+        using var stoppingContext = new TestUiContext { IsLifetimeLinked = true, IsRunning = true };
+        await using var stoppingProvider = CreateServiceProvider(stoppingContext, stoppingLifetime);
+        using var stoppingUiThread = new TestUiThread(stoppingProvider, useDedicatedUiThread: false);
+
+        stoppingUiThread.ExitApplication();
+
+        await Assert.That(stoppingLifetime.StopApplicationCallCount).IsEqualTo(0);
+
+        using var stoppedLifetime = new TestHostApplicationLifetime();
+        stoppedLifetime.TriggerStopped();
+        using var stoppedContext = new TestUiContext { IsLifetimeLinked = true, IsRunning = true };
+        await using var stoppedProvider = CreateServiceProvider(stoppedContext, stoppedLifetime);
+        using var stoppedUiThread = new TestUiThread(stoppedProvider, useDedicatedUiThread: false);
+
+        stoppedUiThread.ExitApplication();
+
+        await Assert.That(stoppedLifetime.StopApplicationCallCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that repeated disposal is harmless after unmanaged disposal.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_AfterUnmanagedDisposal_IsIdempotent()
+    {
+        using var context = new TestUiContext();
+        await using var provider = CreateServiceProvider(context);
+        var uiThread = new TestUiThread(provider, useDedicatedUiThread: false);
+
+        uiThread.DisposeUnmanagedResources();
+        uiThread.Dispose();
+
+        await Assert.That(uiThread).IsNotNull();
+    }
+
+    /// <summary>Creates a service provider for a UI thread test.</summary>
+    /// <param name="context">The UI context to register.</param>
+    /// <param name="lifetime">The optional host lifetime to register.</param>
+    /// <returns>A configured service provider.</returns>
+    private static ServiceProvider CreateServiceProvider(TestUiContext context, IHostApplicationLifetime? lifetime = null)
+    {
+        var services = new ServiceCollection();
+        _ = services.AddSingleton(context);
+
+        if (lifetime is not null)
+        {
+            _ = services.AddSingleton(lifetime);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>Provides a UI context for test instances.</summary>
+    private sealed class TestUiContext : IUiContext, IDisposable
+    {
+        /// <summary>Stores the event that releases a blocked pre-UI initialization.</summary>
+        private readonly ManualResetEventSlim _continuePreUiThreadStart = new(false);
+
+        /// <summary>Gets or sets a value indicating whether pre-UI initialization waits for explicit release.</summary>
+        public bool BlockPreUiThreadStart { get; set; }
+
+        /// <inheritdoc />
+        public bool IsLifetimeLinked { get; set; }
+
+        /// <inheritdoc />
+        public bool IsRunning { get; set; }
+
+        /// <summary>Releases a blocked pre-UI initialization.</summary>
+        public void ContinuePreUiThreadStart() => _continuePreUiThreadStart.Set();
+
+        /// <summary>Waits for permission to finish pre-UI initialization.</summary>
+        public void WaitForPreUiThreadStartContinuation() => _continuePreUiThreadStart.Wait();
+
+        /// <inheritdoc />
+        public void Dispose() => _continuePreUiThreadStart.Dispose();
+    }
+
+    /// <summary>Provides public hooks around the protected members of <see cref="BaseUiThread{T}"/>.</summary>
+    private sealed class TestUiThread : BaseUiThread<TestUiContext>
+    {
+        /// <summary>Initializes a new instance of the <see cref="TestUiThread"/> class with a dedicated UI thread.</summary>
+        /// <param name="serviceProvider">The service provider to use.</param>
+        public TestUiThread(IServiceProvider serviceProvider)
+            : base(serviceProvider)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="TestUiThread"/> class.</summary>
+        /// <param name="serviceProvider">The service provider to use.</param>
+        /// <param name="useDedicatedUiThread">Whether to use a dedicated UI thread.</param>
+        public TestUiThread(IServiceProvider serviceProvider, bool useDedicatedUiThread)
+            : base(serviceProvider, useDedicatedUiThread)
+        {
+        }
+
+        /// <summary>Gets the event signaled when pre-UI initialization begins.</summary>
+        public ManualResetEventSlim PreUiThreadStarted { get; } = new(false);
+
+        /// <summary>Gets the event signaled when the UI thread begins.</summary>
+        public ManualResetEventSlim UiThreadStarted { get; } = new(false);
+
+        /// <summary>Invokes the protected application-exit handler.</summary>
+        public void ExitApplication() => HandleApplicationExit();
+
+        /// <summary>Invokes disposal without managed resource cleanup.</summary>
+        public void DisposeUnmanagedResources() => Dispose(disposing: false);
+
+        /// <inheritdoc />
+        protected override void PreUiThreadStart()
+        {
+            PreUiThreadStarted.Set();
+
+            if (!UiContext.BlockPreUiThreadStart)
+            {
+                return;
+            }
+
+            UiContext.WaitForPreUiThreadStartContinuation();
+        }
+
+        /// <inheritdoc />
+        protected override void UiThreadStart() => UiThreadStarted.Set();
+    }
+
+    /// <summary>Provides a controllable host lifetime for test instances.</summary>
+    private sealed class TestHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+    {
+        /// <summary>Stores the application-started token source.</summary>
+        private readonly CancellationTokenSource _applicationStarted = new();
+
+        /// <summary>Stores the application-stopping token source.</summary>
+        private readonly CancellationTokenSource _applicationStopping = new();
+
+        /// <summary>Stores the application-stopped token source.</summary>
+        private readonly CancellationTokenSource _applicationStopped = new();
+
+        /// <inheritdoc />
+        public CancellationToken ApplicationStarted => _applicationStarted.Token;
+
+        /// <inheritdoc />
+        public CancellationToken ApplicationStopping => _applicationStopping.Token;
+
+        /// <inheritdoc />
+        public CancellationToken ApplicationStopped => _applicationStopped.Token;
+
+        /// <summary>Gets the number of calls to <see cref="StopApplication"/>.</summary>
+        public int StopApplicationCallCount { get; private set; }
+
+        /// <summary>Triggers the application-stopping token.</summary>
+        public void TriggerStopping() => _applicationStopping.Cancel();
+
+        /// <summary>Triggers the application-stopped token.</summary>
+        public void TriggerStopped() => _applicationStopped.Cancel();
+
+        /// <inheritdoc />
+        public void StopApplication()
+        {
+            StopApplicationCallCount++;
+            TriggerStopping();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _applicationStarted.Dispose();
+            _applicationStopping.Dispose();
+            _applicationStopped.Dispose();
+        }
+    }
+}

--- a/src/tests/Extensions.Hosting.Tests/ConcreteTestPlugin.cs
+++ b/src/tests/Extensions.Hosting.Tests/ConcreteTestPlugin.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -10,7 +10,7 @@ namespace Extensions.Hosting.Tests;
 public class ConcreteTestPlugin : AbstractTestPlugin
 {
     /// <inheritdoc />
-    public override void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
+    protected override void ConfigureHostCore(object hostBuilderContext, IServiceCollection serviceCollection)
     {
     }
 }

--- a/src/tests/Extensions.Hosting.Tests/HostBuilderApplicationExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/HostBuilderApplicationExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -18,7 +18,7 @@ public class HostBuilderApplicationExtensionsTests
     public async Task ConfigureSingleInstance_IHostBuilder_WithNullHostBuilder_ThrowsArgumentNullException()
     {
         IHostBuilder? hostBuilder = null;
-        var act = () => hostBuilder!.ConfigureSingleInstance(_ => { });
+        var act = () => hostBuilder!.ConfigureSingleInstance(static _ => { });
         await Assert.That(act).Throws<ArgumentNullException>();
     }
 
@@ -28,7 +28,7 @@ public class HostBuilderApplicationExtensionsTests
     public async Task ConfigureSingleInstance_IHostApplicationBuilder_WithNullHostBuilder_ThrowsArgumentNullException()
     {
         IHostApplicationBuilder? hostBuilder = null;
-        var act = () => hostBuilder!.ConfigureSingleInstance(_ => { });
+        var act = () => hostBuilder!.ConfigureSingleInstance(static _ => { });
         await Assert.That(act).Throws<ArgumentNullException>();
     }
 
@@ -38,7 +38,7 @@ public class HostBuilderApplicationExtensionsTests
     public async Task ConfigureSingleInstance_WithMutexId_ReturnsHostBuilder()
     {
         var hostBuilder = Host.CreateDefaultBuilder();
-        var result = hostBuilder.ConfigureSingleInstance("test-mutex-" + Guid.NewGuid().ToString("N"));
+        var result = hostBuilder.ConfigureSingleInstance($"test-mutex-{Guid.NewGuid():N}");
         await Assert.That(result).IsNotNull();
         await Assert.That(result).IsEqualTo(hostBuilder);
     }
@@ -49,7 +49,7 @@ public class HostBuilderApplicationExtensionsTests
     public async Task ConfigureSingleInstance_WithMutexId_RegistersConfiguredMutexId()
     {
         var hostBuilder = Host.CreateDefaultBuilder();
-        var mutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+        var mutexId = $"test-mutex-{Guid.NewGuid():N}";
 
         _ = hostBuilder.ConfigureSingleInstance(mutexId);
 
@@ -64,7 +64,7 @@ public class HostBuilderApplicationExtensionsTests
     public async Task ConfigureSingleInstance_IHostApplicationBuilder_WithMutexId_ReturnsBuilderAndRegistersMutexBuilder()
     {
         var hostBuilder = Host.CreateApplicationBuilder();
-        var mutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+        var mutexId = $"test-mutex-{Guid.NewGuid():N}";
 
         var result = hostBuilder.ConfigureSingleInstance(mutexId);
 
@@ -86,7 +86,7 @@ public class HostBuilderApplicationExtensionsTests
         _ = hostBuilder.ConfigureSingleInstance(builder =>
         {
             firstBuilder = builder;
-            builder.MutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+            builder.MutexId = $"test-mutex-{Guid.NewGuid():N}";
         });
 
         _ = hostBuilder.ConfigureSingleInstance(builder => secondBuilder = builder);
@@ -102,9 +102,9 @@ public class HostBuilderApplicationExtensionsTests
     public async Task ConfigureSingleInstance_WithConfigureAction_ReturnsHostBuilder()
     {
         var hostBuilder = Host.CreateDefaultBuilder();
-        var result = hostBuilder.ConfigureSingleInstance(builder =>
+        var result = hostBuilder.ConfigureSingleInstance(static builder =>
         {
-            builder.MutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+            builder.MutexId = $"test-mutex-{Guid.NewGuid():N}";
             builder.IsGlobal = false;
         });
         await Assert.That(result).IsNotNull();
@@ -136,7 +136,7 @@ public class HostBuilderApplicationExtensionsTests
         _ = hostBuilder.ConfigureSingleInstance(builder =>
         {
             wasInvoked = true;
-            builder.MutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+            builder.MutexId = $"test-mutex-{Guid.NewGuid():N}";
         });
 
         // Build to trigger the service configuration
@@ -150,7 +150,7 @@ public class HostBuilderApplicationExtensionsTests
     public async Task ConfigureSingleInstance_RegistersMutexBuilder()
     {
         var hostBuilder = Host.CreateDefaultBuilder();
-        _ = hostBuilder.ConfigureSingleInstance(builder => builder.MutexId = "test-mutex-" + Guid.NewGuid().ToString("N"));
+        _ = hostBuilder.ConfigureSingleInstance(static builder => builder.MutexId = $"test-mutex-{Guid.NewGuid():N}");
 
         using var host = hostBuilder.Build();
         var mutexBuilder = host.Services.GetService<IMutexBuilder>();
@@ -169,7 +169,7 @@ public class HostBuilderApplicationExtensionsTests
         _ = hostBuilder.ConfigureSingleInstance(builder =>
         {
             firstBuilder = builder;
-            builder.MutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+            builder.MutexId = $"test-mutex-{Guid.NewGuid():N}";
         });
 
         _ = hostBuilder.ConfigureSingleInstance(builder => secondBuilder = builder);
@@ -186,9 +186,9 @@ public class HostBuilderApplicationExtensionsTests
     public async Task ConfigureSingleInstance_CanSetIsGlobal()
     {
         var hostBuilder = Host.CreateDefaultBuilder();
-        _ = hostBuilder.ConfigureSingleInstance(builder =>
+        _ = hostBuilder.ConfigureSingleInstance(static builder =>
         {
-            builder.MutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+            builder.MutexId = $"test-mutex-{Guid.NewGuid():N}";
             builder.IsGlobal = true;
         });
 
@@ -206,7 +206,7 @@ public class HostBuilderApplicationExtensionsTests
         var hostBuilder = Host.CreateDefaultBuilder();
         _ = hostBuilder.ConfigureSingleInstance(builder =>
         {
-            builder.MutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+            builder.MutexId = $"test-mutex-{Guid.NewGuid():N}";
             builder.WhenNotFirstInstance = (_, _) => callbackSet = true;
         });
 
@@ -224,7 +224,7 @@ public class HostBuilderApplicationExtensionsTests
     [Test]
     public async Task ConfigureSingleInstance_StartAndStop_ReleasesMutex()
     {
-        var mutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+        var mutexId = $"test-mutex-{Guid.NewGuid():N}";
         using var host = Host.CreateDefaultBuilder()
             .ConfigureSingleInstance(builder =>
             {
@@ -246,7 +246,7 @@ public class HostBuilderApplicationExtensionsTests
     public async Task ConfigureSingleInstance_StartAsync_WhenMutexAlreadyLocked_InvokesCallback()
     {
         var callbackSet = false;
-        var mutexId = "test-mutex-" + Guid.NewGuid().ToString("N");
+        var mutexId = $"test-mutex-{Guid.NewGuid():N}";
         using var primaryMutex = ResourceMutex.Create(NullLogger<ResourceMutex>.Instance, mutexId, "primary", false);
         using var host = Host.CreateDefaultBuilder()
             .ConfigureSingleInstance(builder =>

--- a/src/tests/Extensions.Hosting.Tests/HostBuilderPluginExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/HostBuilderPluginExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -12,13 +12,16 @@ namespace Extensions.Hosting.Tests;
 /// <summary>Contains tests for host builder plugin configuration extensions.</summary>
 public class HostBuilderPluginExtensionsTests
 {
+    /// <summary>The expected number of configured plugins.</summary>
+    private const int ExpectedPluginCount = 2;
+
     /// <summary>Verifies that ConfigurePlugins with a null IHostBuilder throws.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
     public async Task ConfigurePlugins_IHostBuilder_WithNullHostBuilder_ThrowsArgumentNullException()
     {
         IHostBuilder? hostBuilder = null;
-        var act = () => hostBuilder!.ConfigurePlugins(_ => { });
+        var act = () => hostBuilder!.ConfigurePlugins(static _ => { });
         await Assert.That(act).Throws<ArgumentNullException>();
     }
 
@@ -28,7 +31,7 @@ public class HostBuilderPluginExtensionsTests
     public async Task ConfigurePlugins_IHostApplicationBuilder_WithNullHostBuilder_ThrowsArgumentNullException()
     {
         IHostApplicationBuilder? hostBuilder = null;
-        var act = () => hostBuilder!.ConfigurePlugins(_ => { });
+        var act = () => hostBuilder!.ConfigurePlugins(static _ => { });
         await Assert.That(act).Throws<ArgumentNullException>();
     }
 
@@ -42,7 +45,7 @@ public class HostBuilderPluginExtensionsTests
 
         _ = hostBuilder.ConfigurePlugins(builder =>
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
             AddCurrentAssemblyAsFramework(builder);
             builder.AssemblyScanFunc = _ =>
             [
@@ -54,7 +57,7 @@ public class HostBuilderPluginExtensionsTests
 
         using var host = hostBuilder.Build();
 
-        await Assert.That(configuredPlugins.Count).IsEqualTo(2);
+        await Assert.That(configuredPlugins.Count).IsEqualTo(ExpectedPluginCount);
         await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierRecordingPlugin.Name);
         await Assert.That(configuredPlugins[1]).IsEqualTo(LaterRecordingPlugin.Name);
     }
@@ -69,7 +72,7 @@ public class HostBuilderPluginExtensionsTests
 
         var result = hostBuilder.ConfigurePlugins(builder =>
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
             AddCurrentAssemblyAsFramework(builder);
             builder.AssemblyScanFunc = _ => [new EarlierRecordingPlugin(configuredPlugins)];
         });
@@ -108,7 +111,7 @@ public class HostBuilderPluginExtensionsTests
 
         _ = hostBuilder.ConfigurePlugins(builder =>
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
             builder.UseContentRoot = true;
             _ = builder.FrameworkMatcher.AddInclude(Path.GetFileName(assemblyPath));
             builder.AssemblyScanFunc = _ => [new EarlierRecordingPlugin(configuredPlugins)];
@@ -134,10 +137,10 @@ public class HostBuilderPluginExtensionsTests
 
             _ = hostBuilder.ConfigurePlugins(builder =>
             {
-                ArgumentNullException.ThrowIfNull(builder);
+                _ = builder ?? throw new ArgumentNullException(nameof(builder));
                 builder.PluginDirectories.Add(tempDirectory);
                 _ = builder.PluginMatcher.AddInclude(Path.GetFileName(pluginPath));
-                builder.ValidatePlugin = _ => false;
+                builder.ValidatePlugin = static _ => false;
             });
 
             using var host = hostBuilder.Build();
@@ -159,7 +162,7 @@ public class HostBuilderPluginExtensionsTests
 
         _ = hostBuilder.ConfigurePlugins(builder =>
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
             builder.PluginDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
             _ = builder.PluginMatcher.AddInclude(Path.GetFileName(assemblyPath));
         });
@@ -182,7 +185,7 @@ public class HostBuilderPluginExtensionsTests
 
             _ = hostBuilder.ConfigurePlugins(builder =>
             {
-                ArgumentNullException.ThrowIfNull(builder);
+                _ = builder ?? throw new ArgumentNullException(nameof(builder));
                 builder.FrameworkDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
                 _ = builder.FrameworkMatcher.AddInclude(Path.GetFileName(assemblyPath));
                 builder.AssemblyScanFunc = _ => [new EarlierRecordingPlugin(configuredPlugins)];
@@ -213,7 +216,7 @@ public class HostBuilderPluginExtensionsTests
 
             _ = hostBuilder.ConfigurePlugins(builder =>
             {
-                ArgumentNullException.ThrowIfNull(builder);
+                _ = builder ?? throw new ArgumentNullException(nameof(builder));
                 builder.PluginDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
                 _ = builder.PluginMatcher.AddInclude(Path.GetFileName(assemblyPath));
                 builder.AssemblyScanFunc = _ => [new EarlierRecordingPlugin(configuredPlugins)];
@@ -236,7 +239,9 @@ public class HostBuilderPluginExtensionsTests
     public async Task ConfigurePlugins_IHostBuilder_WithRequiredPluginsAndNoPlugins_ThrowsInvalidOperationException()
     {
         var hostBuilder = Host.CreateDefaultBuilder();
-        _ = hostBuilder.ConfigurePlugins(builder => builder.RequirePlugins());
+        _ = hostBuilder.ConfigurePlugins(
+            static builder => (builder ?? throw new InvalidOperationException("Plugin builder was not created."))
+                .RequirePlugins());
 
         var act = () => hostBuilder.Build();
         await Assert.That(act).Throws<InvalidOperationException>();

--- a/src/tests/Extensions.Hosting.Tests/HostedServiceBaseTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/HostedServiceBaseTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
@@ -11,17 +11,23 @@ namespace Extensions.Hosting.Tests;
 /// <summary>Contains unit tests for the hosted service base lifecycle implementation.</summary>
 public class HostedServiceBaseTests
 {
+    /// <summary>The lifecycle callback timeout, in seconds.</summary>
+    private const int LifecycleTimeoutSeconds = 5;
+
+    /// <summary>The delay used to allow shutdown callbacks to propagate, in milliseconds.</summary>
+    private const int ShutdownPropagationDelayMilliseconds = 50;
+
     /// <summary>Verifies that lifetime callbacks invoke the overridable lifecycle methods.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
     public async Task LifetimeCallbacks_InvokeLifecycleMethods()
     {
         using var lifetime = new TestHostApplicationLifetime();
-        var service = new TestHostedService(lifetime);
+        using var service = new TestHostedService(lifetime);
 
         await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
         lifetime.TriggerStarted();
-        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(LifecycleTimeoutSeconds)).ConfigureAwait(false);
 
         await Assert.That(service.StartedCount).IsEqualTo(1);
         await Assert.That(service.CleanupDisposable).IsNotNull();
@@ -46,7 +52,7 @@ public class HostedServiceBaseTests
 
         await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
         lifetime.TriggerStarted();
-        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(LifecycleTimeoutSeconds)).ConfigureAwait(false);
 
         service.Dispose();
         service.Dispose();
@@ -62,7 +68,7 @@ public class HostedServiceBaseTests
     public async Task StopAsync_ReturnsCompletedTask()
     {
         using var lifetime = new TestHostApplicationLifetime();
-        var service = new DefaultHostedService(lifetime);
+        using var service = new DefaultHostedService(lifetime);
 
         var stopTask = service.StopAsync(CancellationToken.None);
 
@@ -88,20 +94,19 @@ public class HostedServiceBaseTests
     public async Task LifetimeStarted_WhenOnStartedThrows_DoesNotThrowFromCallback()
     {
         using var lifetime = new TestHostApplicationLifetime();
-        var service = new ThrowingStartedHostedService(lifetime);
+        using var service = new ThrowingStartedHostedService(lifetime);
 
         await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
         lifetime.TriggerStarted();
-        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-        await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
+        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(LifecycleTimeoutSeconds)).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(ShutdownPropagationDelayMilliseconds)).ConfigureAwait(false);
 
         await Assert.That(service.StartedCount).IsEqualTo(1);
     }
 
     /// <summary>Test hosted service used to observe lifecycle callback execution.</summary>
     /// <param name="lifetime">The test lifetime source.</param>
-    private sealed class TestHostedService(IHostApplicationLifetime lifetime)
-        : HostedServiceBase<TestHostedService>(NullLogger<TestHostedService>.Instance, lifetime)
+    private sealed class TestHostedService(IHostApplicationLifetime lifetime) : HostedServiceBase<TestHostedService>(NullLogger<TestHostedService>.Instance, lifetime)
     {
         /// <summary>Gets the started signal.</summary>
         public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -145,13 +150,11 @@ public class HostedServiceBaseTests
 
     /// <summary>Hosted service that uses the base lifecycle implementations.</summary>
     /// <param name="lifetime">The test lifetime source.</param>
-    private sealed class DefaultHostedService(IHostApplicationLifetime lifetime)
-        : HostedServiceBase<DefaultHostedService>(NullLogger<DefaultHostedService>.Instance, lifetime);
+    private sealed class DefaultHostedService(IHostApplicationLifetime lifetime) : HostedServiceBase<DefaultHostedService>(NullLogger<DefaultHostedService>.Instance, lifetime);
 
     /// <summary>Hosted service that throws from OnStarted.</summary>
     /// <param name="lifetime">The test lifetime source.</param>
-    private sealed class ThrowingStartedHostedService(IHostApplicationLifetime lifetime)
-        : HostedServiceBase<ThrowingStartedHostedService>(NullLogger<ThrowingStartedHostedService>.Instance, lifetime)
+    private sealed class ThrowingStartedHostedService(IHostApplicationLifetime lifetime) : HostedServiceBase<ThrowingStartedHostedService>(NullLogger<ThrowingStartedHostedService>.Instance, lifetime)
     {
         /// <summary>Gets the started signal.</summary>
         public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/tests/Extensions.Hosting.Tests/MutexBuilderTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/MutexBuilderTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace Extensions.Hosting.Tests;
@@ -21,10 +21,7 @@ public class MutexBuilderTests
     [Test]
     public async Task MutexBuilder_MutexId_CanBeSetAndRetrieved()
     {
-        var builder = new TestMutexBuilder
-        {
-            MutexId = "test-mutex-id"
-        };
+        var builder = new TestMutexBuilder { MutexId = "test-mutex-id" };
 
         await Assert.That(builder.MutexId).IsEqualTo("test-mutex-id");
     }
@@ -43,10 +40,7 @@ public class MutexBuilderTests
     [Test]
     public async Task MutexBuilder_IsGlobal_CanBeSetAndRetrieved()
     {
-        var builder = new TestMutexBuilder
-        {
-            IsGlobal = true
-        };
+        var builder = new TestMutexBuilder { IsGlobal = true };
 
         await Assert.That(builder.IsGlobal).IsTrue();
     }
@@ -79,12 +73,7 @@ public class MutexBuilderTests
     [Test]
     public async Task MutexBuilder_AllProperties_CanBeConfiguredTogether()
     {
-        var builder = new TestMutexBuilder
-        {
-            MutexId = "my-app-mutex",
-            IsGlobal = true,
-            WhenNotFirstInstance = (env, logger) => { }
-        };
+        var builder = new TestMutexBuilder { MutexId = "my-app-mutex", IsGlobal = true, WhenNotFirstInstance = static (env, logger) => { } };
 
         await Assert.That(builder.MutexId).IsEqualTo("my-app-mutex");
         await Assert.That(builder.IsGlobal).IsTrue();

--- a/src/tests/Extensions.Hosting.Tests/OrderedTestPlugin.cs
+++ b/src/tests/Extensions.Hosting.Tests/OrderedTestPlugin.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/tests/Extensions.Hosting.Tests/Plugin.cs
+++ b/src/tests/Extensions.Hosting.Tests/Plugin.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/tests/Extensions.Hosting.Tests/PluginBaseTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/PluginBaseTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -19,9 +19,9 @@ public class PluginBaseTests
         var services = new ServiceCollection();
         var plugin = new PluginBase<FirstHostedService>();
 
-        plugin.ConfigureHost(new object(), services);
+        plugin.ConfigureHost(new(), services);
 
-        await Assert.That(services.Any(IsFirstHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsFirstHostedServiceRegistration)).IsTrue();
     }
 
     /// <summary>Verifies that PluginBase with two hosted services registers both services.</summary>
@@ -32,10 +32,10 @@ public class PluginBaseTests
         var services = new ServiceCollection();
         var plugin = new PluginBase<FirstHostedService, SecondHostedService>();
 
-        plugin.ConfigureHost(new object(), services);
+        plugin.ConfigureHost(new(), services);
 
-        await Assert.That(services.Any(IsFirstHostedServiceRegistration)).IsTrue();
-        await Assert.That(services.Any(IsSecondHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsFirstHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsSecondHostedServiceRegistration)).IsTrue();
     }
 
     /// <summary>Verifies that PluginBase with three hosted services registers all services.</summary>
@@ -46,11 +46,11 @@ public class PluginBaseTests
         var services = new ServiceCollection();
         var plugin = new PluginBase<FirstHostedService, SecondHostedService, ThirdHostedService>();
 
-        plugin.ConfigureHost(new object(), services);
+        plugin.ConfigureHost(new(), services);
 
-        await Assert.That(services.Any(IsFirstHostedServiceRegistration)).IsTrue();
-        await Assert.That(services.Any(IsSecondHostedServiceRegistration)).IsTrue();
-        await Assert.That(services.Any(IsThirdHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsFirstHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsSecondHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsThirdHostedServiceRegistration)).IsTrue();
     }
 
     /// <summary>Returns a value indicating whether the descriptor registers the first hosted service.</summary>
@@ -77,8 +77,8 @@ public class PluginBaseTests
     /// <returns>True when the descriptor registers the requested hosted service type.</returns>
     private static bool IsHostedServiceRegistration<T>(ServiceDescriptor serviceDescriptor)
         where T : class, IHostedService =>
-        serviceDescriptor.ServiceType == typeof(IHostedService) &&
-        serviceDescriptor.ImplementationType == typeof(T);
+        serviceDescriptor.ServiceType == typeof(IHostedService)
+        && serviceDescriptor.ImplementationType == typeof(T);
 
     /// <summary>First hosted service used for registration tests.</summary>
     public sealed class FirstHostedService : TestHostedService;
@@ -90,7 +90,7 @@ public class PluginBaseTests
     public sealed class ThirdHostedService : TestHostedService;
 
     /// <summary>Base hosted service used for registration tests.</summary>
-    public abstract class TestHostedService : IHostedService
+    public class TestHostedService : IHostedService
     {
         /// <inheritdoc />
         public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/tests/Extensions.Hosting.Tests/PluginBuilderExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/PluginBuilderExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -10,6 +10,9 @@ namespace Extensions.Hosting.Tests;
 /// <summary>Contains unit tests for the PluginBuilderExtensions class.</summary>
 public class PluginBuilderExtensionsTests
 {
+    /// <summary>The expected number of registered directories.</summary>
+    private const int ExpectedDirectoryCount = 2;
+
     /// <summary>Verifies that AddScanDirectories throws when directories is null.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -174,10 +177,7 @@ public class PluginBuilderExtensionsTests
     [Test]
     public async Task RequirePlugins_WithFalse_SetsFailIfNoPluginsFalse()
     {
-        var builder = new TestPluginBuilder
-        {
-            FailIfNoPlugins = true
-        };
+        var builder = new TestPluginBuilder { FailIfNoPlugins = true };
 
         builder.RequirePlugins(false);
         await Assert.That(builder.FailIfNoPlugins).IsFalse();
@@ -194,7 +194,7 @@ public class PluginBuilderExtensionsTests
 
         builder.AddScanDirectories(dir1, dir2);
 
-        await Assert.That(builder.PluginDirectories.Count).IsEqualTo(2);
-        await Assert.That(builder.FrameworkDirectories.Count).IsEqualTo(2);
+        await Assert.That(builder.PluginDirectories.Count).IsEqualTo(ExpectedDirectoryCount);
+        await Assert.That(builder.FrameworkDirectories.Count).IsEqualTo(ExpectedDirectoryCount);
     }
 }

--- a/src/tests/Extensions.Hosting.Tests/PluginOrderAttributeTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/PluginOrderAttributeTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveMarbles.Extensions.Hosting.Plugins;
@@ -9,6 +9,15 @@ namespace Extensions.Hosting.Tests;
 /// <summary>Contains unit tests for the PluginOrderAttribute class.</summary>
 public class PluginOrderAttributeTests
 {
+    /// <summary>A custom positive plugin order.</summary>
+    private const int CustomOrder = 42;
+
+    /// <summary>A custom negative plugin order.</summary>
+    private const int NegativeOrder = -10;
+
+    /// <summary>The order applied to the decorated test plugin.</summary>
+    private const int OrderedPluginOrder = 100;
+
     /// <summary>Verifies that the default constructor sets Order to 0.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -23,8 +32,8 @@ public class PluginOrderAttributeTests
     [Test]
     public async Task IntConstructor_SetsOrderCorrectly()
     {
-        var attribute = new PluginOrderAttribute(42);
-        await Assert.That(attribute.Order).IsEqualTo(42);
+        var attribute = new PluginOrderAttribute(CustomOrder);
+        await Assert.That(attribute.Order).IsEqualTo(CustomOrder);
     }
 
     /// <summary>Verifies that the int constructor handles negative values.</summary>
@@ -32,8 +41,8 @@ public class PluginOrderAttributeTests
     [Test]
     public async Task IntConstructor_WithNegativeValue_SetsOrderCorrectly()
     {
-        var attribute = new PluginOrderAttribute(-10);
-        await Assert.That(attribute.Order).IsEqualTo(-10);
+        var attribute = new PluginOrderAttribute(NegativeOrder);
+        await Assert.That(attribute.Order).IsEqualTo(NegativeOrder);
     }
 
     /// <summary>Verifies that the enum constructor converts the enum to its int value.</summary>
@@ -53,6 +62,6 @@ public class PluginOrderAttributeTests
         var type = typeof(OrderedTestPlugin);
         var attribute = (PluginOrderAttribute?)System.Attribute.GetCustomAttribute(type, typeof(PluginOrderAttribute));
         await Assert.That(attribute).IsNotNull();
-        await Assert.That(attribute!.Order).IsEqualTo(100);
+        await Assert.That(attribute!.Order).IsEqualTo(OrderedPluginOrder);
     }
 }

--- a/src/tests/Extensions.Hosting.Tests/PluginScannerTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/PluginScannerTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -38,7 +38,7 @@ public class PluginScannerTests
         var assembly = typeof(string).Assembly;
         var plugins = PluginScanner.ByNamingConvention(assembly);
         await Assert.That(plugins).IsNotNull();
-        await Assert.That(plugins.Any()).IsFalse();
+        await Assert.That(TestEnumerable.ContainsAny(plugins)).IsFalse();
     }
 
     /// <summary>Verifies that the plugin scanner discovers a plugin by naming convention.</summary>
@@ -46,9 +46,9 @@ public class PluginScannerTests
     [Test]
     public async Task ByNamingConvention_FindsConventionalPlugin()
     {
-        var plugins = PluginScanner.ByNamingConvention(typeof(Plugin).Assembly).ToList();
+        var plugins = TestEnumerable.Materialize(PluginScanner.ByNamingConvention(typeof(Plugin).Assembly));
 
-        await Assert.That(plugins.Any(plugin => plugin is Plugin)).IsTrue();
+        await Assert.That(plugins.Exists(static plugin => plugin is Plugin)).IsTrue();
     }
 
     /// <summary>Verifies that ScanForPluginInstances returns a non-null collection for a valid assembly.</summary>
@@ -67,9 +67,9 @@ public class PluginScannerTests
     public async Task ScanForPluginInstances_FindsTestPlugin()
     {
         var assembly = typeof(TestPlugin).Assembly;
-        var plugins = PluginScanner.ScanForPluginInstances(assembly).ToList();
+        var plugins = TestEnumerable.Materialize(PluginScanner.ScanForPluginInstances(assembly));
         await Assert.That(plugins.Count).IsGreaterThanOrEqualTo(1);
-        await Assert.That(plugins.Any(p => p is TestPlugin)).IsTrue();
+        await Assert.That(plugins.Exists(static p => p is TestPlugin)).IsTrue();
     }
 
     /// <summary>Verifies that ScanForPluginInstances does not include abstract plugin classes.</summary>
@@ -78,8 +78,8 @@ public class PluginScannerTests
     public async Task ScanForPluginInstances_DoesNotIncludeAbstractPlugins()
     {
         var assembly = typeof(AbstractTestPlugin).Assembly;
-        var plugins = PluginScanner.ScanForPluginInstances(assembly).ToList();
-        await Assert.That(plugins.Any(p => p.GetType() == typeof(AbstractTestPlugin))).IsFalse();
+        var plugins = TestEnumerable.Materialize(PluginScanner.ScanForPluginInstances(assembly));
+        await Assert.That(plugins.Exists(static p => p.GetType() == typeof(AbstractTestPlugin))).IsFalse();
     }
 
     /// <summary>Verifies that the test plugin can be configured via ConfigureHost.</summary>
@@ -93,7 +93,7 @@ public class PluginScannerTests
         Exception? exception = null;
         try
         {
-            plugin.ConfigureHost(new object(), serviceCollection);
+            plugin.ConfigureHost(new(), serviceCollection);
         }
         catch (Exception ex)
         {

--- a/src/tests/Extensions.Hosting.Tests/ReactiveAssemblyLoadingTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactiveAssemblyLoadingTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -13,6 +13,12 @@ namespace Extensions.Hosting.Tests;
 /// <summary>Contains tests for reactive shim plugin assembly loading helper types.</summary>
 public class ReactiveAssemblyLoadingTests
 {
+    /// <summary>The native library file name used by resolver tests.</summary>
+    private const string NativeLibraryFileName = "native.dll";
+
+    /// <summary>The native library name used by resolver tests.</summary>
+    private const string NativeLibraryName = "native";
+
     /// <summary>Verifies that the dependency resolver resolves existing managed assembly paths.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -27,7 +33,7 @@ public class ReactiveAssemblyLoadingTests
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
             var resolver = new ReactiveAssemblyDependencyResolver(pluginPath);
 
-            var resolvedPath = resolver.ResolveAssemblyToPath(new AssemblyName("Dependency"));
+            var resolvedPath = resolver.ResolveAssemblyToPath(new("Dependency"));
 
             await Assert.That(resolvedPath).IsEqualTo(dependencyPath);
         }
@@ -49,7 +55,7 @@ public class ReactiveAssemblyLoadingTests
             await File.WriteAllTextAsync(pluginPath, string.Empty);
             var resolver = new ReactiveAssemblyDependencyResolver(pluginPath);
 
-            var resolvedPath = resolver.ResolveAssemblyToPath(new AssemblyName("Missing.Dependency"));
+            var resolvedPath = resolver.ResolveAssemblyToPath(new("Missing.Dependency"));
 
             await Assert.That(resolvedPath).IsNull();
         }
@@ -81,12 +87,12 @@ public class ReactiveAssemblyLoadingTests
         try
         {
             var pluginPath = Path.Combine(tempDirectory, $"{nameof(Plugin)}.dll");
-            var dependencyPath = Path.Combine(tempDirectory, "native.dll");
+            var dependencyPath = Path.Combine(tempDirectory, NativeLibraryFileName);
             await File.WriteAllTextAsync(pluginPath, string.Empty);
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
             var resolver = new ReactiveAssemblyDependencyResolver(pluginPath);
 
-            var resolvedPath = resolver.ResolveUnmanagedDllToPath("native");
+            var resolvedPath = resolver.ResolveUnmanagedDllToPath(NativeLibraryName);
 
             await Assert.That(resolvedPath).IsEqualTo(dependencyPath);
         }
@@ -140,7 +146,7 @@ public class ReactiveAssemblyLoadingTests
         var context = ReactiveAssemblyLoadContext.Default;
 
         await Assert.That(context.Name).IsEqualTo("default");
-        await Assert.That(ReactiveAssemblyLoadContext.Assemblies.Any()).IsTrue();
+        await Assert.That(TestEnumerable.ContainsAny(ReactiveAssemblyLoadContext.Assemblies)).IsTrue();
     }
 
     /// <summary>Verifies that loading from a null assembly name throws.</summary>
@@ -163,7 +169,7 @@ public class ReactiveAssemblyLoadingTests
     {
         var context = new ReactiveAssemblyLoadContext("test");
 
-        Assembly? assembly = context.LoadFromAssemblyName(new AssemblyName("Missing.Assembly"));
+        Assembly? assembly = context.LoadFromAssemblyName(new("Missing.Assembly"));
 
         await Assert.That(assembly).IsNull();
     }
@@ -200,8 +206,8 @@ public class ReactiveAssemblyLoadingTests
     {
         var context = new TestAssemblyLoadContext("test", typeof(ReactiveAssemblyLoadingTests).Assembly);
 
-        await Assert.That(TestAssemblyLoadContext.LoadNativeFromPath("native.dll")).IsEqualTo(IntPtr.Zero);
-        await Assert.That(context.LoadNativeByName("native")).IsEqualTo(IntPtr.Zero);
+        await Assert.That(TestAssemblyLoadContext.LoadNativeFromPath(NativeLibraryFileName)).IsEqualTo(IntPtr.Zero);
+        await Assert.That(context.LoadNativeByName(NativeLibraryName)).IsEqualTo(IntPtr.Zero);
     }
 
     /// <summary>Verifies that TryGetAssembly returns false when the context is null.</summary>
@@ -237,7 +243,7 @@ public class ReactiveAssemblyLoadingTests
     {
         var context = ReactiveAssemblyLoadContext.Default;
 
-        var result = context.TryGetAssembly(new AssemblyName("Missing.Plugin.Assembly"), out var assembly);
+        var result = context.TryGetAssembly(new("Missing.Plugin.Assembly"), out var assembly);
 
         await Assert.That(result).IsFalse();
         await Assert.That(assembly).IsNull();
@@ -257,7 +263,7 @@ public class ReactiveAssemblyLoadingTests
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
             var context = new PluginLoadContext(pluginPath, nameof(Plugin));
 
-            var resolvedPath = context.ResolveAssemblyPath(new AssemblyName("Dependency"));
+            var resolvedPath = context.ResolveAssemblyPath(new("Dependency"));
 
             await Assert.That(resolvedPath).IsEqualTo(dependencyPath);
         }
@@ -301,7 +307,7 @@ public class ReactiveAssemblyLoadingTests
     {
         var context = new PluginLoadContext(typeof(ReactiveAssemblyLoadingTests).Assembly.Location, nameof(Plugin));
 
-        Assembly? assembly = context.LoadFromAssemblyName(new AssemblyName("Missing.Plugin.Assembly"));
+        Assembly? assembly = context.LoadFromAssemblyName(new("Missing.Plugin.Assembly"));
 
         await Assert.That(assembly).IsNull();
     }
@@ -312,9 +318,8 @@ public class ReactiveAssemblyLoadingTests
     public async Task PluginLoadContext_LoadUnmanagedDll_WithMissingLibrary_ReturnsZero()
     {
         var context = new PluginLoadContext(typeof(ReactiveAssemblyLoadingTests).Assembly.Location, nameof(Plugin));
-        var method = typeof(PluginLoadContext).GetMethod("LoadUnmanagedDll", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        var result = (IntPtr)method!.Invoke(context, ["missing"])!;
+        var result = context.LoadUnmanagedLibrary("missing");
 
         await Assert.That(result).IsEqualTo(IntPtr.Zero);
     }
@@ -328,13 +333,12 @@ public class ReactiveAssemblyLoadingTests
         try
         {
             var pluginPath = Path.Combine(tempDirectory, $"{nameof(Plugin)}.dll");
-            var dependencyPath = Path.Combine(tempDirectory, "native.dll");
+            var dependencyPath = Path.Combine(tempDirectory, NativeLibraryFileName);
             await File.WriteAllTextAsync(pluginPath, string.Empty);
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
             var context = new PluginLoadContext(pluginPath, nameof(Plugin));
-            var method = typeof(PluginLoadContext).GetMethod("LoadUnmanagedDll", BindingFlags.Instance | BindingFlags.NonPublic);
 
-            var result = (IntPtr)method!.Invoke(context, ["native"])!;
+            var result = context.LoadUnmanagedLibrary(NativeLibraryName);
 
             await Assert.That(result).IsEqualTo(IntPtr.Zero);
         }
@@ -358,17 +362,26 @@ public class ReactiveAssemblyLoadingTests
     private static string GetUnloadedAssemblyPath()
     {
         var assemblyDirectory = Path.GetDirectoryName(typeof(ReactiveAssemblyLoadingTests).Assembly.Location)!;
-        var loadedAssemblyNames = AppDomain.CurrentDomain.GetAssemblies()
-            .Select(assembly => assembly.GetName().Name)
-            .Where(name => name is not null)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var loadedAssemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var loadedAssembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var loadedAssemblyName = loadedAssembly.GetName().Name;
+            if (loadedAssemblyName is not null)
+            {
+                _ = loadedAssemblyNames.Add(loadedAssemblyName);
+            }
+        }
 
-        foreach (var assemblyPath in Directory.EnumerateFiles(assemblyDirectory, "*.dll").OrderBy(Path.GetFileName))
+        var assemblyPaths = new List<string>(Directory.EnumerateFiles(assemblyDirectory, "*.dll"));
+        assemblyPaths.Sort(
+            static (left, right) =>
+                StringComparer.Ordinal.Compare(Path.GetFileName(left), Path.GetFileName(right)));
+        foreach (var assemblyPath in assemblyPaths)
         {
             var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-            if (!loadedAssemblyNames.Contains(assemblyName) &&
-                !assemblyName.StartsWith("Extensions.Hosting", StringComparison.OrdinalIgnoreCase) &&
-                IsManagedAssembly(assemblyPath))
+            if (!loadedAssemblyNames.Contains(assemblyName)
+                && !assemblyName.StartsWith("Extensions.Hosting", StringComparison.OrdinalIgnoreCase)
+                && IsManagedAssembly(assemblyPath))
             {
                 return assemblyPath;
             }

--- a/src/tests/Extensions.Hosting.Tests/ReactiveHostedServiceBaseTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactiveHostedServiceBaseTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
@@ -11,17 +11,23 @@ namespace Extensions.Hosting.Tests;
 /// <summary>Contains unit tests for the reactive shim hosted service base lifecycle implementation.</summary>
 public class ReactiveHostedServiceBaseTests
 {
+    /// <summary>The lifecycle callback timeout, in seconds.</summary>
+    private const int LifecycleTimeoutSeconds = 5;
+
+    /// <summary>The delay used to allow shutdown callbacks to propagate, in milliseconds.</summary>
+    private const int ShutdownPropagationDelayMilliseconds = 50;
+
     /// <summary>Verifies that lifetime callbacks invoke the overridable lifecycle methods.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
     public async Task LifetimeCallbacks_InvokeLifecycleMethods()
     {
         using var lifetime = new TestHostApplicationLifetime();
-        var service = new TestHostedService(lifetime);
+        using var service = new TestHostedService(lifetime);
 
         await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
         lifetime.TriggerStarted();
-        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(LifecycleTimeoutSeconds)).ConfigureAwait(false);
 
         await Assert.That(service.StartedCount).IsEqualTo(1);
         await Assert.That(service.CleanupDisposable).IsNotNull();
@@ -46,7 +52,7 @@ public class ReactiveHostedServiceBaseTests
 
         await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
         lifetime.TriggerStarted();
-        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(LifecycleTimeoutSeconds)).ConfigureAwait(false);
 
         service.Dispose();
         service.Dispose();
@@ -62,7 +68,7 @@ public class ReactiveHostedServiceBaseTests
     public async Task StopAsync_ReturnsCompletedTask()
     {
         using var lifetime = new TestHostApplicationLifetime();
-        var service = new DefaultHostedService(lifetime);
+        using var service = new DefaultHostedService(lifetime);
 
         var stopTask = service.StopAsync(CancellationToken.None);
 
@@ -88,20 +94,19 @@ public class ReactiveHostedServiceBaseTests
     public async Task LifetimeStarted_WhenOnStartedThrows_DoesNotThrowFromCallback()
     {
         using var lifetime = new TestHostApplicationLifetime();
-        var service = new ThrowingStartedHostedService(lifetime);
+        using var service = new ThrowingStartedHostedService(lifetime);
 
         await service.StartAsync(CancellationToken.None).ConfigureAwait(false);
         lifetime.TriggerStarted();
-        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-        await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
+        await service.Started.Task.WaitAsync(TimeSpan.FromSeconds(LifecycleTimeoutSeconds)).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(ShutdownPropagationDelayMilliseconds)).ConfigureAwait(false);
 
         await Assert.That(service.StartedCount).IsEqualTo(1);
     }
 
     /// <summary>Test hosted service used to observe lifecycle callback execution.</summary>
     /// <param name="lifetime">The test lifetime source.</param>
-    private sealed class TestHostedService(IHostApplicationLifetime lifetime)
-        : HostedServiceBase<TestHostedService>(NullLogger<TestHostedService>.Instance, lifetime)
+    private sealed class TestHostedService(IHostApplicationLifetime lifetime) : HostedServiceBase<TestHostedService>(NullLogger<TestHostedService>.Instance, lifetime)
     {
         /// <summary>Gets the started signal.</summary>
         public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -145,13 +150,11 @@ public class ReactiveHostedServiceBaseTests
 
     /// <summary>Hosted service that uses the base lifecycle implementations.</summary>
     /// <param name="lifetime">The test lifetime source.</param>
-    private sealed class DefaultHostedService(IHostApplicationLifetime lifetime)
-        : HostedServiceBase<DefaultHostedService>(NullLogger<DefaultHostedService>.Instance, lifetime);
+    private sealed class DefaultHostedService(IHostApplicationLifetime lifetime) : HostedServiceBase<DefaultHostedService>(NullLogger<DefaultHostedService>.Instance, lifetime);
 
     /// <summary>Hosted service that throws from OnStarted.</summary>
     /// <param name="lifetime">The test lifetime source.</param>
-    private sealed class ThrowingStartedHostedService(IHostApplicationLifetime lifetime)
-        : HostedServiceBase<ThrowingStartedHostedService>(NullLogger<ThrowingStartedHostedService>.Instance, lifetime)
+    private sealed class ThrowingStartedHostedService(IHostApplicationLifetime lifetime) : HostedServiceBase<ThrowingStartedHostedService>(NullLogger<ThrowingStartedHostedService>.Instance, lifetime)
     {
         /// <summary>Gets the started signal.</summary>
         public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginBaseTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginBaseTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -19,9 +19,9 @@ public class ReactivePluginBaseTests
         var services = new ServiceCollection();
         var plugin = new PluginBase<FirstReactiveHostedService>();
 
-        plugin.ConfigureHost(new object(), services);
+        plugin.ConfigureHost(new(), services);
 
-        await Assert.That(services.Any(IsFirstHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsFirstHostedServiceRegistration)).IsTrue();
     }
 
     /// <summary>Verifies that PluginBase with two hosted services registers both services.</summary>
@@ -32,10 +32,10 @@ public class ReactivePluginBaseTests
         var services = new ServiceCollection();
         var plugin = new PluginBase<FirstReactiveHostedService, SecondReactiveHostedService>();
 
-        plugin.ConfigureHost(new object(), services);
+        plugin.ConfigureHost(new(), services);
 
-        await Assert.That(services.Any(IsFirstHostedServiceRegistration)).IsTrue();
-        await Assert.That(services.Any(IsSecondHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsFirstHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsSecondHostedServiceRegistration)).IsTrue();
     }
 
     /// <summary>Verifies that PluginBase with three hosted services registers all services.</summary>
@@ -46,11 +46,11 @@ public class ReactivePluginBaseTests
         var services = new ServiceCollection();
         var plugin = new PluginBase<FirstReactiveHostedService, SecondReactiveHostedService, ThirdReactiveHostedService>();
 
-        plugin.ConfigureHost(new object(), services);
+        plugin.ConfigureHost(new(), services);
 
-        await Assert.That(services.Any(IsFirstHostedServiceRegistration)).IsTrue();
-        await Assert.That(services.Any(IsSecondHostedServiceRegistration)).IsTrue();
-        await Assert.That(services.Any(IsThirdHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsFirstHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsSecondHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsThirdHostedServiceRegistration)).IsTrue();
     }
 
     /// <summary>Returns a value indicating whether the descriptor registers the first hosted service.</summary>
@@ -77,8 +77,8 @@ public class ReactivePluginBaseTests
     /// <returns>True when the descriptor registers the requested hosted service type.</returns>
     private static bool IsHostedServiceRegistration<T>(ServiceDescriptor serviceDescriptor)
         where T : class, IHostedService =>
-        serviceDescriptor.ServiceType == typeof(IHostedService) &&
-        serviceDescriptor.ImplementationType == typeof(T);
+        serviceDescriptor.ServiceType == typeof(IHostedService)
+        && serviceDescriptor.ImplementationType == typeof(T);
 
     /// <summary>First hosted service used for reactive registration tests.</summary>
     public sealed class FirstReactiveHostedService : ReactiveHostedService;
@@ -90,7 +90,7 @@ public class ReactivePluginBaseTests
     public sealed class ThirdReactiveHostedService : ReactiveHostedService;
 
     /// <summary>Base hosted service used for reactive registration tests.</summary>
-    public abstract class ReactiveHostedService : IHostedService
+    public class ReactiveHostedService : IHostedService
     {
         /// <inheritdoc />
         public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginBuilderExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginBuilderExtensionsTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -10,6 +10,9 @@ namespace Extensions.Hosting.Tests;
 /// <summary>Contains unit tests for the reactive shim PluginBuilderExtensions class.</summary>
 public class ReactivePluginBuilderExtensionsTests
 {
+    /// <summary>The expected number of registered directories.</summary>
+    private const int ExpectedDirectoryCount = 2;
+
     /// <summary>Verifies that AddScanDirectories throws when directories is null.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -45,8 +48,8 @@ public class ReactivePluginBuilderExtensionsTests
 
         builder.AddScanDirectories(dir1, dir2);
 
-        await Assert.That(builder.PluginDirectories.Count).IsEqualTo(2);
-        await Assert.That(builder.FrameworkDirectories.Count).IsEqualTo(2);
+        await Assert.That(builder.PluginDirectories.Count).IsEqualTo(ExpectedDirectoryCount);
+        await Assert.That(builder.FrameworkDirectories.Count).IsEqualTo(ExpectedDirectoryCount);
     }
 
     /// <summary>Verifies that ExcludeFrameworks throws when frameworkGlobs is null.</summary>
@@ -193,10 +196,7 @@ public class ReactivePluginBuilderExtensionsTests
     [Test]
     public async Task RequirePlugins_WithFalse_SetsFailIfNoPluginsFalse()
     {
-        var builder = new ReactiveTestPluginBuilder
-        {
-            FailIfNoPlugins = true
-        };
+        var builder = new ReactiveTestPluginBuilder { FailIfNoPlugins = true };
 
         builder.RequirePlugins(false);
         await Assert.That(builder.FailIfNoPlugins).IsFalse();

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginOrderAttributeTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginOrderAttributeTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
@@ -9,6 +9,15 @@ namespace Extensions.Hosting.Tests;
 /// <summary>Contains unit tests for the reactive shim PluginOrderAttribute class.</summary>
 public class ReactivePluginOrderAttributeTests
 {
+    /// <summary>A custom positive plugin order.</summary>
+    private const int CustomOrder = 42;
+
+    /// <summary>A custom negative plugin order.</summary>
+    private const int NegativeOrder = -10;
+
+    /// <summary>The order applied to the decorated test plugin.</summary>
+    private const int OrderedPluginOrder = 100;
+
     /// <summary>Verifies that the default constructor sets Order to 0.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -23,8 +32,8 @@ public class ReactivePluginOrderAttributeTests
     [Test]
     public async Task IntConstructor_SetsOrderCorrectly()
     {
-        var attribute = new PluginOrderAttribute(42);
-        await Assert.That(attribute.Order).IsEqualTo(42);
+        var attribute = new PluginOrderAttribute(CustomOrder);
+        await Assert.That(attribute.Order).IsEqualTo(CustomOrder);
     }
 
     /// <summary>Verifies that the int constructor handles negative values.</summary>
@@ -32,8 +41,8 @@ public class ReactivePluginOrderAttributeTests
     [Test]
     public async Task IntConstructor_WithNegativeValue_SetsOrderCorrectly()
     {
-        var attribute = new PluginOrderAttribute(-10);
-        await Assert.That(attribute.Order).IsEqualTo(-10);
+        var attribute = new PluginOrderAttribute(NegativeOrder);
+        await Assert.That(attribute.Order).IsEqualTo(NegativeOrder);
     }
 
     /// <summary>Verifies that the enum constructor converts the enum to its int value.</summary>
@@ -54,10 +63,10 @@ public class ReactivePluginOrderAttributeTests
         var attribute = (PluginOrderAttribute?)Attribute.GetCustomAttribute(type, typeof(PluginOrderAttribute));
 
         await Assert.That(attribute).IsNotNull();
-        await Assert.That(attribute!.Order).IsEqualTo(100);
+        await Assert.That(attribute!.Order).IsEqualTo(OrderedPluginOrder);
     }
 
     /// <summary>A reactive shim plugin with a custom order attribute for testing plugin ordering.</summary>
-    [PluginOrder(100)]
+    [PluginOrder(OrderedPluginOrder)]
     public class ReactiveOrderedTestPlugin : ReactivePluginScannerTests.ReactiveScannerTestPlugin;
 }

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginScannerTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginScannerTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -36,7 +36,7 @@ public class ReactivePluginScannerTests
         var plugins = PluginScanner.ByNamingConvention(typeof(string).Assembly);
 
         await Assert.That(plugins).IsNotNull();
-        await Assert.That(plugins.Any()).IsFalse();
+        await Assert.That(TestEnumerable.ContainsAny(plugins)).IsFalse();
     }
 
     /// <summary>Verifies that the reactive shim plugin scanner discovers a plugin by naming convention.</summary>
@@ -44,9 +44,9 @@ public class ReactivePluginScannerTests
     [Test]
     public async Task ByNamingConvention_FindsConventionalPlugin()
     {
-        var plugins = PluginScanner.ByNamingConvention(typeof(Plugin).Assembly).ToList();
+        var plugins = TestEnumerable.Materialize(PluginScanner.ByNamingConvention(typeof(Plugin).Assembly));
 
-        await Assert.That(plugins.Any(plugin => plugin is Plugin)).IsTrue();
+        await Assert.That(plugins.Exists(static plugin => plugin is Plugin)).IsTrue();
     }
 
     /// <summary>Verifies that ScanForPluginInstances returns a non-null collection for a valid assembly.</summary>
@@ -64,10 +64,11 @@ public class ReactivePluginScannerTests
     [Test]
     public async Task ScanForPluginInstances_FindsReactiveTestPlugin()
     {
-        var plugins = PluginScanner.ScanForPluginInstances(typeof(ReactiveScannerTestPlugin).Assembly).ToList();
+        var plugins = TestEnumerable.Materialize(
+            PluginScanner.ScanForPluginInstances(typeof(ReactiveScannerTestPlugin).Assembly));
 
         await Assert.That(plugins.Count).IsGreaterThanOrEqualTo(1);
-        await Assert.That(plugins.Any(plugin => plugin is ReactiveScannerTestPlugin)).IsTrue();
+        await Assert.That(plugins.Exists(static plugin => plugin is ReactiveScannerTestPlugin)).IsTrue();
     }
 
     /// <summary>Verifies that ScanForPluginInstances does not include abstract reactive plugin classes.</summary>
@@ -75,9 +76,10 @@ public class ReactivePluginScannerTests
     [Test]
     public async Task ScanForPluginInstances_DoesNotIncludeAbstractPlugins()
     {
-        var plugins = PluginScanner.ScanForPluginInstances(typeof(ReactiveAbstractTestPlugin).Assembly).ToList();
+        var plugins = TestEnumerable.Materialize(
+            PluginScanner.ScanForPluginInstances(typeof(ReactiveAbstractTestPlugin).Assembly));
 
-        await Assert.That(plugins.Any(plugin => plugin.GetType() == typeof(ReactiveAbstractTestPlugin))).IsFalse();
+        await Assert.That(plugins.Exists(static plugin => plugin.GetType() == typeof(ReactiveAbstractTestPlugin))).IsFalse();
     }
 
     /// <summary>Verifies that the reactive test plugin can be configured via ConfigureHost.</summary>
@@ -88,7 +90,7 @@ public class ReactivePluginScannerTests
         var plugin = new ReactiveScannerTestPlugin();
         var services = new ServiceCollection();
 
-        plugin.ConfigureHost(new object(), services);
+        plugin.ConfigureHost(new(), services);
 
         await Assert.That(plugin.WasConfigured).IsTrue();
     }
@@ -106,7 +108,19 @@ public class ReactivePluginScannerTests
     /// <summary>An abstract reactive shim plugin used to test that abstract classes are not discovered.</summary>
     public abstract class ReactiveAbstractTestPlugin : IPlugin
     {
+        /// <summary>Gets a value indicating whether the plugin received host configuration.</summary>
+        public bool WasConfigured { get; private set; }
+
         /// <inheritdoc />
-        public abstract void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection);
+        public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
+        {
+            WasConfigured = true;
+            ConfigureHostCore(hostBuilderContext, serviceCollection);
+        }
+
+        /// <summary>Configures services for a concrete reactive test plugin.</summary>
+        /// <param name="hostBuilderContext">The host builder context.</param>
+        /// <param name="serviceCollection">The service collection.</param>
+        protected abstract void ConfigureHostCore(object hostBuilderContext, IServiceCollection serviceCollection);
     }
 }

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginShimTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginShimTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -12,6 +12,9 @@ namespace Extensions.Hosting.Tests;
 /// <summary>Contains tests for the reactive plugin shim surface.</summary>
 public class ReactivePluginShimTests
 {
+    /// <summary>The expected number of configured plugins.</summary>
+    private const int ExpectedPluginCount = 2;
+
     /// <summary>Verifies that the reactive shim PluginBase registers hosted services.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -20,9 +23,9 @@ public class ReactivePluginShimTests
         var services = new ServiceCollection();
         var plugin = new PluginBase<ReactiveHostedService>();
 
-        plugin.ConfigureHost(new object(), services);
+        plugin.ConfigureHost(new(), services);
 
-        await Assert.That(services.Any(IsReactiveHostedServiceRegistration)).IsTrue();
+        await Assert.That(TestEnumerable.Contains(services, IsReactiveHostedServiceRegistration)).IsTrue();
     }
 
     /// <summary>Verifies that the reactive shim plugin scanner discovers reactive plugin implementations.</summary>
@@ -30,9 +33,10 @@ public class ReactivePluginShimTests
     [Test]
     public async Task PluginScanner_WithReactiveNamespace_FindsReactivePlugin()
     {
-        var plugins = PluginScanner.ScanForPluginInstances(typeof(ReactiveDiscoveredPlugin).Assembly).ToList();
+        var plugins = TestEnumerable.Materialize(
+            PluginScanner.ScanForPluginInstances(typeof(ReactiveDiscoveredPlugin).Assembly));
 
-        await Assert.That(plugins.Any(plugin => plugin is ReactiveDiscoveredPlugin)).IsTrue();
+        await Assert.That(plugins.Exists(static plugin => plugin is ReactiveDiscoveredPlugin)).IsTrue();
     }
 
     /// <summary>Verifies that the reactive shim host builder extension configures discovered plugins in order.</summary>
@@ -45,7 +49,7 @@ public class ReactivePluginShimTests
 
         _ = hostBuilder.ConfigurePlugins(builder =>
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
             AddCurrentAssemblyAsFramework(builder);
             builder.AssemblyScanFunc = _ =>
             [
@@ -57,7 +61,7 @@ public class ReactivePluginShimTests
 
         using var host = hostBuilder.Build();
 
-        await Assert.That(configuredPlugins.Count).IsEqualTo(2);
+        await Assert.That(configuredPlugins.Count).IsEqualTo(ExpectedPluginCount);
         await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierReactiveRecordingPlugin.Name);
         await Assert.That(configuredPlugins[1]).IsEqualTo(LaterReactiveRecordingPlugin.Name);
     }
@@ -68,7 +72,7 @@ public class ReactivePluginShimTests
     public async Task ConfigurePlugins_IHostBuilder_WithNullHostBuilder_ThrowsArgumentNullException()
     {
         IHostBuilder? hostBuilder = null;
-        var act = () => hostBuilder!.ConfigurePlugins(_ => { });
+        var act = () => hostBuilder!.ConfigurePlugins(static _ => { });
         await Assert.That(act).Throws<ArgumentNullException>();
     }
 
@@ -78,7 +82,7 @@ public class ReactivePluginShimTests
     public async Task ConfigurePlugins_IHostApplicationBuilder_WithNullHostBuilder_ThrowsArgumentNullException()
     {
         IHostApplicationBuilder? hostBuilder = null;
-        var act = () => hostBuilder!.ConfigurePlugins(_ => { });
+        var act = () => hostBuilder!.ConfigurePlugins(static _ => { });
         await Assert.That(act).Throws<ArgumentNullException>();
     }
 
@@ -92,7 +96,7 @@ public class ReactivePluginShimTests
 
         var result = hostBuilder.ConfigurePlugins(builder =>
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
             AddCurrentAssemblyAsFramework(builder);
             builder.AssemblyScanFunc = _ => [new EarlierReactiveRecordingPlugin(configuredPlugins)];
         });
@@ -148,7 +152,7 @@ public class ReactivePluginShimTests
 
         _ = hostBuilder.ConfigurePlugins(builder =>
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
             builder.UseContentRoot = true;
             _ = builder.FrameworkMatcher.AddInclude(Path.GetFileName(assemblyPath));
             builder.AssemblyScanFunc = _ => [new EarlierReactiveRecordingPlugin(configuredPlugins)];
@@ -174,10 +178,10 @@ public class ReactivePluginShimTests
 
             _ = hostBuilder.ConfigurePlugins(builder =>
             {
-                ArgumentNullException.ThrowIfNull(builder);
+                _ = builder ?? throw new ArgumentNullException(nameof(builder));
                 builder.PluginDirectories.Add(tempDirectory);
                 _ = builder.PluginMatcher.AddInclude(Path.GetFileName(pluginPath));
-                builder.ValidatePlugin = _ => false;
+                builder.ValidatePlugin = static _ => false;
             });
 
             using var host = hostBuilder.Build();
@@ -199,7 +203,7 @@ public class ReactivePluginShimTests
 
         _ = hostBuilder.ConfigurePlugins(builder =>
         {
-            ArgumentNullException.ThrowIfNull(builder);
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
             builder.PluginDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
             _ = builder.PluginMatcher.AddInclude(Path.GetFileName(assemblyPath));
         });
@@ -222,7 +226,7 @@ public class ReactivePluginShimTests
 
             _ = hostBuilder.ConfigurePlugins(builder =>
             {
-                ArgumentNullException.ThrowIfNull(builder);
+                _ = builder ?? throw new ArgumentNullException(nameof(builder));
                 builder.FrameworkDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
                 _ = builder.FrameworkMatcher.AddInclude(Path.GetFileName(assemblyPath));
                 builder.AssemblyScanFunc = _ => [new EarlierReactiveRecordingPlugin(configuredPlugins)];
@@ -253,7 +257,7 @@ public class ReactivePluginShimTests
 
             _ = hostBuilder.ConfigurePlugins(builder =>
             {
-                ArgumentNullException.ThrowIfNull(builder);
+                _ = builder ?? throw new ArgumentNullException(nameof(builder));
                 builder.PluginDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
                 _ = builder.PluginMatcher.AddInclude(Path.GetFileName(assemblyPath));
                 builder.AssemblyScanFunc = _ => [new EarlierReactiveRecordingPlugin(configuredPlugins)];
@@ -276,7 +280,9 @@ public class ReactivePluginShimTests
     public async Task ConfigurePlugins_IHostBuilder_WithRequiredPluginsAndNoPlugins_ThrowsInvalidOperationException()
     {
         var hostBuilder = Host.CreateDefaultBuilder();
-        _ = hostBuilder.ConfigurePlugins(builder => builder.RequirePlugins());
+        _ = hostBuilder.ConfigurePlugins(
+            static builder => (builder ?? throw new InvalidOperationException("Plugin builder was not created."))
+                .RequirePlugins());
 
         var act = () => hostBuilder.Build();
         await Assert.That(act).Throws<InvalidOperationException>();
@@ -314,8 +320,8 @@ public class ReactivePluginShimTests
     /// <param name="serviceDescriptor">The service descriptor to inspect.</param>
     /// <returns>True when the descriptor registers the reactive hosted service.</returns>
     private static bool IsReactiveHostedServiceRegistration(ServiceDescriptor serviceDescriptor) =>
-        serviceDescriptor.ServiceType == typeof(IHostedService) &&
-        serviceDescriptor.ImplementationType == typeof(ReactiveHostedService);
+        serviceDescriptor.ServiceType == typeof(IHostedService)
+        && serviceDescriptor.ImplementationType == typeof(ReactiveHostedService);
 
     /// <summary>Hosted service used to verify reactive shim service registration.</summary>
     public sealed class ReactiveHostedService : IHostedService

--- a/src/tests/Extensions.Hosting.Tests/ReactiveTestPluginBuilder.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactiveTestPluginBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Reflection;
@@ -24,13 +24,13 @@ public class ReactiveTestPluginBuilder : IPluginBuilder
     public bool FailIfNoPlugins { get; set; }
 
     /// <inheritdoc />
-    public Matcher FrameworkMatcher { get; } = new Matcher();
+    public Matcher FrameworkMatcher { get; } = new();
 
     /// <inheritdoc />
-    public Matcher PluginMatcher { get; } = new Matcher();
+    public Matcher PluginMatcher { get; } = new();
 
     /// <inheritdoc />
-    public Func<string, bool> ValidatePlugin { get; set; } = _ => true;
+    public Func<string, bool> ValidatePlugin { get; set; } = static _ => true;
 
     /// <inheritdoc />
     public Func<Assembly, IEnumerable<IPlugin?>?> AssemblyScanFunc { get; set; } = PluginScanner.ScanForPluginInstances;

--- a/src/tests/Extensions.Hosting.Tests/ResourceMutexTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ResourceMutexTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,6 +13,12 @@ namespace Extensions.Hosting.Tests;
 /// ResourceMutex.</remarks>
 public class ResourceMutexTests
 {
+    /// <summary>The mutex operation timeout, in seconds.</summary>
+    private const int MutexOperationTimeoutSeconds = 5;
+
+    /// <summary>The prefix for process-local named mutexes.</summary>
+    private const string LocalMutexPrefix = @"Local\";
+
     /// <summary>Verifies that calling ResourceMutex.Create with a null mutex ID throws an ArgumentException.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -46,7 +52,7 @@ public class ResourceMutexTests
     public async Task Create_ValidMutexId_IsLocked()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-{Guid.NewGuid():N}";
 
         using var mutex = ResourceMutex.Create(logger, id);
         await Assert.That(mutex.IsLocked).IsTrue();
@@ -57,7 +63,7 @@ public class ResourceMutexTests
     [Test]
     public async Task Create_WithNullLogger_CreatesDefaultLogger()
     {
-        var id = "test-mutex-nulllogger-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-nulllogger-{Guid.NewGuid():N}";
 
         using var mutex = ResourceMutex.Create(null, id);
         await Assert.That(mutex).IsNotNull();
@@ -70,7 +76,7 @@ public class ResourceMutexTests
     public async Task Create_WithResourceName_Succeeds()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-resource-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-resource-{Guid.NewGuid():N}";
         const string resourceName = "TestResource";
 
         using var mutex = ResourceMutex.Create(logger, id, resourceName);
@@ -83,7 +89,7 @@ public class ResourceMutexTests
     public async Task Create_LocalMutex_Succeeds()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-local-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-local-{Guid.NewGuid():N}";
 
         using var mutex = ResourceMutex.Create(logger, id, global: false);
         await Assert.That(mutex.IsLocked).IsTrue();
@@ -95,7 +101,7 @@ public class ResourceMutexTests
     public async Task Create_SecondLocalMutexWithSameId_IsNotLocked()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-contention-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-contention-{Guid.NewGuid():N}";
 
         using var first = ResourceMutex.Create(logger, id);
         using var second = ResourceMutex.Create(logger, id);
@@ -110,8 +116,8 @@ public class ResourceMutexTests
     public async Task Create_WhenNamedMutexExistsButIsUnowned_ClaimsMutex()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-existing-" + Guid.NewGuid().ToString("N");
-        using var existing = new Mutex(initiallyOwned: false, @"Local\" + id);
+        var id = $"test-mutex-existing-{Guid.NewGuid():N}";
+        using var existing = new Mutex(initiallyOwned: false, LocalMutexPrefix + id);
 
         using var mutex = ResourceMutex.Create(logger, id);
 
@@ -124,7 +130,7 @@ public class ResourceMutexTests
     public async Task Create_WithInvalidMutexName_ReturnsUnlockedMutex()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-invalid-" + Guid.NewGuid().ToString("N") + @"\child";
+        var id = $"test-mutex-invalid-{Guid.NewGuid():N}\\child";
 
         using var mutex = ResourceMutex.Create(logger, id);
 
@@ -137,11 +143,11 @@ public class ResourceMutexTests
     public async Task Create_WhenNamedMutexIsAbandoned_RecoversMutex()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-abandoned-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-abandoned-{Guid.NewGuid():N}";
         var ready = new ManualResetEventSlim(initialState: false);
         var abandonThread = new Thread(() =>
         {
-            _ = new Mutex(initiallyOwned: true, @"Local\" + id);
+            _ = new Mutex(initiallyOwned: true, LocalMutexPrefix + id);
             ready.Set();
         });
 
@@ -167,11 +173,11 @@ public class ResourceMutexTests
 
         using var mutex = new ResourceMutex(
             NullLogger.Instance,
-            "test-mutex-unauthorized-" + Guid.NewGuid().ToString("N"),
+            $"test-mutex-unauthorized-{Guid.NewGuid():N}",
             resourceName: null,
             ThrowUnauthorized,
             static mutex => mutex.ReleaseMutex(),
-            TimeSpan.FromSeconds(5));
+            TimeSpan.FromSeconds(MutexOperationTimeoutSeconds));
 
         var locked = mutex.Lock();
 
@@ -185,7 +191,7 @@ public class ResourceMutexTests
     public async Task Create_GlobalMutex_Succeeds()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-global-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-global-{Guid.NewGuid():N}";
 
         using var mutex = ResourceMutex.Create(logger, id, global: true);
         await Assert.That(mutex.IsLocked).IsTrue();
@@ -197,7 +203,7 @@ public class ResourceMutexTests
     public async Task Dispose_DoesNotThrow()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-dispose-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-dispose-{Guid.NewGuid():N}";
 
         var mutex = ResourceMutex.Create(logger, id);
         Exception? exception = null;
@@ -219,7 +225,7 @@ public class ResourceMutexTests
     public async Task Dispose_MultipleTimes_DoesNotThrow()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-double-dispose-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-double-dispose-{Guid.NewGuid():N}";
 
         var mutex = ResourceMutex.Create(logger, id);
         mutex.Dispose();
@@ -247,7 +253,7 @@ public class ResourceMutexTests
     public async Task Dispose_FromDifferentThread_DoesNotThrow()
     {
         var logger = NullLogger.Instance;
-        var id = "test-mutex-cross-thread-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-cross-thread-{Guid.NewGuid():N}";
 
         var mutex = ResourceMutex.Create(logger, id);
         await Assert.That(mutex.IsLocked).IsTrue();
@@ -276,12 +282,12 @@ public class ResourceMutexTests
     [Test]
     public async Task Dispose_WhenOwnerThreadDoesNotExitWithinTimeout_DoesNotThrow()
     {
-        var id = "test-mutex-timeout-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-timeout-{Guid.NewGuid():N}";
         using var releaseStarted = new ManualResetEventSlim(initialState: false);
         using var releaseCanContinue = new ManualResetEventSlim(initialState: false);
         var mutex = new ResourceMutex(
             NullLogger.Instance,
-            @"Local\" + id,
+            LocalMutexPrefix + id,
             resourceName: null,
             CreateNamedMutex,
             static mutex => mutex.ReleaseMutex(),
@@ -324,14 +330,14 @@ public class ResourceMutexTests
             throw new InvalidOperationException("Release failure.");
         }
 
-        var id = "test-mutex-release-failure-" + Guid.NewGuid().ToString("N");
+        var id = $"test-mutex-release-failure-{Guid.NewGuid():N}";
         var mutex = new ResourceMutex(
             NullLogger.Instance,
-            @"Local\" + id,
+            LocalMutexPrefix + id,
             resourceName: null,
             CreateNamedMutex,
             ReleaseThenThrow,
-            TimeSpan.FromSeconds(5));
+            TimeSpan.FromSeconds(MutexOperationTimeoutSeconds));
 
         Exception? exception = null;
         try
@@ -352,8 +358,5 @@ public class ResourceMutexTests
     /// <summary>Creates a named mutex for ResourceMutex test seams.</summary>
     /// <param name="mutexId">The fully qualified mutex identifier.</param>
     /// <returns>The created mutex and a value indicating whether it was newly created.</returns>
-    private static (Mutex Mutex, bool CreatedNew) CreateNamedMutex(string mutexId)
-    {
-        return (new Mutex(true, mutexId, out var createdNew), createdNew);
-    }
+    private static (Mutex Mutex, bool CreatedNew) CreateNamedMutex(string mutexId) => (new Mutex(true, mutexId, out var createdNew), createdNew);
 }

--- a/src/tests/Extensions.Hosting.Tests/TestEnumerable.cs
+++ b/src/tests/Extensions.Hosting.Tests/TestEnumerable.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Extensions.Hosting.Tests;
+
+/// <summary>Provides allocation-conscious enumerable helpers for test assertions.</summary>
+internal static class TestEnumerable
+{
+    /// <summary>Determines whether a sequence contains at least one element.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to inspect.</param>
+    /// <returns>true when the sequence contains an element; otherwise, false.</returns>
+    internal static bool ContainsAny<T>(IEnumerable<T> source)
+    {
+        using var enumerator = source.GetEnumerator();
+        return enumerator.MoveNext();
+    }
+
+    /// <summary>Determines whether a sequence contains an element matching a predicate.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to inspect.</param>
+    /// <param name="predicate">The predicate used to identify a matching element.</param>
+    /// <returns>true when a matching element is found; otherwise, false.</returns>
+    internal static bool Contains<T>(IEnumerable<T> source, Func<T, bool> predicate)
+    {
+        foreach (var item in source)
+        {
+            if (predicate(item))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Materializes a sequence into a list through explicit iteration.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to materialize.</param>
+    /// <returns>A list containing the sequence elements.</returns>
+    internal static List<T> Materialize<T>(IEnumerable<T> source) =>
+        new(source);
+}

--- a/src/tests/Extensions.Hosting.Tests/TestMutexBuilder.cs
+++ b/src/tests/Extensions.Hosting.Tests/TestMutexBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;

--- a/src/tests/Extensions.Hosting.Tests/TestOrder.cs
+++ b/src/tests/Extensions.Hosting.Tests/TestOrder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace Extensions.Hosting.Tests;

--- a/src/tests/Extensions.Hosting.Tests/TestPlugin.cs
+++ b/src/tests/Extensions.Hosting.Tests/TestPlugin.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/tests/Extensions.Hosting.Tests/TestPluginBuilder.cs
+++ b/src/tests/Extensions.Hosting.Tests/TestPluginBuilder.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2026 ReactiveUI and Contributors. All rights reserved.
-// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Reflection;
@@ -24,13 +24,13 @@ public class TestPluginBuilder : IPluginBuilder
     public bool FailIfNoPlugins { get; set; }
 
     /// <inheritdoc />
-    public Matcher FrameworkMatcher { get; } = new Matcher();
+    public Matcher FrameworkMatcher { get; } = new();
 
     /// <inheritdoc />
-    public Matcher PluginMatcher { get; } = new Matcher();
+    public Matcher PluginMatcher { get; } = new();
 
     /// <inheritdoc />
-    public Func<string, bool> ValidatePlugin { get; set; } = _ => true;
+    public Func<string, bool> ValidatePlugin { get; set; } = static _ => true;
 
     /// <inheritdoc />
     public Func<Assembly, IEnumerable<IPlugin?>?> AssemblyScanFunc { get; set; } = PluginScanner.ScanForPluginInstances;

--- a/src/tests/Extensions.Hosting.WinForms.Tests/AutoClosingTestShell.cs
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/AutoClosingTestShell.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Forms;
+using ReactiveMarbles.Extensions.Hosting.WinForms;
+using FormsTimer = System.Windows.Forms.Timer;
+
+namespace Extensions.Hosting.WinForms.Tests;
+
+/// <summary>Provides a shell that closes after the Windows Forms message loop starts.</summary>
+public sealed class AutoClosingTestShell : Form, IWinFormsShell
+{
+    /// <summary>Stores the delay before the test shell closes.</summary>
+    private const int CloseDelayMilliseconds = 250;
+
+    /// <summary>Stores the timer that schedules the shell shutdown.</summary>
+    private readonly FormsTimer _closeTimer = new() { Interval = CloseDelayMilliseconds };
+
+    /// <summary>Initializes a new instance of the <see cref="AutoClosingTestShell"/> class.</summary>
+    public AutoClosingTestShell() => _closeTimer.Tick += OnCloseTimerTick;
+
+    /// <inheritdoc />
+    protected override void OnShown(EventArgs e)
+    {
+        base.OnShown(e);
+        _closeTimer.Start();
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _closeTimer.Stop();
+            _closeTimer.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <summary>Stops the delay timer and closes the shell.</summary>
+    /// <param name="sender">The timer that raised the event.</param>
+    /// <param name="e">The event data.</param>
+    private void OnCloseTimerTick(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+        _closeTimer.Stop();
+        Close();
+    }
+}

--- a/src/tests/Extensions.Hosting.WinForms.Tests/Extensions.Hosting.ReactiveUI.WinForms.Reactive.Tests.csproj
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/Extensions.Hosting.ReactiveUI.WinForms.Reactive.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <IsTestProject>true</IsTestProject>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.WinForms.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ReactiveUiWinFormsExtensionsTests.cs" Link="ReactiveUiWinFormsExtensionsTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.ReactiveUI.WinForms.Reactive\Extensions.Hosting.ReactiveUI.WinForms.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.WinForms.Tests/Extensions.Hosting.WinForms.Tests.csproj
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/Extensions.Hosting.WinForms.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.WinForms.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.WinForms\Extensions.Hosting.WinForms.csproj" />
+    <ProjectReference Include="..\..\Extensions.Hosting.ReactiveUI.WinForms\Extensions.Hosting.ReactiveUI.WinForms.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.WinForms.Tests/ReactiveUiWinFormsExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/ReactiveUiWinFormsExtensionsTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Hosting;
+#if REACTIVE_SHIM
+using ReactiveMarbles.Extensions.Hosting.Reactive.ReactiveUI;
+#else
+using ReactiveMarbles.Extensions.Hosting.ReactiveUI;
+#endif
+
+namespace Extensions.Hosting.WinForms.Tests;
+
+/// <summary>Verifies ReactiveUI and Microsoft dependency-injection integration for Windows Forms hosts.</summary>
+[NotInParallel]
+public sealed class ReactiveUiWinFormsExtensionsTests
+{
+    /// <summary>Verifies that application builders reject a null receiver.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_ApplicationBuilderNull_ThrowsArgumentNullException()
+    {
+        IHostApplicationBuilder? hostBuilder = null;
+
+        await Assert.That(() => hostBuilder!.ConfigureSplatForMicrosoftDependencyResolver()).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that application builders can initialize the Microsoft dependency resolver integration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_ApplicationBuilder_ReturnsConfiguredBuilder()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+
+        var configuredBuilder = hostBuilder.ConfigureSplatForMicrosoftDependencyResolver();
+
+        using var host = hostBuilder.Build();
+        await Assert.That(configuredBuilder).IsSameReferenceAs(hostBuilder);
+        await Assert.That(host.Services).IsNotNull();
+    }
+
+    /// <summary>Verifies that legacy builders configure the dependency resolver integration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureSplatForMicrosoftDependencyResolver_HostBuilder_ReturnsConfiguredBuilder()
+    {
+        var hostBuilder = Host.CreateDefaultBuilder();
+
+        var configuredBuilder = hostBuilder.ConfigureSplatForMicrosoftDependencyResolver();
+
+        using var host = hostBuilder.Build();
+        await Assert.That(configuredBuilder).IsSameReferenceAs(hostBuilder);
+        await Assert.That(host.Services).IsNotNull();
+    }
+
+    /// <summary>Verifies that mapping the Splat locator invokes the supplied container callback.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MapSplatLocator_Host_MapsServicesAndInvokesFactory()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+        _ = hostBuilder.ConfigureSplatForMicrosoftDependencyResolver();
+        using var host = hostBuilder.Build();
+        IServiceProvider? mappedProvider = null;
+
+        var mappedHost = host!.MapSplatLocator(provider => mappedProvider = provider);
+
+        await Assert.That(mappedHost).IsSameReferenceAs(host);
+        await Assert.That(mappedProvider).IsSameReferenceAs(host.Services);
+    }
+
+    /// <summary>Verifies that mapping a null host retains the nullable extension contract.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MapSplatLocator_NullHost_ReturnsNullAndInvokesFactoryWithNull()
+    {
+        IHost? host = null;
+        IServiceProvider? mappedProvider = null;
+
+        var mappedHost = host!.MapSplatLocator(provider => mappedProvider = provider);
+
+        await Assert.That(mappedHost).IsNull();
+        await Assert.That(mappedProvider).IsNull();
+    }
+}

--- a/src/tests/Extensions.Hosting.WinForms.Tests/RecordingWinFormsService.cs
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/RecordingWinFormsService.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveMarbles.Extensions.Hosting.WinForms;
+
+namespace Extensions.Hosting.WinForms.Tests;
+
+/// <summary>Records whether initialization occurred on the Windows Forms UI thread.</summary>
+public sealed class RecordingWinFormsService : IWinFormsService
+{
+    /// <summary>Gets completion for the service initialization operation.</summary>
+    public TaskCompletionSource Initialized { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <inheritdoc />
+    public void Initialize() => _ = Initialized.TrySetResult();
+}

--- a/src/tests/Extensions.Hosting.WinForms.Tests/TestForm.cs
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/TestForm.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Forms;
+
+namespace Extensions.Hosting.WinForms.Tests;
+
+/// <summary>Provides a form that does not participate in shell registration.</summary>
+public sealed class TestForm : Form;

--- a/src/tests/Extensions.Hosting.WinForms.Tests/TestShell.cs
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/TestShell.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Forms;
+using ReactiveMarbles.Extensions.Hosting.WinForms;
+
+namespace Extensions.Hosting.WinForms.Tests;
+
+/// <summary>Provides a shell form for Windows Forms host integration tests.</summary>
+public sealed class TestShell : Form, IWinFormsShell;

--- a/src/tests/Extensions.Hosting.WinForms.Tests/ThrowingDisposeTestShell.cs
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/ThrowingDisposeTestShell.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Forms;
+using ReactiveMarbles.Extensions.Hosting.WinForms;
+
+namespace Extensions.Hosting.WinForms.Tests;
+
+/// <summary>Provides a shell that fails once during hosted-service cleanup.</summary>
+public sealed class ThrowingDisposeTestShell : Form, IWinFormsShell
+{
+    /// <summary>Indicates whether the next disposal attempt should fail.</summary>
+    private bool _throwOnDispose = true;
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && IsDisposed && _throwOnDispose)
+        {
+            _throwOnDispose = false;
+            throw new InvalidOperationException("The test shell cleanup failed.");
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/tests/Extensions.Hosting.WinForms.Tests/WinFormsHostBuilderExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/WinFormsHostBuilderExtensionsTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.WinForms;
+
+namespace Extensions.Hosting.WinForms.Tests;
+
+/// <summary>Verifies Windows Forms service registration on generic host builders.</summary>
+public sealed class WinFormsHostBuilderExtensionsTests
+{
+    /// <summary>Stores the expected number of configuration callbacks.</summary>
+    private const int ExpectedConfigurationCallbackCount = 2;
+
+    /// <summary>Verifies that application builders reject a null receiver.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ApplicationBuilderExtensions_NullBuilder_ThrowArgumentNullException()
+    {
+        IHostApplicationBuilder? hostBuilder = null;
+
+        await Assert.That(() => hostBuilder!.UseWinFormsLifetime()).Throws<ArgumentNullException>();
+        await Assert.That(() => hostBuilder!.ConfigureWinForms()).Throws<ArgumentNullException>();
+        await Assert.That(() => hostBuilder!.ConfigureWinForms<TestForm>()).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that application builders configure the shared context once and apply each requested configuration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinForms_ApplicationBuilder_RegistersServicesOnceAndAppliesConfiguration()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+        var configuredContexts = new List<IWinFormsContext>();
+
+        void Configure(IWinFormsContext context)
+        {
+            context.EnableVisualStyles = false;
+            configuredContexts.Add(context);
+        }
+
+        _ = hostBuilder.ConfigureWinForms(Configure);
+        _ = hostBuilder.ConfigureWinForms(configuredContexts.Add);
+        _ = hostBuilder.UseWinFormsLifetime();
+
+        using var host = hostBuilder.Build();
+        var context = host.Services.GetRequiredService<IWinFormsContext>();
+        var hostedServiceCount = 0;
+        foreach (var hostedService in host.Services.GetServices<IHostedService>())
+        {
+            _ = hostedService;
+            hostedServiceCount++;
+        }
+
+        await Assert.That(context.EnableVisualStyles).IsFalse();
+        await Assert.That(context.IsLifetimeLinked).IsTrue();
+        await Assert.That(configuredContexts.Count).IsEqualTo(ExpectedConfigurationCallbackCount);
+        await Assert.That(configuredContexts[0]).IsSameReferenceAs(context);
+        await Assert.That(configuredContexts[1]).IsSameReferenceAs(context);
+        await Assert.That(hostedServiceCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that configured shells are registered as both their concrete and shell service types.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinFormsShell_ApplicationBuilder_RegistersConcreteShellAndShellInterface()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+        _ = hostBuilder.ConfigureWinFormsShell<TestShell>();
+
+        using var host = hostBuilder.Build();
+        var shell = host.Services.GetRequiredService<TestShell>();
+
+        await Assert.That(host.Services.GetRequiredService<IWinFormsShell>()).IsSameReferenceAs(shell);
+    }
+
+    /// <summary>Verifies that ordinary forms are not exposed as shells.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinForms_ApplicationBuilder_RegistersNonShellFormWithoutShellInterface()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+        _ = hostBuilder.ConfigureWinForms<TestForm>();
+
+        using var host = hostBuilder.Build();
+
+        await Assert.That(host.Services.GetRequiredService<TestForm>()).IsNotNull();
+        await Assert.That(host.Services.GetService<IWinFormsShell>()).IsNull();
+    }
+
+    /// <summary>Verifies that legacy builders preserve null-compatible extension behavior.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HostBuilderExtensions_NullBuilder_ReturnNull()
+    {
+        IHostBuilder? hostBuilder = null;
+
+        await Assert.That(hostBuilder!.UseWinFormsLifetime()).IsNull();
+        await Assert.That(hostBuilder!.ConfigureWinForms()).IsNull();
+        await Assert.That(hostBuilder!.ConfigureWinForms<TestForm>()).IsNull();
+        await Assert.That(hostBuilder!.ConfigureWinFormsShell<TestShell>()).IsNull();
+    }
+
+    /// <summary>Verifies that legacy builders configure a shared context and shell registrations.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinForms_HostBuilder_RegistersContextAndShell()
+    {
+        var hostBuilder = Host.CreateDefaultBuilder();
+        _ = hostBuilder.ConfigureWinForms(static context => context.EnableVisualStyles = false);
+        _ = hostBuilder.ConfigureWinFormsShell<TestShell>();
+        _ = hostBuilder.UseWinFormsLifetime();
+
+        using var host = hostBuilder.Build();
+        var context = host.Services.GetRequiredService<IWinFormsContext>();
+        var shell = host.Services.GetRequiredService<TestShell>();
+
+        await Assert.That(context.EnableVisualStyles).IsFalse();
+        await Assert.That(context.IsLifetimeLinked).IsTrue();
+        await Assert.That(host.Services.GetRequiredService<IWinFormsShell>()).IsSameReferenceAs(shell);
+        var hostedServiceCount = 0;
+        foreach (var hostedService in host.Services.GetServices<IHostedService>())
+        {
+            _ = hostedService;
+            hostedServiceCount++;
+        }
+
+        await Assert.That(hostedServiceCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that legacy builders register ordinary forms without exposing them as shells.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWinForms_HostBuilder_RegistersNonShellFormWithoutShellInterface()
+    {
+        var hostBuilder = Host.CreateDefaultBuilder();
+        _ = hostBuilder.ConfigureWinForms<TestForm>();
+
+        using var host = hostBuilder.Build();
+
+        await Assert.That(host.Services.GetRequiredService<TestForm>()).IsNotNull();
+        await Assert.That(host.Services.GetService<IWinFormsShell>()).IsNull();
+    }
+}

--- a/src/tests/Extensions.Hosting.WinForms.Tests/WinFormsLifetimeTests.cs
+++ b/src/tests/Extensions.Hosting.WinForms.Tests/WinFormsLifetimeTests.cs
@@ -1,0 +1,215 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ReactiveMarbles.Extensions.Hosting.WinForms;
+
+namespace Extensions.Hosting.WinForms.Tests;
+
+/// <summary>Verifies Windows Forms thread startup and hosted-service shutdown paths.</summary>
+[NotInParallel]
+public sealed class WinFormsLifetimeTests
+{
+    /// <summary>Stores the event identifier logged when form cleanup fails.</summary>
+    private const int FormCleanupFailedEventId = 2;
+
+    /// <summary>Gets the maximum duration allowed for UI startup and shutdown.</summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>Gets the interval used to poll UI state.</summary>
+    private static readonly TimeSpan PollingInterval = TimeSpan.FromMilliseconds(10);
+
+    /// <summary>Gets the time provider used to bound asynchronous test operations.</summary>
+    private static readonly TimeProvider SystemTimeProvider = TimeProvider.System;
+
+    /// <summary>Verifies that a cancelled start does not release the dedicated UI thread.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HostedService_StartAsync_WithCancelledToken_DoesNotStartUiThread()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+        _ = hostBuilder.ConfigureWinForms(static context => context.EnableVisualStyles = false);
+        using var host = hostBuilder.Build();
+        var context = host.Services.GetRequiredService<IWinFormsContext>();
+        var hostedService = host.Services.GetRequiredService<IHostedService>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        await hostedService.StartAsync(cancellationTokenSource.Token);
+
+        await Assert.That(context.IsRunning).IsFalse();
+    }
+
+    /// <summary>Verifies the no-shell message-loop path and service initialization.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HostedService_WithoutShell_InitializesServicesAndStopsMessageLoop()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+        _ = hostBuilder.ConfigureWinForms(static context => context.EnableVisualStyles = false);
+        _ = hostBuilder.Services.AddSingleton<RecordingWinFormsService>();
+        _ = hostBuilder.Services.AddSingleton<IWinFormsService>(static serviceProvider => serviceProvider.GetRequiredService<RecordingWinFormsService>());
+        using var host = hostBuilder.Build();
+        var context = host.Services.GetRequiredService<IWinFormsContext>();
+        var service = host.Services.GetRequiredService<RecordingWinFormsService>();
+
+        await host.StartAsync().WaitAsync(Timeout);
+        await service.Initialized.Task.WaitAsync(Timeout);
+        await WaitForAsync(() => context.IsRunning && context.Dispatcher is not null);
+
+        await host.StopAsync().WaitAsync(Timeout);
+        await WaitForAsync(() => !context.IsRunning);
+
+        await Assert.That(context.Dispatcher).IsNotNull();
+    }
+
+    /// <summary>Verifies that shutdown closes an open shell without mutating the forms enumeration.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HostedService_StopAsync_WithOpenShell_ClosesShellAndStopsMessageLoop()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+        _ = hostBuilder.ConfigureWinFormsShell<TestShell>();
+        using var host = hostBuilder.Build();
+        var context = host.Services.GetRequiredService<IWinFormsContext>();
+
+        await host.StartAsync().WaitAsync(Timeout);
+        await WaitForAsync(() => context.IsRunning && context.Dispatcher is not null);
+
+        await host.StopAsync().WaitAsync(Timeout);
+
+        await WaitForAsync(() => !context.IsRunning);
+    }
+
+    /// <summary>Verifies that a cleanup exception is logged and does not prevent message-loop shutdown.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HostedService_StopAsync_WhenShellCleanupThrows_LogsWarningAndStopsMessageLoop()
+    {
+        var loggerProvider = new RecordingLoggerProvider();
+        var hostBuilder = Host.CreateApplicationBuilder();
+        _ = hostBuilder.Logging.ClearProviders();
+        _ = hostBuilder.Logging.AddProvider(loggerProvider);
+        _ = hostBuilder.ConfigureWinFormsShell<ThrowingDisposeTestShell>();
+        using var host = hostBuilder.Build();
+        var context = host.Services.GetRequiredService<IWinFormsContext>();
+
+        await host.StartAsync().WaitAsync(Timeout);
+        await WaitForAsync(() => context.IsRunning && context.Dispatcher is not null);
+
+        await host.StopAsync().WaitAsync(Timeout);
+        await WaitForAsync(() => !context.IsRunning);
+
+        var cleanupLogEntry = loggerProvider.FindEntry(FormCleanupFailedEventId);
+        await Assert.That(cleanupLogEntry is not null).IsTrue();
+        await Assert.That(cleanupLogEntry!.LogLevel).IsEqualTo(LogLevel.Warning);
+        await Assert.That(cleanupLogEntry.Exception).IsTypeOf<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies the multiple-shell application context path.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task HostedService_WithMultipleShells_StartsAndStopsMessageLoop()
+    {
+        var hostBuilder = Host.CreateApplicationBuilder();
+        _ = hostBuilder.ConfigureWinForms(static context => context.EnableVisualStyles = false);
+        _ = hostBuilder.Services.AddSingleton<IWinFormsShell, AutoClosingTestShell>();
+        _ = hostBuilder.Services.AddSingleton<IWinFormsShell, AutoClosingTestShell>();
+        using var host = hostBuilder.Build();
+        var context = host.Services.GetRequiredService<IWinFormsContext>();
+
+        await host.StartAsync().WaitAsync(Timeout);
+        await WaitForAsync(() => context.IsRunning && context.Dispatcher is not null);
+
+        await WaitForAsync(() => !context.IsRunning);
+        await host.StopAsync().WaitAsync(Timeout);
+    }
+
+    /// <summary>Waits for an asynchronous UI-state condition without blocking a test runner thread.</summary>
+    /// <param name="condition">The condition to wait for.</param>
+    /// <returns>A task that completes when the condition is met.</returns>
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        var deadline = SystemTimeProvider.GetUtcNow() + Timeout;
+        using var timer = new PeriodicTimer(PollingInterval);
+        while (!condition())
+        {
+            if (SystemTimeProvider.GetUtcNow() >= deadline)
+            {
+                throw new TimeoutException("The Windows Forms UI operation did not complete within the allotted timeout.");
+            }
+
+            _ = await timer.WaitForNextTickAsync();
+        }
+    }
+
+    /// <summary>Captures logger entries emitted by the hosted service.</summary>
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        /// <summary>Stores the recorded logging events.</summary>
+        private readonly List<LogEntry> _entries = [];
+
+        /// <inheritdoc />
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(_entries);
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+
+        /// <summary>Finds the first recorded logging event with the specified identifier.</summary>
+        /// <param name="eventId">The event identifier to find.</param>
+        /// <returns>The matching logging event, or <see langword="null"/> when none was recorded.</returns>
+        public LogEntry? FindEntry(int eventId)
+        {
+            lock (_entries)
+            {
+                foreach (var entry in _entries)
+                {
+                    if (entry.EventId.Id == eventId)
+                    {
+                        return entry;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>Records log entries for one logger category.</summary>
+        /// <param name="entries">The shared collection of recorded entries.</param>
+        private sealed class RecordingLogger(List<LogEntry> entries) : ILogger
+        {
+            /// <inheritdoc />
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull => null;
+
+            /// <inheritdoc />
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            /// <inheritdoc />
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                lock (entries)
+                {
+                    entries.Add(new(logLevel, eventId, exception));
+                }
+            }
+        }
+    }
+
+    /// <summary>Represents a captured logging event.</summary>
+    /// <param name="LogLevel">The severity of the logging event.</param>
+    /// <param name="EventId">The event identifier of the logging event.</param>
+    /// <param name="Exception">The exception associated with the logging event.</param>
+    private sealed record LogEntry(LogLevel LogLevel, EventId EventId, Exception? Exception);
+}

--- a/src/tests/Extensions.Hosting.Wpf.BuilderCoverage.Tests/Extensions.Hosting.Wpf.BuilderCoverage.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Wpf.BuilderCoverage.Tests/Extensions.Hosting.Wpf.BuilderCoverage.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.Wpf.BuilderCoverage.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.Wpf\Extensions.Hosting.Wpf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Wpf.BuilderCoverage.Tests/WpfBuilderCoverageTests.cs
+++ b/src/tests/Extensions.Hosting.Wpf.BuilderCoverage.Tests/WpfBuilderCoverageTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+using ReactiveMarbles.Extensions.Hosting.Wpf.Internals;
+
+namespace Extensions.Hosting.Wpf.BuilderCoverage.Tests;
+
+/// <summary>Verifies WPF branches that require a process-owned application instance.</summary>
+[NotInParallel]
+public sealed class WpfBuilderCoverageTests
+{
+    /// <summary>Verifies base application registration, default generic builder configuration, and inactive hosted-service branches.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task ConfigureWpf_RegistersCurrentBaseApplicationAndCoversInactiveHostedServiceBranches()
+    {
+        var configurationSucceeded = await RunOnStaThreadAsync(static () =>
+        {
+            var application = new Application();
+            var applicationBuilder = Host.CreateApplicationBuilder();
+            _ = applicationBuilder.ConfigureWpf(wpfBuilder => wpfBuilder.UseCurrentApplication(application));
+            using var host = applicationBuilder.Build();
+            var context = host.Services.GetRequiredService<IWpfContext>();
+            var serviceProvider = new WpfServiceProvider(context, application);
+            using var wpfThread = new WpfThread(serviceProvider);
+            WpfHostedService hostedService = new(NullLogger<WpfHostedService>.Instance, wpfThread, context);
+
+            _ = hostedService.StartAsync(new(canceled: true));
+            _ = hostedService.StopAsync(CancellationToken.None);
+
+            var genericHostBuilder = new HostBuilder();
+            _ = genericHostBuilder.ConfigureWpf(static wpfBuilder =>
+                wpfBuilder.ConfigureContext(static configuredContext => configuredContext.IsLifetimeLinked = true));
+            _ = genericHostBuilder.ConfigureWpf();
+            using var genericHost = genericHostBuilder.Build();
+            var genericContext = genericHost.Services.GetRequiredService<IWpfContext>();
+
+            return ReferenceEquals(host.Services.GetRequiredService<Application>(), application)
+                && !context.IsRunning
+                && genericContext.IsLifetimeLinked;
+        });
+
+        await Assert.That(configurationSucceeded).IsTrue();
+    }
+
+    /// <summary>Runs an asynchronous operation on a dedicated single-threaded apartment thread.</summary>
+    /// <typeparam name="T">The result type returned by the operation.</typeparam>
+    /// <param name="operation">The operation to execute.</param>
+    /// <returns>A task that completes when the operation finishes.</returns>
+    private static Task<T> RunOnStaThreadAsync<T>(Func<T> operation)
+    {
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                _ = completion.TrySetResult(operation());
+            }
+            catch (Exception exception)
+            {
+                _ = completion.TrySetException(exception);
+            }
+        }) { IsBackground = true };
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        return completion.Task;
+    }
+
+    /// <summary>Provides the services required by <see cref="WpfThread"/>.</summary>
+    /// <param name="context">The WPF context to provide.</param>
+    /// <param name="application">The WPF application to provide.</param>
+    public sealed class WpfServiceProvider(IWpfContext context, Application application) : IServiceProvider
+    {
+        /// <inheritdoc />
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IWpfContext))
+            {
+                return context;
+            }
+
+            return serviceType == typeof(Application) ? application : null;
+        }
+    }
+}

--- a/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.Wpf.MultipleShellCoverage.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.Wpf\Extensions.Hosting.Wpf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/FirstShellWindow.cs
+++ b/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/FirstShellWindow.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Windows;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+
+namespace Extensions.Hosting.Wpf.MultipleShellCoverage.Tests;
+
+/// <summary>Provides the first WPF shell window for the lifecycle test.</summary>
+public sealed class FirstShellWindow : Window, IWpfShell
+{
+    /// <summary>Gets the registered first shell window type.</summary>
+    public static Type RegistrationType => typeof(FirstShellWindow);
+}

--- a/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/MultipleShellApplication.cs
+++ b/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/MultipleShellApplication.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace Extensions.Hosting.Wpf.MultipleShellCoverage.Tests;
+
+/// <summary>Provides the application used by the multiple-shell lifecycle test.</summary>
+public sealed class MultipleShellApplication : Application
+{
+    /// <summary>Gets a signal for when the application starts.</summary>
+    public static TaskCompletionSource<Dispatcher> Started { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <inheritdoc />
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        _ = Started.TrySetResult(Dispatcher);
+    }
+}

--- a/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/MultipleShellLifecycleCoverageTests.cs
+++ b/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/MultipleShellLifecycleCoverageTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+using ReactiveMarbles.Extensions.Hosting.Wpf.Internals;
+
+namespace Extensions.Hosting.Wpf.MultipleShellCoverage.Tests;
+
+/// <summary>Verifies the hosted WPF multiple-shell lifecycle in an isolated executable process.</summary>
+[NotInParallel]
+public sealed class MultipleShellLifecycleCoverageTests
+{
+    /// <summary>Gets the maximum duration allowed for WPF application startup and shutdown.</summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies two registered shell windows are shown during application startup.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StartAsync_MultipleShellsRunsApplicationAndShowsShellWindows()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        _ = builder.ConfigureWpf(static wpfBuilder =>
+        {
+            _ = wpfBuilder.UseApplication<MultipleShellApplication>();
+            _ = wpfBuilder.UseWindow<FirstShellWindow>();
+            _ = wpfBuilder.UseWindow<SecondShellWindow>();
+        });
+        using var host = builder.Build();
+
+        try
+        {
+            await host.StartAsync().WaitAsync(Timeout);
+            var dispatcher = await MultipleShellApplication.Started.Task.WaitAsync(Timeout);
+            var context = host.Services.GetRequiredService<IWpfContext>();
+            var firstShell = host.Services.GetRequiredService<FirstShellWindow>();
+            var secondShell = host.Services.GetRequiredService<SecondShellWindow>();
+            var shellsAreVisible = await context.Dispatcher.InvokeAsync(
+                () => firstShell.IsVisible && secondShell.IsVisible);
+
+            await Assert.That(context.WpfApplication).IsTypeOf<MultipleShellApplication>();
+            await Assert.That(context.Dispatcher).IsSameReferenceAs(dispatcher);
+            await Assert.That(shellsAreVisible).IsTrue();
+
+            using var runningThread = new ExposedWpfThread(host.Services);
+            runningThread.RunUiThreadStart();
+        }
+        finally
+        {
+            await host.StopAsync().WaitAsync(Timeout);
+        }
+    }
+
+    /// <summary>Exposes the protected WPF thread start implementation for a running-dispatcher harness.</summary>
+    public sealed class ExposedWpfThread : WpfThread
+    {
+        /// <summary>Initializes a new instance of the <see cref="ExposedWpfThread"/> class.</summary>
+        /// <param name="serviceProvider">The service provider used by the WPF thread.</param>
+        public ExposedWpfThread(IServiceProvider serviceProvider)
+            : base(serviceProvider)
+        {
+        }
+
+        /// <summary>Runs the protected WPF UI-thread start implementation.</summary>
+        public void RunUiThreadStart() => UiThreadStart();
+    }
+}

--- a/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/SecondShellWindow.cs
+++ b/src/tests/Extensions.Hosting.Wpf.MultipleShellCoverage.Tests/SecondShellWindow.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Windows;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+
+namespace Extensions.Hosting.Wpf.MultipleShellCoverage.Tests;
+
+/// <summary>Provides the second WPF shell window for the lifecycle test.</summary>
+public sealed class SecondShellWindow : Window, IWpfShell
+{
+    /// <summary>Gets the registered second shell window type.</summary>
+    public static Type RegistrationType => typeof(SecondShellWindow);
+}

--- a/src/tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TestTfmsInParallel>false</TestTfmsInParallel>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.Wpf.SingleShellCoverage.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.Wpf\Extensions.Hosting.Wpf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests/SingleShellApplication.cs
+++ b/src/tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests/SingleShellApplication.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace Extensions.Hosting.Wpf.SingleShellCoverage.Tests;
+
+/// <summary>Provides the application used by the single-shell lifecycle test.</summary>
+public sealed class SingleShellApplication : Application
+{
+    /// <summary>Gets a signal for when the application starts.</summary>
+    public static TaskCompletionSource<Dispatcher> Started { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <inheritdoc />
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        _ = Started.TrySetResult(Dispatcher);
+    }
+}

--- a/src/tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests/SingleShellLifecycleCoverageTests.cs
+++ b/src/tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests/SingleShellLifecycleCoverageTests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+using ReactiveMarbles.Extensions.Hosting.Wpf.Internals;
+
+namespace Extensions.Hosting.Wpf.SingleShellCoverage.Tests;
+
+/// <summary>Verifies the hosted WPF single-shell lifecycle in an isolated executable process.</summary>
+[NotInParallel]
+public sealed partial class SingleShellLifecycleCoverageTests
+{
+    /// <summary>Gets the Win32 message that closes a window.</summary>
+    private const uint CloseWindowMessage = 0x0010;
+
+    /// <summary>Gets the Win32 dialog window class name.</summary>
+    private const string DialogWindowClass = "#32770";
+
+    /// <summary>Gets the interval between searches for the WPF message box.</summary>
+    private static readonly TimeSpan DialogPollInterval = TimeSpan.FromMilliseconds(20);
+
+    /// <summary>Gets the maximum duration allowed for WPF application startup and shutdown.</summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies a single shell window is used as the WPF application's main window.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task StartAsync_SingleShellRunsApplicationWithRegisteredWindow()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        _ = builder.ConfigureWpf(static wpfBuilder =>
+        {
+            _ = wpfBuilder.UseApplication<SingleShellApplication>();
+            _ = wpfBuilder.UseWindow<SingleShellWindow>();
+        });
+        using var host = builder.Build();
+
+        try
+        {
+            await host.StartAsync().WaitAsync(Timeout);
+            var dispatcher = await SingleShellApplication.Started.Task.WaitAsync(Timeout);
+            var context = host.Services.GetRequiredService<IWpfContext>();
+            var mainWindowIsShell = await context.Dispatcher.InvokeAsync(
+                static () => Application.Current?.MainWindow is SingleShellWindow);
+
+            await Assert.That(context.WpfApplication).IsTypeOf<SingleShellApplication>();
+            await Assert.That(mainWindowIsShell).IsTrue();
+            await Assert.That(context.Dispatcher).IsSameReferenceAs(dispatcher);
+
+            var wpfApplication = context.WpfApplication
+                ?? throw new InvalidOperationException("The WPF application was not initialized.");
+            using var noApplicationThread = new ExposedWpfThread(host.Services);
+            context.WpfApplication = null;
+            noApplicationThread.RunUiThreadStart();
+            context.WpfApplication = wpfApplication;
+            using var runningThread = new ExposedWpfThread(host.Services);
+            runningThread.RunUiThreadStart();
+
+            await context.Dispatcher.InvokeAsync(
+                () => wpfApplication.StartupUri = new("Unused.xaml", UriKind.Relative));
+            var messageBoxCloserStarted = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var messageBoxClosed = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var messageBoxCloser = new Thread(
+                () => CloseMessageBox(messageBoxCloserStarted, messageBoxClosed))
+                { IsBackground = true };
+            messageBoxCloser.Start();
+            await messageBoxCloserStarted.Task.WaitAsync(Timeout);
+            runningThread.RunUiThreadStart();
+            await messageBoxClosed.Task.WaitAsync(Timeout);
+        }
+        finally
+        {
+            await host.StopAsync().WaitAsync(Timeout);
+        }
+    }
+
+    /// <summary>Closes the WPF warning message box after its native dialog is created.</summary>
+    /// <param name="started">The signal completed after native window lookup is available.</param>
+    /// <param name="closed">The signal completed after the native dialog is closed.</param>
+    private static void CloseMessageBox(
+        TaskCompletionSource started,
+        TaskCompletionSource closed)
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(Timeout);
+        _ = FindCurrentProcessDialog();
+        _ = started.TrySetResult();
+
+        do
+        {
+            var dialogHandle = FindCurrentProcessDialog();
+            if (dialogHandle != nint.Zero
+                && NativeMethods.PostMessage(
+                    dialogHandle,
+                    CloseWindowMessage,
+                    nuint.Zero,
+                    nint.Zero))
+            {
+                _ = closed.TrySetResult();
+                return;
+            }
+        }
+        while (!cancellationTokenSource.Token.WaitHandle.WaitOne(DialogPollInterval));
+
+        _ = closed.TrySetException(
+            new TimeoutException("The WPF warning message box was not created."));
+    }
+
+    /// <summary>Finds a native dialog owned by the current test process.</summary>
+    /// <returns>The native dialog handle, or zero when no matching dialog exists.</returns>
+    private static nint FindCurrentProcessDialog()
+    {
+        var dialogHandle = nint.Zero;
+        while ((dialogHandle = NativeMethods.FindWindowEx(
+            nint.Zero,
+            dialogHandle,
+            DialogWindowClass,
+            null)) != nint.Zero)
+        {
+            _ = NativeMethods.GetWindowThreadProcessId(dialogHandle, out var processId);
+            if (processId == Environment.ProcessId)
+            {
+                return dialogHandle;
+            }
+        }
+
+        return nint.Zero;
+    }
+
+    /// <summary>Exposes the protected WPF thread start implementation for a running-dispatcher harness.</summary>
+    public sealed class ExposedWpfThread : WpfThread
+    {
+        /// <summary>Initializes a new instance of the <see cref="ExposedWpfThread"/> class.</summary>
+        /// <param name="serviceProvider">The service provider used by the WPF thread.</param>
+        public ExposedWpfThread(IServiceProvider serviceProvider)
+            : base(serviceProvider)
+        {
+        }
+
+        /// <summary>Runs the protected WPF UI-thread start implementation.</summary>
+        public void RunUiThreadStart() => UiThreadStart();
+    }
+
+    /// <summary>Provides the native window operations required by the message-box harness.</summary>
+    private static partial class NativeMethods
+    {
+        /// <summary>Finds a child or top-level native window.</summary>
+        /// <param name="parentWindow">The optional parent window.</param>
+        /// <param name="childAfter">The child window after which searching begins.</param>
+        /// <param name="className">The native window class name.</param>
+        /// <param name="windowName">The optional native window title.</param>
+        /// <returns>The native window handle, or zero if no matching window exists.</returns>
+        [LibraryImport("user32.dll", EntryPoint = "FindWindowExW", StringMarshalling = StringMarshalling.Utf16)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        internal static partial nint FindWindowEx(
+            nint parentWindow,
+            nint childAfter,
+            string? className,
+            string? windowName);
+
+        /// <summary>Gets the process that owns a native window.</summary>
+        /// <param name="windowHandle">The native window handle.</param>
+        /// <param name="processId">The owning process identifier.</param>
+        /// <returns>The identifier of the thread that created the window.</returns>
+        [LibraryImport("user32.dll")]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        internal static partial uint GetWindowThreadProcessId(
+            nint windowHandle,
+            out uint processId);
+
+        /// <summary>Posts a message to a native window.</summary>
+        /// <param name="windowHandle">The target native window handle.</param>
+        /// <param name="message">The message identifier.</param>
+        /// <param name="wordParameter">The message word parameter.</param>
+        /// <param name="longParameter">The message long parameter.</param>
+        /// <returns><see langword="true"/> when the message was posted; otherwise, <see langword="false"/>.</returns>
+        [LibraryImport("user32.dll", EntryPoint = "PostMessageW")]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool PostMessage(
+            nint windowHandle,
+            uint message,
+            nuint wordParameter,
+            nint longParameter);
+    }
+}

--- a/src/tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests/SingleShellWindow.cs
+++ b/src/tests/Extensions.Hosting.Wpf.SingleShellCoverage.Tests/SingleShellWindow.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Windows;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+
+namespace Extensions.Hosting.Wpf.SingleShellCoverage.Tests;
+
+/// <summary>Provides the registered WPF shell window for the lifecycle test.</summary>
+public sealed class SingleShellWindow : Window, IWpfShell
+{
+    /// <summary>Gets the registered shell window type.</summary>
+    public static Type RegistrationType => typeof(SingleShellWindow);
+}

--- a/src/tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-windows10.0.19041;net11.0-windows10.0.19041</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>Extensions.Hosting.Wpf.ZeroShellCoverage.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions.Hosting.Wpf\Extensions.Hosting.Wpf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="TUnit.Assertions" />
+    <Using Include="TUnit.Assertions.Extensions" />
+    <Using Include="TUnit.Core" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests/ZeroShellApplication.cs
+++ b/src/tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests/ZeroShellApplication.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Extensions.Hosting.Wpf.ZeroShellCoverage.Tests;
+
+/// <summary>Provides the WPF application used by the zero-shell lifecycle test.</summary>
+public sealed class ZeroShellApplication : Application
+{
+    /// <summary>Gets a signal for when the application starts.</summary>
+    public static TaskCompletionSource Started { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <inheritdoc />
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        _ = Started.TrySetResult();
+    }
+}

--- a/src/tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests/ZeroShellCoverageTests.cs
+++ b/src/tests/Extensions.Hosting.Wpf.ZeroShellCoverage.Tests/ZeroShellCoverageTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveMarbles.Extensions.Hosting.Wpf;
+using ReactiveMarbles.Extensions.Hosting.Wpf.Internals;
+
+namespace Extensions.Hosting.Wpf.ZeroShellCoverage.Tests;
+
+/// <summary>Verifies zero-shell behavior against an already-running WPF application.</summary>
+[NotInParallel]
+public sealed class ZeroShellCoverageTests
+{
+    /// <summary>Gets the maximum duration allowed for WPF application startup and shutdown.</summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies that an existing main window is shown and a missing main window is rejected.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task RunningApplication_ZeroShellShowsMainWindowAndRejectsMissingMainWindow()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        _ = builder.ConfigureWpf(static wpfBuilder => wpfBuilder.UseApplication<ZeroShellApplication>());
+        using var host = builder.Build();
+
+        try
+        {
+            await host.StartAsync().WaitAsync(Timeout);
+            var context = host.Services.GetRequiredService<IWpfContext>();
+            await ZeroShellApplication.Started.Task.WaitAsync(Timeout);
+            var mainWindow = await context.Dispatcher.InvokeAsync(static () => new Window());
+            await context.Dispatcher.InvokeAsync(() => Application.Current!.MainWindow = mainWindow);
+            using var runningThread = new ExposedWpfThread(host.Services);
+            runningThread.RunUiThreadStart();
+            var isVisible = await context.Dispatcher.InvokeAsync(() => mainWindow.IsVisible);
+            await Assert.That(isVisible).IsTrue();
+            await context.Dispatcher.InvokeAsync(static () => Application.Current!.MainWindow = null);
+
+            void Act() => runningThread.RunUiThreadStart();
+
+            await Assert.That(Act).Throws<InvalidOperationException>();
+        }
+        finally
+        {
+            await host.StopAsync().WaitAsync(Timeout);
+        }
+    }
+
+    /// <summary>Exposes the protected WPF thread start implementation for a running-dispatcher harness.</summary>
+    public sealed class ExposedWpfThread : WpfThread
+    {
+        /// <summary>Initializes a new instance of the <see cref="ExposedWpfThread"/> class.</summary>
+        /// <param name="serviceProvider">The service provider used by the WPF thread.</param>
+        public ExposedWpfThread(IServiceProvider serviceProvider)
+            : base(serviceProvider)
+        {
+        }
+
+        /// <summary>Runs the protected WPF UI-thread start implementation.</summary>
+        public void RunUiThreadStart() => UiThreadStart();
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

A breaking feature release for Extensions.Hosting 4.0. It modernizes the hosting surface and dependencies, fixes desktop UI lifecycle and dispatcher behavior, adds normal/reactive package support, expands platform, plug-in, service, logging, and data coverage, and delivers comprehensive consumer documentation and package-embedded AI guidance.

## What is the new behavior?

- Composes and hardens UI-thread startup, shutdown, cancellation, and cleanup for WPF, WinForms, WinUI, MAUI, and Avalonia.
- Wires `RxSchedulers.MainThreadScheduler` through the hosted WPF lifecycle without consumer `SchedulerRegistrar` or `RxApp` workarounds.
- Adds and refines normal and `.Reactive` package paths, stable plug-in discovery and ordering, hosted-service lifetimes, single-instance mutex APIs, PluginService runtime behavior, EF Core helper overloads, and Log4Net integration.
- Updates examples, solution projects, analyzers, package versions, target frameworks, and test configuration.
- Adds broad TUnit platform and infrastructure coverage plus BenchmarkDotNet plug-in ordering benchmarks.
- Documents all production packages and audited public API groups, including detailed C# examples and a V3.1.26-to-V4.0.0 migration guide.
- Packages `Skill.md` into the six relevant base/infrastructure NuGet packages at both `Skill.md` and `.agents/skills/extensions-hosting/SKILL.md`.

## What is the current behavior?

V3.1.26 requires manual or inconsistent reactive scheduler and lifecycle setup in affected hosting scenarios, exposes older optional-parameter APIs and reactive disposable contracts, and lacks the complete V4 package, API, migration, and package-loaded AI guidance introduced here. Several platform shutdown paths could wait indefinitely when dispatch failed or was unavailable, and plug-in/service lifecycle behavior was less deterministic.

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- This change is intentionally breaking (`feat!`). Consumers should follow the README migration section when moving from V3.1.26.
- Post-rebase validation: `dotnet build Extensions.Hosting.slnx -c Release -warnaserror --disable-build-servers -m:4` succeeded with 0 warnings and 0 errors.
- Full MTP/TUnit solution validation with Cobertura collection passed: 579 succeeded, 0 failed, 0 skipped.
- NuGet validation confirmed the final README and identical embedded skill content in all six scoped base/infrastructure packages.
- The current MinVer-derived validation package is `4.0.0-beta.2.8`; publish final `4.0.0` after creating or reaching the corresponding release tag.
- Generated local coverage, test-result, and composed-project output directories were deliberately excluded from the commit.
