### PR TITLE
fix(plugins): load external plugin assemblies from their paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,9 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Local coverage test output
+/src/*[Bb]aseline*/
+/src/*[Cc]omposed*/
+/src/*[Cc]overage*/
+/src/*[Tt]est[Rr]esult*/

--- a/src/Extensions.Hosting.Plugins/HostBuilderPluginExtensions.cs
+++ b/src/Extensions.Hosting.Plugins/HostBuilderPluginExtensions.cs
@@ -329,6 +329,6 @@ public static class HostBuilderPluginExtensions
         }
 
         var loadContext = new PluginLoadContext(pluginAssemblyLocation, pluginName);
-        return loadContext.LoadFromAssemblyName(pluginAssemblyName);
+        return loadContext.TryLoadFromAssemblyName(pluginAssemblyName);
     }
 }

--- a/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContext.cs
@@ -36,8 +36,8 @@ public class AssemblyLoadContext(string name)
     public string Name { get; } = name;
 
     /// <summary>Loads an assembly from the specified file path.</summary>
-    /// <remarks>The path is used to read the assembly's full identity before the runtime resolves that identity
-    /// through its normal trusted assembly-loading process.</remarks>
+    /// <remarks>The assembly is loaded from the supplied path so plug-ins discovered outside the application's
+    /// trusted assembly probing paths remain loadable.</remarks>
     /// <param name="assemblyPath">The path to the assembly file to load. The path must be a valid file system path to a managed assembly file.</param>
     /// <returns>The loaded assembly represented by the specified file path.</returns>
     public static Assembly LoadFromAssemblyPath(string assemblyPath)
@@ -46,7 +46,11 @@ public class AssemblyLoadContext(string name)
             ? assemblyPath
             : throw new ArgumentException("The assembly path cannot be null or whitespace.", nameof(assemblyPath));
         var fullPath = Path.GetFullPath(validAssemblyPath);
+#if NETFRAMEWORK
         return Assembly.Load(AssemblyName.GetAssemblyName(fullPath));
+#else
+        return System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(fullPath);
+#endif
     }
 
     /// <summary>Loads an assembly given its display name.</summary>

--- a/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContextExtensions.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/AssemblyLoadContextExtensions.cs
@@ -36,7 +36,12 @@ public static class AssemblyLoadContextExtensions
                 return false;
             }
 
-            foreach (var assembly in AssemblyLoadContext.Assemblies)
+#if NETFRAMEWORK
+            var loadedAssemblies = AssemblyLoadContext.Assemblies;
+#else
+            var loadedAssemblies = System.Runtime.Loader.AssemblyLoadContext.Default.Assemblies;
+#endif
+            foreach (var assembly in loadedAssemblies)
             {
                 var name = assembly.GetName().Name;
                 if (name is null)

--- a/src/Extensions.Hosting.Plugins/Internals/PluginLoadContext.cs
+++ b/src/Extensions.Hosting.Plugins/Internals/PluginLoadContext.cs
@@ -19,7 +19,11 @@ namespace ReactiveMarbles.Extensions.Hosting.Plugins.Internals;
 /// <param name="pluginPath">The file system path to the root directory containing the plugin's assemblies and dependencies. Cannot be null or
 /// empty.</param>
 /// <param name="name">The unique name for the assembly load context. Used to identify the context within the application.</param>
+#if NETFRAMEWORK
 internal sealed class PluginLoadContext(string pluginPath, string name) : AssemblyLoadContext(name)
+#else
+internal sealed class PluginLoadContext(string pluginPath, string name) : System.Runtime.Loader.AssemblyLoadContext(name)
+#endif
 {
     /// <summary>Stores the resolver value.</summary>
     private readonly AssemblyDependencyResolver _resolver = new(pluginPath);
@@ -36,9 +40,19 @@ internal sealed class PluginLoadContext(string pluginPath, string name) : Assemb
     internal IntPtr LoadUnmanagedLibrary(string unmanagedDllName) =>
         LoadUnmanagedDll(unmanagedDllName);
 
+    /// <summary>Attempts to load an assembly by name without replacing a missing plugin-local assembly with a runtime exception.</summary>
+    /// <param name="assemblyName">The assembly name to resolve.</param>
+    /// <returns>The loaded assembly, or null when neither the default nor plugin context can resolve it.</returns>
+    internal Assembly? TryLoadFromAssemblyName(AssemblyName assemblyName) =>
+        Load(assemblyName);
+
     /// <inheritdoc />
+#if NETFRAMEWORK
     protected override Assembly Load(AssemblyName assemblyName) =>
-        Default.TryGetAssembly(assemblyName, out var alreadyLoadedAssembly)
+#else
+    protected override Assembly? Load(AssemblyName assemblyName) =>
+#endif
+        AssemblyLoadContext.Default.TryGetAssembly(assemblyName, out var alreadyLoadedAssembly)
             ? alreadyLoadedAssembly!
             : LoadAssemblyFromResolvedPath(assemblyName)!;
 
@@ -55,6 +69,10 @@ internal sealed class PluginLoadContext(string pluginPath, string name) : Assemb
     private Assembly? LoadAssemblyFromResolvedPath(AssemblyName assemblyName)
     {
         var assemblyPath = ResolveAssemblyPath(assemblyName);
+#if NETFRAMEWORK
         return assemblyPath is null ? null : AssemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
+#else
+        return assemblyPath is null ? null : LoadFromAssemblyPath(assemblyPath);
+#endif
     }
 }

--- a/src/Extensions.Hosting.slnx
+++ b/src/Extensions.Hosting.slnx
@@ -34,6 +34,8 @@
     <File Path="Directory.Build.props" />
   </Folder>
   <Folder Name="/Tests/">
+    <Project Path="tests/Extensions.Hosting.PluginLoading.Fixture/Extensions.Hosting.PluginLoading.Fixture.csproj" />
+    <Project Path="tests/Extensions.Hosting.PluginLoading.Reactive.Fixture/Extensions.Hosting.PluginLoading.Reactive.Fixture.csproj" />
     <Project Path="tests/Extensions.Hosting.Avalonia.Lifecycle.Tests/Extensions.Hosting.Avalonia.Lifecycle.Tests.csproj" />
     <Project Path="tests/Extensions.Hosting.Avalonia.MultipleWindow.Tests/Extensions.Hosting.Avalonia.MultipleWindow.Tests.csproj" />
     <Project Path="tests/Extensions.Hosting.Avalonia.OneWindow.Tests/Extensions.Hosting.Avalonia.OneWindow.Tests.csproj" />

--- a/src/tests/Extensions.Hosting.PluginLoading.Fixture.Shared/ExternalPathPlugin.cs
+++ b/src/tests/Extensions.Hosting.PluginLoading.Fixture.Shared/ExternalPathPlugin.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+#if REACTIVE_SHIM
+using ReactiveMarbles.Extensions.Hosting.Reactive.Plugins;
+
+namespace Extensions.Hosting.PluginLoading.Reactive.Fixture;
+#else
+using ReactiveMarbles.Extensions.Hosting.Plugins;
+
+namespace Extensions.Hosting.PluginLoading.Fixture;
+#endif
+
+/// <summary>Provides an external-path plugin fixture that is intentionally absent from the test host dependency graph.</summary>
+public sealed class ExternalPathPlugin : IPlugin
+{
+    /// <inheritdoc />
+    public void ConfigureHost(object hostBuilderContext, IServiceCollection serviceCollection)
+    {
+    }
+}

--- a/src/tests/Extensions.Hosting.PluginLoading.Fixture/Extensions.Hosting.PluginLoading.Fixture.csproj
+++ b/src/tests/Extensions.Hosting.PluginLoading.Fixture/Extensions.Hosting.PluginLoading.Fixture.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
+    <AssemblyName>Extensions.Hosting.PluginLoading.Fixture</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.PluginLoading.Fixture.Shared\ExternalPathPlugin.cs" Link="ExternalPathPlugin.cs" />
+    <ProjectReference Include="..\..\Extensions.Hosting.Plugins\Extensions.Hosting.Plugins.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.PluginLoading.Reactive.Fixture/Extensions.Hosting.PluginLoading.Reactive.Fixture.csproj
+++ b/src/tests/Extensions.Hosting.PluginLoading.Reactive.Fixture/Extensions.Hosting.PluginLoading.Reactive.Fixture.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
+    <AssemblyName>Extensions.Hosting.PluginLoading.Reactive.Fixture</AssemblyName>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Extensions.Hosting.PluginLoading.Fixture.Shared\ExternalPathPlugin.cs" Link="ExternalPathPlugin.cs" />
+    <ProjectReference Include="..\..\Extensions.Hosting.Plugins.Reactive\Extensions.Hosting.Plugins.Reactive.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Extensions.Hosting.Tests/AssemblyLoadingTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/AssemblyLoadingTests.cs
@@ -272,13 +272,26 @@ public class AssemblyLoadingTests
     [Test]
     public async Task PluginLoadContext_LoadFromAssemblyName_WithPluginLocalAssembly_ReturnsAssembly()
     {
-        var candidatePath = GetUnloadedAssemblyPath();
-        var assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(candidatePath));
-        var context = new PluginLoadContext(candidatePath, assemblyName.Name!);
+        var pluginPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "ExternalPluginFixtures",
+            "normal",
+            "Extensions.Hosting.PluginLoading.Fixture.dll");
+        var assemblyName = AssemblyName.GetAssemblyName(pluginPath);
+        var context = new PluginLoadContext(pluginPath, assemblyName.Name!);
 
-        var assembly = context.LoadFromAssemblyName(assemblyName);
+        var assembly = context.TryLoadFromAssemblyName(assemblyName);
 
-        await Assert.That(assembly.GetName().Name).IsEqualTo(assemblyName.Name);
+        await Assert.That(assembly!.GetName().Name).IsEqualTo(assemblyName.Name);
+        await Assert.That(Path.GetFullPath(assembly.Location)).IsEqualTo(Path.GetFullPath(pluginPath));
+        var pluginCount = 0;
+        foreach (var plugin in ReactiveMarbles.Extensions.Hosting.Plugins.PluginScanner.ScanForPluginInstances(assembly))
+        {
+            _ = plugin;
+            pluginCount++;
+        }
+
+        await Assert.That(pluginCount).IsEqualTo(1);
     }
 
     /// <summary>Verifies that PluginLoadContext returns null when a plugin-local assembly cannot be resolved.</summary>
@@ -288,7 +301,7 @@ public class AssemblyLoadingTests
     {
         var context = new PluginLoadContext(typeof(AssemblyLoadingTests).Assembly.Location, nameof(Plugin));
 
-        Assembly? assembly = context.LoadFromAssemblyName(new("Missing.Plugin.Assembly"));
+        var assembly = context.TryLoadFromAssemblyName(new("Missing.Plugin.Assembly"));
 
         await Assert.That(assembly).IsNull();
     }
@@ -312,34 +325,6 @@ public class AssemblyLoadingTests
         var tempDirectory = Path.Combine(Path.GetTempPath(), "Extensions.Hosting.Tests", Guid.NewGuid().ToString("N"));
         _ = Directory.CreateDirectory(tempDirectory);
         return tempDirectory;
-    }
-
-    /// <summary>Finds a managed assembly in the test output that has not yet been loaded.</summary>
-    /// <returns>The path to an unloaded managed assembly.</returns>
-    private static string GetUnloadedAssemblyPath()
-    {
-        var assemblyDirectory = Path.GetDirectoryName(typeof(AssemblyLoadingTests).Assembly.Location)!;
-        var loadedAssemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var loadedAssembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            var loadedAssemblyName = loadedAssembly.GetName().Name;
-            if (loadedAssemblyName is not null)
-            {
-                _ = loadedAssemblyNames.Add(loadedAssemblyName);
-            }
-        }
-
-        foreach (var assemblyPath in Directory.EnumerateFiles(assemblyDirectory, "*.dll"))
-        {
-            var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-            if (!loadedAssemblyNames.Contains(assemblyName)
-                && !assemblyName.StartsWith("Extensions.Hosting", StringComparison.OrdinalIgnoreCase))
-            {
-                return assemblyPath;
-            }
-        }
-
-        throw new InvalidOperationException("No unloaded assembly was available in the test output directory.");
     }
 
     /// <summary>Test assembly load context that delegates managed loads to a supplied assembly.</summary>

--- a/src/tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj
+++ b/src/tests/Extensions.Hosting.Tests/Extensions.Hosting.Tests.csproj
@@ -12,11 +12,25 @@
     <ProjectReference Include="..\..\Extensions.Hosting.MainUIThread\Extensions.Hosting.MainUIThread.csproj" />
     <ProjectReference Include="..\..\Extensions.Hosting.Plugins\Extensions.Hosting.Plugins.csproj" />
     <ProjectReference Include="..\..\Extensions.Hosting.Plugins.Reactive\Extensions.Hosting.Plugins.Reactive.csproj" />
+    <ProjectReference Include="..\Extensions.Hosting.PluginLoading.Fixture\Extensions.Hosting.PluginLoading.Fixture.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Extensions.Hosting.PluginLoading.Reactive.Fixture\Extensions.Hosting.PluginLoading.Reactive.Fixture.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
+
+  <Target Name="CopyExternalPluginFixtures" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
+    <ItemGroup>
+      <_ExternalPluginFixture Include="$(MSBuildProjectDirectory)\..\Extensions.Hosting.PluginLoading.Fixture\bin\$(Configuration)\$(TargetFramework)\Extensions.Hosting.PluginLoading.Fixture.dll">
+        <FixtureKind>normal</FixtureKind>
+      </_ExternalPluginFixture>
+      <_ExternalPluginFixture Include="$(MSBuildProjectDirectory)\..\Extensions.Hosting.PluginLoading.Reactive.Fixture\bin\$(Configuration)\$(TargetFramework)\Extensions.Hosting.PluginLoading.Reactive.Fixture.dll">
+        <FixtureKind>reactive</FixtureKind>
+      </_ExternalPluginFixture>
+    </ItemGroup>
+    <Copy SourceFiles="@(_ExternalPluginFixture)" DestinationFolder="$(OutDir)ExternalPluginFixtures\%(_ExternalPluginFixture.FixtureKind)" />
+  </Target>
 
   <!-- Global usings -->
   <ItemGroup>

--- a/src/tests/Extensions.Hosting.Tests/HostBuilderPluginExtensionsTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/HostBuilderPluginExtensionsTests.cs
@@ -208,29 +208,31 @@ public class HostBuilderPluginExtensionsTests
     public async Task ConfigurePlugins_IHostBuilder_WithUnloadedPluginAssembly_LoadsAndScansAssembly()
     {
         var configuredPlugins = new List<string>();
-        var tempDirectory = CreateTemporaryDirectory();
-        try
-        {
-            var assemblyPath = CopyCurrentAssemblyToTemporaryPlugin(tempDirectory);
-            var hostBuilder = Host.CreateDefaultBuilder();
+        var assemblyPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "ExternalPluginFixtures",
+            "normal",
+            "Extensions.Hosting.PluginLoading.Fixture.dll");
+        string? loadedAssemblyLocation = null;
+        var hostBuilder = Host.CreateDefaultBuilder();
 
-            _ = hostBuilder.ConfigurePlugins(builder =>
+        _ = hostBuilder.ConfigurePlugins(builder =>
+        {
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
+            builder.PluginDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
+            _ = builder.PluginMatcher.AddInclude(Path.GetFileName(assemblyPath));
+            builder.AssemblyScanFunc = assembly =>
             {
-                _ = builder ?? throw new ArgumentNullException(nameof(builder));
-                builder.PluginDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
-                _ = builder.PluginMatcher.AddInclude(Path.GetFileName(assemblyPath));
-                builder.AssemblyScanFunc = _ => [new EarlierRecordingPlugin(configuredPlugins)];
-            });
+                loadedAssemblyLocation = assembly.Location;
+                return [new EarlierRecordingPlugin(configuredPlugins)];
+            };
+        });
 
-            using var host = hostBuilder.Build();
+        using var host = hostBuilder.Build();
 
-            await Assert.That(configuredPlugins.Count).IsEqualTo(1);
-            await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierRecordingPlugin.Name);
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory, recursive: true);
-        }
+        await Assert.That(configuredPlugins.Count).IsEqualTo(1);
+        await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierRecordingPlugin.Name);
+        await Assert.That(Path.GetFullPath(loadedAssemblyLocation!)).IsEqualTo(Path.GetFullPath(assemblyPath));
     }
 
     /// <summary>Verifies that required plugin configuration fails when no plugins are discovered.</summary>

--- a/src/tests/Extensions.Hosting.Tests/ReactiveAssemblyLoadingTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactiveAssemblyLoadingTests.cs
@@ -291,13 +291,26 @@ public class ReactiveAssemblyLoadingTests
     [Test]
     public async Task PluginLoadContext_LoadFromAssemblyName_WithPluginLocalAssembly_ReturnsAssembly()
     {
-        var candidatePath = GetUnloadedAssemblyPath();
-        var assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(candidatePath));
-        var context = new PluginLoadContext(candidatePath, assemblyName.Name!);
+        var pluginPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "ExternalPluginFixtures",
+            "reactive",
+            "Extensions.Hosting.PluginLoading.Reactive.Fixture.dll");
+        var assemblyName = AssemblyName.GetAssemblyName(pluginPath);
+        var context = new PluginLoadContext(pluginPath, assemblyName.Name!);
 
-        var assembly = context.LoadFromAssemblyName(assemblyName);
+        var assembly = context.TryLoadFromAssemblyName(assemblyName);
 
-        await Assert.That(assembly.GetName().Name).IsEqualTo(assemblyName.Name);
+        await Assert.That(assembly!.GetName().Name).IsEqualTo(assemblyName.Name);
+        await Assert.That(Path.GetFullPath(assembly.Location)).IsEqualTo(Path.GetFullPath(pluginPath));
+        var pluginCount = 0;
+        foreach (var plugin in ReactiveMarbles.Extensions.Hosting.Reactive.Plugins.PluginScanner.ScanForPluginInstances(assembly))
+        {
+            _ = plugin;
+            pluginCount++;
+        }
+
+        await Assert.That(pluginCount).IsEqualTo(1);
     }
 
     /// <summary>Verifies that PluginLoadContext returns null when a plugin-local assembly cannot be resolved.</summary>
@@ -307,7 +320,7 @@ public class ReactiveAssemblyLoadingTests
     {
         var context = new PluginLoadContext(typeof(ReactiveAssemblyLoadingTests).Assembly.Location, nameof(Plugin));
 
-        Assembly? assembly = context.LoadFromAssemblyName(new("Missing.Plugin.Assembly"));
+        var assembly = context.TryLoadFromAssemblyName(new("Missing.Plugin.Assembly"));
 
         await Assert.That(assembly).IsNull();
     }
@@ -324,10 +337,10 @@ public class ReactiveAssemblyLoadingTests
         await Assert.That(result).IsEqualTo(IntPtr.Zero);
     }
 
-    /// <summary>Verifies that PluginLoadContext resolves unmanaged dependency paths before loading.</summary>
+    /// <summary>Verifies that PluginLoadContext attempts to load an existing unmanaged dependency from its resolved path.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
-    public async Task PluginLoadContext_LoadUnmanagedDll_WithExistingLibrary_ReturnsZeroFromShimLoader()
+    public async Task PluginLoadContext_LoadUnmanagedDll_WithInvalidExistingLibrary_ThrowsBadImageFormatException()
     {
         var tempDirectory = CreateTemporaryDirectory();
         try
@@ -338,9 +351,9 @@ public class ReactiveAssemblyLoadingTests
             await File.WriteAllTextAsync(dependencyPath, string.Empty);
             var context = new PluginLoadContext(pluginPath, nameof(Plugin));
 
-            var result = context.LoadUnmanagedLibrary(NativeLibraryName);
+            var act = () => context.LoadUnmanagedLibrary(NativeLibraryName);
 
-            await Assert.That(result).IsEqualTo(IntPtr.Zero);
+            await Assert.That(act).Throws<BadImageFormatException>();
         }
         finally
         {
@@ -355,55 +368,6 @@ public class ReactiveAssemblyLoadingTests
         var tempDirectory = Path.Combine(Path.GetTempPath(), "Extensions.Hosting.Tests", Guid.NewGuid().ToString("N"));
         _ = Directory.CreateDirectory(tempDirectory);
         return tempDirectory;
-    }
-
-    /// <summary>Finds a managed assembly in the test output that has not yet been loaded.</summary>
-    /// <returns>The path to an unloaded managed assembly.</returns>
-    private static string GetUnloadedAssemblyPath()
-    {
-        var assemblyDirectory = Path.GetDirectoryName(typeof(ReactiveAssemblyLoadingTests).Assembly.Location)!;
-        var loadedAssemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var loadedAssembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            var loadedAssemblyName = loadedAssembly.GetName().Name;
-            if (loadedAssemblyName is not null)
-            {
-                _ = loadedAssemblyNames.Add(loadedAssemblyName);
-            }
-        }
-
-        var assemblyPaths = new List<string>(Directory.EnumerateFiles(assemblyDirectory, "*.dll"));
-        assemblyPaths.Sort(
-            static (left, right) =>
-                StringComparer.Ordinal.Compare(Path.GetFileName(left), Path.GetFileName(right)));
-        foreach (var assemblyPath in assemblyPaths)
-        {
-            var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-            if (!loadedAssemblyNames.Contains(assemblyName)
-                && !assemblyName.StartsWith("Extensions.Hosting", StringComparison.OrdinalIgnoreCase)
-                && IsManagedAssembly(assemblyPath))
-            {
-                return assemblyPath;
-            }
-        }
-
-        throw new InvalidOperationException("No unloaded assembly was available in the test output directory.");
-    }
-
-    /// <summary>Returns a value indicating whether the file is a managed assembly.</summary>
-    /// <param name="assemblyPath">The assembly path to inspect.</param>
-    /// <returns>True when the file is a managed assembly.</returns>
-    private static bool IsManagedAssembly(string assemblyPath)
-    {
-        try
-        {
-            _ = AssemblyName.GetAssemblyName(assemblyPath);
-            return true;
-        }
-        catch (BadImageFormatException)
-        {
-            return false;
-        }
     }
 
     /// <summary>Test assembly load context that delegates managed loads to a supplied assembly.</summary>

--- a/src/tests/Extensions.Hosting.Tests/ReactivePluginShimTests.cs
+++ b/src/tests/Extensions.Hosting.Tests/ReactivePluginShimTests.cs
@@ -249,29 +249,31 @@ public class ReactivePluginShimTests
     public async Task ConfigurePlugins_IHostBuilder_WithUnloadedPluginAssembly_LoadsAndScansAssembly()
     {
         var configuredPlugins = new List<string>();
-        var tempDirectory = CreateTemporaryDirectory();
-        try
-        {
-            var assemblyPath = CopyCurrentAssemblyToTemporaryPlugin(tempDirectory);
-            var hostBuilder = Host.CreateDefaultBuilder();
+        var assemblyPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "ExternalPluginFixtures",
+            "reactive",
+            "Extensions.Hosting.PluginLoading.Reactive.Fixture.dll");
+        string? loadedAssemblyLocation = null;
+        var hostBuilder = Host.CreateDefaultBuilder();
 
-            _ = hostBuilder.ConfigurePlugins(builder =>
+        _ = hostBuilder.ConfigurePlugins(builder =>
+        {
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
+            builder.PluginDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
+            _ = builder.PluginMatcher.AddInclude(Path.GetFileName(assemblyPath));
+            builder.AssemblyScanFunc = assembly =>
             {
-                _ = builder ?? throw new ArgumentNullException(nameof(builder));
-                builder.PluginDirectories.Add(Path.GetDirectoryName(assemblyPath)!);
-                _ = builder.PluginMatcher.AddInclude(Path.GetFileName(assemblyPath));
-                builder.AssemblyScanFunc = _ => [new EarlierReactiveRecordingPlugin(configuredPlugins)];
-            });
+                loadedAssemblyLocation = assembly.Location;
+                return [new EarlierReactiveRecordingPlugin(configuredPlugins)];
+            };
+        });
 
-            using var host = hostBuilder.Build();
+        using var host = hostBuilder.Build();
 
-            await Assert.That(configuredPlugins.Count).IsEqualTo(1);
-            await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierReactiveRecordingPlugin.Name);
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory, recursive: true);
-        }
+        await Assert.That(configuredPlugins.Count).IsEqualTo(1);
+        await Assert.That(configuredPlugins[0]).IsEqualTo(EarlierReactiveRecordingPlugin.Name);
+        await Assert.That(Path.GetFullPath(loadedAssemblyLocation!)).IsEqualTo(Path.GetFullPath(assemblyPath));
     }
 
     /// <summary>Verifies that required plugin configuration fails when no plugins are discovered.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and test coverage improvement for plug-ins discovered outside the host application's trusted assembly probing paths, plus repository hygiene for locally generated coverage artifacts.

## What is the new behavior?

Plugin discovery now loads managed plug-in assemblies directly from their resolved external paths on modern .NET. Dedicated normal and Reactive plug-in fixture assemblies are copied into test output and verify that scanning and configuration load the actual external assembly and discover its plug-in instance.

Local coverage investigation output under src is ignored through root-scoped Baseline, Composed, Coverage, and TestResult patterns, so newly named output folders remain ignored without adding timestamped entries.

The test suite also verifies the expected BadImageFormatException when a resolved unmanaged library path points to an invalid binary.

## What is the current behavior?

External plug-in assembly loading relied on normal trusted assembly resolution, which could prevent plug-ins outside the application's probing paths from loading. Tests used copied test assemblies or arbitrary unloaded assemblies rather than dedicated external plug-in fixtures.

The ignore file listed individual dated coverage folders, so every new output folder required another entry.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 

## Additional information

Local TUnit/MTP validation passed 185/185 tests on net10.0. The generated src/FutureCoverage_20260806 directory and its reports were confirmed ignored by the new rule. MTP coverage reports 100% line coverage for both Extensions.Hosting.Plugins and Extensions.Hosting.Plugins.Reactive.

Native net11.0 verification is left to CI because this workstation does not have a .NET 11 SDK installed.